### PR TITLE
flatten_overtransfection defaults True; power figs read MWU

### DIFF
--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:39.463678</dc:date>
+    <dc:date>2026-08-16T17:12:22.889526</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m11660a6f08" d="M 0 0 
+       <path id="m1723208b96" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m11660a6f08" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -121,7 +121,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m11660a6f08" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,7 +177,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m11660a6f08" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -208,7 +208,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m11660a6f08" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -249,7 +249,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m11660a6f08" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -285,7 +285,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m11660a6f08" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1723208b96" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -582,12 +582,12 @@ z
     <g id="ytick_1">
      <g id="line2d_7">
       <defs>
-       <path id="m9a6c506ae4" d="M 0 0 
+       <path id="mcf1628fae4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -602,7 +602,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,7 +617,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -632,7 +632,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -647,7 +647,7 @@ L -3.5 0
     <g id="ytick_5">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -662,7 +662,7 @@ L -3.5 0
     <g id="ytick_6">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9a6c506ae4" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf1628fae4" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -812,109 +812,109 @@ z
     </g>
    </g>
    <g id="line2d_13">
-    <path d="M 68.055 43.488224 
-L 72.328841 45.110588 
-L 76.416863 50.08 
-L 80.504885 51.774 
-L 84.592907 50.136514 
-L 88.680929 53.949744 
-L 92.768951 51.995294 
-L 96.856973 51.990741 
-L 100.944995 49.980645 
-L 105.033017 52.04 
-L 109.121039 61.876981 
-L 113.209061 58.88 
-L 117.297084 57.36 
-L 121.385106 60.08384 
-L 125.473128 59.240345 
-L 129.56115 64.622957 
-L 133.649172 62.370097 
-L 137.737194 62.814118 
-L 141.825216 68.354667 
-L 145.913238 71.968197 
-L 150.00126 69.725405 
-L 154.089282 74.869515 
-L 158.177304 76.501569 
-L 162.265326 89.92037 
-L 166.353348 88.717724 
-L 170.44137 91.146667 
-L 174.529392 92.246018 
-L 178.617414 101.171765 
-L 182.705436 113.470085 
-L 186.793458 111.947826 
-L 190.88148 128.106667 
-L 194.969502 137.648073 
-L 199.057524 148.872941 
-L 203.145546 151.206667 
-L 207.233568 159.941613 
-L 211.32159 185.494701 
-L 215.409612 197.824496 
-L 219.497634 211.177391 
-L 223.585656 239.007835 
-L 227.673678 247.271628 
-L 231.7617 257.966372 
-L 235.849722 266.088571 
-L 239.937744 281.52352 
-L 244.025766 298.861176 
-L 248.113788 304.208 
-L 252.20181 303.41 
-L 256.289832 305.465455 
+    <path d="M 68.055 46.76972 
+L 72.328841 48.552941 
+L 76.416863 55.726667 
+L 80.504885 58.113667 
+L 84.592907 54.43156 
+L 88.680929 59.951795 
+L 92.768951 60.355294 
+L 96.856973 55.241852 
+L 100.944995 55.643871 
+L 105.033017 57.36 
+L 109.121039 64.637358 
+L 113.209061 65.272941 
+L 117.297084 62.148 
+L 121.385106 65.2336 
+L 125.473128 64.789655 
+L 129.56115 70.729391 
+L 133.649172 70.324272 
+L 137.737194 68.223529 
+L 141.825216 75.6 
+L 145.913238 78.683607 
+L 150.00126 75.524685 
+L 154.089282 81.119223 
+L 158.177304 84.533725 
+L 162.265326 98.048148 
+L 166.353348 101.563577 
+L 170.44137 96.793333 
+L 174.529392 106.746549 
+L 178.617414 110.023529 
+L 182.705436 120.97265 
+L 186.793458 126.196174 
+L 190.88148 139.913333 
+L 194.969502 148.922569 
+L 199.057524 163.134118 
+L 203.145546 159.933333 
+L 207.233568 169.852258 
+L 211.32159 196.498462 
+L 215.409612 205.536434 
+L 219.497634 222.881391 
+L 223.585656 249.867216 
+L 227.673678 258.15907 
+L 231.7617 266.770265 
+L 235.849722 278.628571 
+L 239.937744 288.54592 
+L 244.025766 300.336471 
+L 248.113788 305.804 
+L 252.20181 305.769677 
+L 256.289832 305.949091 
 L 260.377855 295.577778 
 L 264.465877 295.032137 
-L 268.553899 276.312696 
-L 272.641921 268.994667 
-L 276.729943 250.929908 
-L 280.817965 238.331724 
-L 284.905987 216.224715 
-L 288.994009 195.2525 
-L 293.082031 171.485565 
-L 297.170053 167.405185 
-L 301.258075 148.79098 
-L 305.346097 151.8432 
-L 309.434119 135.277538 
-L 313.522141 134.325574 
-L 317.610163 122.044444 
-L 321.698185 118.962617 
-L 325.786207 107.368 
-L 329.874229 100.81376 
-L 333.962251 100.965812 
-L 338.050273 99.152692 
-L 342.138295 86.596036 
-L 346.226317 83.96 
-L 350.314339 76.501569 
-L 354.402361 80.058667 
-L 358.490383 74.621702 
-L 362.578405 73.51 
-L 366.666427 69.33 
-L 370.754449 61.942574 
-L 374.842471 64.085283 
-L 378.930493 70.088593 
-L 383.018515 70.128 
-L 387.106537 62.250968 
-L 391.194559 60.753793 
-L 395.282581 57.548319 
-L 399.370603 63.94 
-L 403.458626 59.534261 
-L 407.546648 58.39301 
-L 411.63467 62.502667 
-L 415.722692 57.36 
-L 419.810714 55.505321 
-L 423.898736 47.504918 
-L 427.986758 46.486667 
-L 432.07478 46.72 
-L 436.162802 48.464262 
-L 440.250824 55.463304 
-L 444.338846 47.311111 
-L 448.426868 47.316636 
-L 452.51489 41.125773 
-L 456.602912 47.055495 
-L 460.690934 40.197217 
-L 464.778956 43.658491 
-L 468.866978 45.794783 
-L 472.955 43.862963 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+L 268.553899 282.928 
+L 272.641921 274.568 
+L 276.729943 253.614312 
+L 280.817965 249.430345 
+L 284.905987 224.788618 
+L 288.994009 208.8375 
+L 293.082031 186.242783 
+L 297.170053 174.449259 
+L 301.258075 153.95451 
+L 305.346097 164.7176 
+L 309.434119 146.981538 
+L 313.522141 135.284918 
+L 317.610163 125.295556 
+L 321.698185 127.713271 
+L 325.786207 111.757 
+L 329.874229 104.09088 
+L 333.962251 106.967863 
+L 338.050273 103.091538 
+L 342.138295 90.286486 
+L 346.226317 90.876 
+L 350.314339 85.107451 
+L 354.402361 84.826963 
+L 358.490383 78.357021 
+L 362.578405 76.645 
+L 366.666427 75.669667 
+L 370.754449 63.101386 
+L 374.842471 64.637358 
+L 378.930493 71.822519 
+L 383.018515 71.724 
+L 387.106537 66.970323 
+L 391.194559 64.285172 
+L 395.282581 63.762832 
+L 399.370603 65.48 
+L 403.458626 64.114087 
+L 407.546648 61.801942 
+L 411.63467 65.753778 
+L 415.722692 60.745455 
+L 419.810714 57.652844 
+L 423.898736 51.821967 
+L 427.986758 49.566667 
+L 432.07478 50.976 
+L 436.162802 51.342295 
+L 440.250824 56.989913 
+L 444.338846 49.675556 
+L 448.426868 53.879626 
+L 452.51489 45.348866 
+L 456.602912 50.745946 
+L 460.690934 44.268174 
+L 464.778956 46.418868 
+L 468.866978 51.519565 
+L 472.955 45.488519 
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="m8a97c86d7c" d="M 0 1 
+     <path id="m01ead28dd5" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -926,213 +926,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p877c0b4f0d)">
-     <use xlink:href="#m8a97c86d7c" x="68.055" y="43.488224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="72.328841" y="45.110588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="76.416863" y="50.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="80.504885" y="51.774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="84.592907" y="50.136514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="88.680929" y="53.949744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="92.768951" y="51.995294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="96.856973" y="51.990741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="100.944995" y="49.980645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="105.033017" y="52.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="109.121039" y="61.876981" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="113.209061" y="58.88" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="117.297084" y="57.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="121.385106" y="60.08384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="125.473128" y="59.240345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="129.56115" y="64.622957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="133.649172" y="62.370097" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="137.737194" y="62.814118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="141.825216" y="68.354667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="145.913238" y="71.968197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="150.00126" y="69.725405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="154.089282" y="74.869515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="158.177304" y="76.501569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="162.265326" y="89.92037" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="166.353348" y="88.717724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="170.44137" y="91.146667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="174.529392" y="92.246018" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="178.617414" y="101.171765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="182.705436" y="113.470085" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="186.793458" y="111.947826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="190.88148" y="128.106667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="194.969502" y="137.648073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="199.057524" y="148.872941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="203.145546" y="151.206667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="207.233568" y="159.941613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="211.32159" y="185.494701" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="215.409612" y="197.824496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="219.497634" y="211.177391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="223.585656" y="239.007835" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="227.673678" y="247.271628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="231.7617" y="257.966372" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="235.849722" y="266.088571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="239.937744" y="281.52352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="244.025766" y="298.861176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="248.113788" y="304.208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="252.20181" y="303.41" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="256.289832" y="305.465455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="260.377855" y="295.577778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="264.465877" y="295.032137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="268.553899" y="276.312696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="272.641921" y="268.994667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="276.729943" y="250.929908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="280.817965" y="238.331724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="284.905987" y="216.224715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="288.994009" y="195.2525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="293.082031" y="171.485565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="297.170053" y="167.405185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="301.258075" y="148.79098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="305.346097" y="151.8432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="309.434119" y="135.277538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="313.522141" y="134.325574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="317.610163" y="122.044444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="321.698185" y="118.962617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="325.786207" y="107.368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="329.874229" y="100.81376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="333.962251" y="100.965812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="338.050273" y="99.152692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="342.138295" y="86.596036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="346.226317" y="83.96" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="350.314339" y="76.501569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="354.402361" y="80.058667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="358.490383" y="74.621702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="362.578405" y="73.51" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="366.666427" y="69.33" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="370.754449" y="61.942574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="374.842471" y="64.085283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="378.930493" y="70.088593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="383.018515" y="70.128" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="387.106537" y="62.250968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="391.194559" y="60.753793" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="395.282581" y="57.548319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="399.370603" y="63.94" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="403.458626" y="59.534261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="407.546648" y="58.39301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="411.63467" y="62.502667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="415.722692" y="57.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="419.810714" y="55.505321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="423.898736" y="47.504918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="427.986758" y="46.486667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="432.07478" y="46.72" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="436.162802" y="48.464262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="440.250824" y="55.463304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="444.338846" y="47.311111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="448.426868" y="47.316636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="452.51489" y="41.125773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="456.602912" y="47.055495" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="460.690934" y="40.197217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="464.778956" y="43.658491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="468.866978" y="45.794783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m8a97c86d7c" x="472.955" y="43.862963" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p35cf3a6bba)">
+     <use xlink:href="#m01ead28dd5" x="68.055" y="46.76972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="72.328841" y="48.552941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="76.416863" y="55.726667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="80.504885" y="58.113667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="84.592907" y="54.43156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="88.680929" y="59.951795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="92.768951" y="60.355294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="96.856973" y="55.241852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="100.944995" y="55.643871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="105.033017" y="57.36" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="109.121039" y="64.637358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="113.209061" y="65.272941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="117.297084" y="62.148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="121.385106" y="65.2336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="125.473128" y="64.789655" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="129.56115" y="70.729391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="133.649172" y="70.324272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="137.737194" y="68.223529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="141.825216" y="75.6" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="145.913238" y="78.683607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="150.00126" y="75.524685" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="154.089282" y="81.119223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="158.177304" y="84.533725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="162.265326" y="98.048148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="166.353348" y="101.563577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="170.44137" y="96.793333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="174.529392" y="106.746549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="178.617414" y="110.023529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="182.705436" y="120.97265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="186.793458" y="126.196174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="190.88148" y="139.913333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="194.969502" y="148.922569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="199.057524" y="163.134118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="203.145546" y="159.933333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="207.233568" y="169.852258" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="211.32159" y="196.498462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="215.409612" y="205.536434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="219.497634" y="222.881391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="223.585656" y="249.867216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="227.673678" y="258.15907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="231.7617" y="266.770265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="235.849722" y="278.628571" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="239.937744" y="288.54592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="244.025766" y="300.336471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="248.113788" y="305.804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="252.20181" y="305.769677" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="256.289832" y="305.949091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="260.377855" y="295.577778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="264.465877" y="295.032137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="268.553899" y="282.928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="272.641921" y="274.568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="276.729943" y="253.614312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="280.817965" y="249.430345" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="284.905987" y="224.788618" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="288.994009" y="208.8375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="293.082031" y="186.242783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="297.170053" y="174.449259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="301.258075" y="153.95451" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="305.346097" y="164.7176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="309.434119" y="146.981538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="313.522141" y="135.284918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="317.610163" y="125.295556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="321.698185" y="127.713271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="325.786207" y="111.757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="329.874229" y="104.09088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="333.962251" y="106.967863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="338.050273" y="103.091538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="342.138295" y="90.286486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="346.226317" y="90.876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="350.314339" y="85.107451" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="354.402361" y="84.826963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="358.490383" y="78.357021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="362.578405" y="76.645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="366.666427" y="75.669667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="370.754449" y="63.101386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="374.842471" y="64.637358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="378.930493" y="71.822519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="383.018515" y="71.724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="387.106537" y="66.970323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="391.194559" y="64.285172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="395.282581" y="63.762832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="399.370603" y="65.48" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="403.458626" y="64.114087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="407.546648" y="61.801942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="411.63467" y="65.753778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="415.722692" y="60.745455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="419.810714" y="57.652844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="423.898736" y="51.821967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="427.986758" y="49.566667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="432.07478" y="50.976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="436.162802" y="51.342295" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="440.250824" y="56.989913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="444.338846" y="49.675556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="448.426868" y="53.879626" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="452.51489" y="45.348866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="456.602912" y="50.745946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="460.690934" y="44.268174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="464.778956" y="46.418868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="468.866978" y="51.519565" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m01ead28dd5" x="472.955" y="45.488519" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_14">
-    <path d="M 68.055 34.030092 
-L 72.328841 40.916364 
-L 76.416863 38.786667 
-L 80.504885 46.409667 
-L 84.592907 42.837838 
-L 88.680929 48.252881 
-L 92.768951 45.434333 
-L 96.856973 40.472661 
-L 100.944995 47.463656 
-L 105.033017 47.325528 
-L 109.121039 50.907037 
-L 113.209061 50.52 
-L 117.297084 44.946667 
-L 121.385106 49.31616 
-L 125.473128 51.168621 
-L 129.56115 51.673103 
-L 133.649172 57.256699 
-L 137.737194 54.7 
-L 141.825216 59.668679 
-L 145.913238 62.76378 
-L 150.00126 60.762883 
-L 154.089282 62.015 
-L 158.177304 66.347184 
-L 162.265326 73.664815 
-L 166.353348 82.056911 
-L 170.44137 80.397913 
-L 174.529392 76.835826 
-L 178.617414 92.665455 
-L 182.705436 96.464274 
-L 186.793458 93.628522 
-L 190.88148 99.226087 
-L 194.969502 109.193394 
-L 199.057524 123.134545 
-L 203.145546 124.823103 
-L 207.233568 141.551111 
-L 211.32159 145.481026 
-L 215.409612 159.455267 
-L 219.497634 177.28931 
-L 223.585656 216.082474 
-L 227.673678 225.758462 
-L 231.7617 242.218435 
-L 235.849722 263.066667 
-L 239.937744 280.11904 
-L 244.025766 292.617377 
+    <path d="M 68.055 36.714495 
+L 72.328841 43.334545 
+L 76.416863 43.406667 
+L 80.504885 50.798667 
+L 84.592907 44.419459 
+L 88.680929 49.740678 
+L 92.768951 50.798667 
+L 96.856973 45.841468 
+L 100.944995 49.351398 
+L 105.033017 49.228618 
+L 109.121039 54.7 
+L 113.209061 53.962353 
+L 117.297084 48.637117 
+L 121.385106 49.78432 
+L 125.473128 57.726897 
+L 129.56115 56.717931 
+L 133.649172 60.097476 
+L 137.737194 59.089 
+L 141.825216 64.637358 
+L 145.913238 68.754016 
+L 150.00126 67.616577 
+L 154.089282 68.204615 
+L 158.177304 70.324272 
+L 162.265326 80.167037 
+L 166.353348 90.620813 
+L 170.44137 85.486609 
+L 174.529392 88.539826 
+L 178.617414 97.501818 
+L 182.705436 106.967863 
+L 186.793458 107.368 
+L 190.88148 111.438957 
+L 194.969502 123.689174 
+L 199.057524 141.029091 
+L 203.145546 132.390345 
+L 207.233568 153.162222 
+L 211.32159 157.985299 
+L 215.409612 171.516641 
+L 219.497634 186.874483 
+L 223.585656 230.561649 
+L 227.673678 232.510769 
+L 231.7617 249.851478 
+L 235.849722 268.386667 
+L 239.937744 283.39616 
+L 244.025766 296.454754 
 L 248.113788 301.8425 
-L 252.20181 299.462222 
-L 256.289832 301.251475 
-L 260.377855 299.107059 
-L 264.465877 286.300339 
-L 268.553899 267.087241 
-L 272.641921 246.394019 
-L 276.729943 235.58 
-L 280.817965 205.501538 
-L 284.905987 184.82374 
-L 288.994009 177.4875 
-L 293.082031 159.485812 
-L 297.170053 142.48 
-L 301.258075 130.100769 
-L 305.346097 130.891881 
-L 309.434119 113.670154 
-L 313.522141 107.748618 
-L 317.610163 99.961562 
-L 321.698185 102.924815 
-L 325.786207 95.176333 
-L 329.874229 84.42816 
-L 333.962251 80.090909 
-L 338.050273 77.207692 
-L 342.138295 72.9875 
-L 346.226317 74.120354 
-L 350.314339 66.347184 
-L 354.402361 74.423407 
-L 358.490383 67.151064 
-L 362.578405 59.619823 
-L 366.666427 62.374754 
-L 370.754449 57.307327 
-L 374.842471 53.043774 
-L 378.930493 59.002941 
-L 383.018515 60.762883 
-L 387.106537 54.228065 
-L 391.194559 47.637241 
-L 395.282581 52.410087 
-L 399.370603 57.726897 
-L 403.458626 50.159655 
-L 407.546648 51.634667 
-L 411.63467 47.304615 
-L 415.722692 48.654545 
-L 419.810714 52.284037 
-L 423.898736 45.422439 
-L 427.986758 38.273333 
-L 432.07478 40.201802 
-L 436.162802 45.58623 
-L 440.250824 48.848 
-L 444.338846 47.6776 
+L 252.20181 303.177778 
+L 256.289832 299.812459 
+L 260.377855 301.975686 
+L 264.465877 292.251525 
+L 268.553899 272.636552 
+L 272.641921 248.034766 
+L 276.729943 241.432 
+L 280.817965 215.004786 
+L 284.905987 195.290732 
+L 288.994009 184.8025 
+L 293.082031 172.490256 
+L 297.170053 152.143853 
+L 301.258075 139.666538 
+L 305.346097 143.638812 
+L 309.434119 122.673231 
+L 313.522141 113.457886 
+L 317.610163 104.990625 
+L 321.698185 111.594444 
+L 325.786207 102.491333 
+L 329.874229 89.57792 
+L 333.962251 87.345455 
+L 338.050273 85.085385 
+L 342.138295 77.69 
+L 346.226317 73.084602 
+L 350.314339 68.619806 
+L 354.402361 75.723852 
+L 358.490383 66.528511 
+L 362.578405 60.137699 
+L 366.666427 64.773115 
+L 370.754449 59.045545 
+L 374.842471 51.939623 
+L 378.930493 61.154412 
+L 383.018515 58.654054 
+L 387.106537 55.171935 
+L 391.194559 49.655172 
+L 395.282581 53.936696 
+L 399.370603 58.231379 
+L 403.458626 53.691034 
+L 407.546648 54.421333 
+L 411.63467 50.52 
+L 415.722692 50.105455 
+L 419.810714 54.96844 
+L 423.898736 49.228618 
+L 427.986758 41.866667 
+L 432.07478 42.310631 
+L 436.162802 47.98459 
+L 440.250824 47.830261 
+L 444.338846 49.4332 
 L 448.426868 44.03514 
-L 452.51489 41.08396 
-L 456.602912 42.837838 
-L 460.690934 37.144 
+L 452.51489 41.663366 
+L 456.602912 43.365045 
+L 460.690934 39.179478 
 L 464.778956 42.394393 
-L 468.866978 45.794783 
-L 472.955 40.07 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+L 468.866978 47.703043 
+L 472.955 42.779259 
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="m350ca17da6" d="M 0 1 
+     <path id="m0a4af889ee" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1144,213 +1144,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p877c0b4f0d)">
-     <use xlink:href="#m350ca17da6" x="68.055" y="34.030092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="72.328841" y="40.916364" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="76.416863" y="38.786667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="80.504885" y="46.409667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="84.592907" y="42.837838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="88.680929" y="48.252881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="92.768951" y="45.434333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="96.856973" y="40.472661" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="100.944995" y="47.463656" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="105.033017" y="47.325528" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="109.121039" y="50.907037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="113.209061" y="50.52" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="117.297084" y="44.946667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="121.385106" y="49.31616" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="125.473128" y="51.168621" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="129.56115" y="51.673103" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="133.649172" y="57.256699" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="137.737194" y="54.7" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="141.825216" y="59.668679" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="145.913238" y="62.76378" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="150.00126" y="60.762883" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="154.089282" y="62.015" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="158.177304" y="66.347184" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="162.265326" y="73.664815" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="166.353348" y="82.056911" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="170.44137" y="80.397913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="174.529392" y="76.835826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="178.617414" y="92.665455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="182.705436" y="96.464274" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="186.793458" y="93.628522" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="190.88148" y="99.226087" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="194.969502" y="109.193394" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="199.057524" y="123.134545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="203.145546" y="124.823103" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="207.233568" y="141.551111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="211.32159" y="145.481026" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="215.409612" y="159.455267" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="219.497634" y="177.28931" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="223.585656" y="216.082474" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="227.673678" y="225.758462" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="231.7617" y="242.218435" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="235.849722" y="263.066667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="239.937744" y="280.11904" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="244.025766" y="292.617377" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="248.113788" y="301.8425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="252.20181" y="299.462222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="256.289832" y="301.251475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="260.377855" y="299.107059" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="264.465877" y="286.300339" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="268.553899" y="267.087241" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="272.641921" y="246.394019" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="276.729943" y="235.58" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="280.817965" y="205.501538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="284.905987" y="184.82374" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="288.994009" y="177.4875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="293.082031" y="159.485812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="297.170053" y="142.48" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="301.258075" y="130.100769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="305.346097" y="130.891881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="309.434119" y="113.670154" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="313.522141" y="107.748618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="317.610163" y="99.961562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="321.698185" y="102.924815" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="325.786207" y="95.176333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="329.874229" y="84.42816" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="333.962251" y="80.090909" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="338.050273" y="77.207692" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="342.138295" y="72.9875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="346.226317" y="74.120354" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="350.314339" y="66.347184" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="354.402361" y="74.423407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="358.490383" y="67.151064" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="362.578405" y="59.619823" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="366.666427" y="62.374754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="370.754449" y="57.307327" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="374.842471" y="53.043774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="378.930493" y="59.002941" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="383.018515" y="60.762883" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="387.106537" y="54.228065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="391.194559" y="47.637241" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="395.282581" y="52.410087" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="399.370603" y="57.726897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="403.458626" y="50.159655" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="407.546648" y="51.634667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="411.63467" y="47.304615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="415.722692" y="48.654545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="419.810714" y="52.284037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="423.898736" y="45.422439" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="427.986758" y="38.273333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="432.07478" y="40.201802" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="436.162802" y="45.58623" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="440.250824" y="48.848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="444.338846" y="47.6776" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="448.426868" y="44.03514" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="452.51489" y="41.08396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="456.602912" y="42.837838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="460.690934" y="37.144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="464.778956" y="42.394393" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="468.866978" y="45.794783" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m350ca17da6" x="472.955" y="40.07" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p35cf3a6bba)">
+     <use xlink:href="#m0a4af889ee" x="68.055" y="36.714495" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="72.328841" y="43.334545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="76.416863" y="43.406667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="80.504885" y="50.798667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="84.592907" y="44.419459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="88.680929" y="49.740678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="92.768951" y="50.798667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="96.856973" y="45.841468" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="100.944995" y="49.351398" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="105.033017" y="49.228618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="109.121039" y="54.7" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="113.209061" y="53.962353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="117.297084" y="48.637117" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="121.385106" y="49.78432" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="125.473128" y="57.726897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="129.56115" y="56.717931" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="133.649172" y="60.097476" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="137.737194" y="59.089" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="141.825216" y="64.637358" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="145.913238" y="68.754016" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="150.00126" y="67.616577" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="154.089282" y="68.204615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="158.177304" y="70.324272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="162.265326" y="80.167037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="166.353348" y="90.620813" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="170.44137" y="85.486609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="174.529392" y="88.539826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="178.617414" y="97.501818" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="182.705436" y="106.967863" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="186.793458" y="107.368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="190.88148" y="111.438957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="194.969502" y="123.689174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="199.057524" y="141.029091" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="203.145546" y="132.390345" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="207.233568" y="153.162222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="211.32159" y="157.985299" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="215.409612" y="171.516641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="219.497634" y="186.874483" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="223.585656" y="230.561649" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="227.673678" y="232.510769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="231.7617" y="249.851478" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="235.849722" y="268.386667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="239.937744" y="283.39616" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="244.025766" y="296.454754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="248.113788" y="301.8425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="252.20181" y="303.177778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="256.289832" y="299.812459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="260.377855" y="301.975686" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="264.465877" y="292.251525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="268.553899" y="272.636552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="272.641921" y="248.034766" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="276.729943" y="241.432" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="280.817965" y="215.004786" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="284.905987" y="195.290732" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="288.994009" y="184.8025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="293.082031" y="172.490256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="297.170053" y="152.143853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="301.258075" y="139.666538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="305.346097" y="143.638812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="309.434119" y="122.673231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="313.522141" y="113.457886" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="317.610163" y="104.990625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="321.698185" y="111.594444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="325.786207" y="102.491333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="329.874229" y="89.57792" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="333.962251" y="87.345455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="338.050273" y="85.085385" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="342.138295" y="77.69" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="346.226317" y="73.084602" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="350.314339" y="68.619806" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="354.402361" y="75.723852" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="358.490383" y="66.528511" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="362.578405" y="60.137699" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="366.666427" y="64.773115" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="370.754449" y="59.045545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="374.842471" y="51.939623" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="378.930493" y="61.154412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="383.018515" y="58.654054" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="387.106537" y="55.171935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="391.194559" y="49.655172" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="395.282581" y="53.936696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="399.370603" y="58.231379" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="403.458626" y="53.691034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="407.546648" y="54.421333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="411.63467" y="50.52" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="415.722692" y="50.105455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="419.810714" y="54.96844" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="423.898736" y="49.228618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="427.986758" y="41.866667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="432.07478" y="42.310631" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="436.162802" y="47.98459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="440.250824" y="47.830261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="444.338846" y="49.4332" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="448.426868" y="44.03514" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="452.51489" y="41.663366" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="456.602912" y="43.365045" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="460.690934" y="39.179478" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="464.778956" y="42.394393" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="468.866978" y="47.703043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m0a4af889ee" x="472.955" y="42.779259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_15">
-    <path d="M 68.055 43.157064 
-L 72.328841 45.752727 
-L 76.416863 50.593333 
-L 80.504885 49.823333 
-L 84.592907 50.745946 
-L 88.680929 54.204068 
-L 92.768951 52.261667 
-L 96.856973 48.525872 
-L 100.944995 54.385376 
-L 105.033017 49.70439 
-L 109.121039 60.66037 
-L 113.209061 60.355294 
-L 117.297084 54.436396 
+    <path d="M 68.055 45.304587 
+L 72.328841 47.203636 
+L 76.416863 52.133333 
+L 80.504885 55.675333 
+L 84.592907 52.327568 
+L 88.680929 59.16339 
+L 92.768951 54.212333 
+L 96.856973 55.505321 
+L 100.944995 58.790108 
+L 105.033017 53.986341 
+L 109.121039 65.537037 
+L 113.209061 63.797647 
+L 117.297084 55.490811 
 L 121.385106 57.74304 
-L 125.473128 61.762759 
-L 129.56115 63.276207 
-L 133.649172 64.642718 
-L 137.737194 64.941 
-L 141.825216 66.84566 
-L 145.913238 69.675591 
-L 150.00126 70.77982 
-L 154.089282 70.455385 
-L 158.177304 75.43767 
-L 162.265326 87.211111 
-L 166.353348 85.863089 
-L 170.44137 88.539826 
-L 174.529392 89.557565 
-L 178.617414 97.985455 
-L 182.705436 109.468718 
-L 186.793458 112.456696 
-L 190.88148 117.545391 
-L 194.969502 128.521101 
-L 199.057524 134.258182 
-L 203.145546 143.993448 
-L 207.233568 158.271111 
-L 211.32159 186.495043 
-L 215.409612 190.278779 
-L 219.497634 210.585172 
-L 223.585656 226.338557 
-L 227.673678 241.964 
-L 231.7617 259.01113 
-L 235.849722 271.342222 
-L 239.937744 292.75936 
-L 244.025766 294.056393 
-L 248.113788 308.635 
-L 252.20181 304.106667 
-L 256.289832 302.690492 
-L 260.377855 300.25451 
-L 264.465877 295.227119 
-L 268.553899 285.753103 
-L 272.641921 263.895327 
-L 276.729943 245.688 
-L 280.817965 230.009915 
-L 284.905987 216.224715 
-L 288.994009 204.6575 
-L 293.082031 168.488889 
-L 297.170053 160.733945 
-L 301.258075 145.293462 
-L 305.346097 151.171089 
-L 309.434119 129.425538 
-L 313.522141 124.40065 
-L 317.610163 120.535 
-L 321.698185 109.968889 
-L 325.786207 99.077667 
-L 329.874229 97.06848 
-L 333.962251 101.370909 
-L 338.050273 90.149615 
-L 342.138295 86.05 
-L 346.226317 83.96 
-L 350.314339 73.165049 
-L 354.402361 81.792593 
-L 358.490383 75.244255 
-L 362.578405 68.423717 
-L 366.666427 64.293443 
-L 370.754449 59.045545 
-L 374.842471 57.460377 
-L 378.930493 63.305882 
-L 383.018515 62.344505 
-L 387.106537 57.531613 
-L 391.194559 54.195517 
-L 395.282581 56.989913 
-L 399.370603 54.195517 
-L 403.458626 54.7 
-L 407.546648 53.306667 
-L 411.63467 52.449231 
-L 415.722692 51.072727 
-L 419.810714 54.43156 
-L 423.898736 46.849756 
-L 427.986758 38.273333 
-L 432.07478 41.256216 
-L 436.162802 47.025246 
-L 440.250824 47.321391 
-L 444.338846 45.3368 
+L 125.473128 64.285172 
+L 129.56115 69.834483 
+L 133.649172 66.91534 
+L 137.737194 69.817667 
+L 141.825216 72.366415 
+L 145.913238 76.126614 
+L 150.00126 74.997477 
+L 154.089282 77.770385 
+L 158.177304 81.119223 
+L 162.265326 94.797037 
+L 166.353348 96.330081 
+L 170.44137 95.15513 
+L 174.529392 96.681739 
+L 178.617414 106.207273 
+L 182.705436 116.471111 
+L 186.793458 125.687304 
+L 190.88148 124.669565 
+L 194.969502 134.426789 
+L 199.057524 143.930909 
+L 203.145546 156.605517 
+L 207.233568 165.237778 
+L 211.32159 186.995214 
+L 215.409612 207.254046 
+L 219.497634 221.17931 
+L 223.585656 233.578144 
+L 227.673678 247.365846 
+L 231.7617 265.626435 
+L 235.849722 283.755556 
+L 239.937744 296.9728 
+L 244.025766 299.812459 
+L 248.113788 309.68 
+L 252.20181 305.964444 
+L 256.289832 306.527869 
+L 260.377855 301.401961 
+L 264.465877 298.202712 
+L 268.553899 288.78 
+L 272.641921 267.176822 
+L 276.729943 252.604 
+L 280.817965 234.011282 
+L 284.905987 223.837073 
+L 288.994009 210.405 
+L 293.082031 185.994872 
+L 297.170053 168.250275 
+L 301.258075 152.045769 
+L 305.346097 166.235644 
+L 309.434119 142.029846 
+L 313.522141 137.246504 
+L 317.610163 127.392812 
+L 321.698185 122.431481 
+L 325.786207 108.343333 
+L 329.874229 105.96352 
+L 333.962251 108.141818 
+L 338.050273 99.152692 
+L 342.138295 97.0225 
+L 346.226317 89.656637 
+L 350.314339 79.982913 
+L 354.402361 85.260444 
+L 358.490383 80.847234 
+L 362.578405 72.566726 
+L 366.666427 67.171475 
+L 370.754449 67.736634 
+L 374.842471 67.397736 
+L 378.930493 68.899706 
+L 383.018515 68.143784 
+L 387.106537 63.194839 
+L 391.194559 61.762759 
+L 395.282581 62.587478 
+L 399.370603 63.78069 
+L 403.458626 59.744828 
+L 407.546648 57.208 
+L 411.63467 54.378462 
+L 415.722692 52.523636 
+L 419.810714 59.263486 
+L 423.898736 51.60748 
+L 427.986758 41.353333 
+L 432.07478 43.892252 
+L 436.162802 51.821967 
+L 440.250824 51.901217 
+L 444.338846 50.0184 
 L 448.426868 46.222804 
-L 452.51489 38.766337 
-L 456.602912 39.674595 
-L 460.690934 35.617391 
-L 464.778956 39.112897 
-L 468.866978 47.066957 
-L 472.955 42.779259 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+L 452.51489 43.401584 
+L 456.602912 41.256216 
+L 460.690934 39.179478 
+L 464.778956 42.394393 
+L 468.866978 48.33913 
+L 472.955 44.404815 
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m80172c8fe4" d="M 0 1 
+     <path id="m709140e92d" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1362,213 +1362,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p877c0b4f0d)">
-     <use xlink:href="#m80172c8fe4" x="68.055" y="43.157064" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="72.328841" y="45.752727" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="76.416863" y="50.593333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="80.504885" y="49.823333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="84.592907" y="50.745946" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="88.680929" y="54.204068" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="92.768951" y="52.261667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="96.856973" y="48.525872" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="100.944995" y="54.385376" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="105.033017" y="49.70439" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="109.121039" y="60.66037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="113.209061" y="60.355294" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="117.297084" y="54.436396" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="121.385106" y="57.74304" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="125.473128" y="61.762759" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="129.56115" y="63.276207" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="133.649172" y="64.642718" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="137.737194" y="64.941" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="141.825216" y="66.84566" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="145.913238" y="69.675591" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="150.00126" y="70.77982" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="154.089282" y="70.455385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="158.177304" y="75.43767" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="162.265326" y="87.211111" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="166.353348" y="85.863089" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="170.44137" y="88.539826" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="174.529392" y="89.557565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="178.617414" y="97.985455" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="182.705436" y="109.468718" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="186.793458" y="112.456696" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="190.88148" y="117.545391" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="194.969502" y="128.521101" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="199.057524" y="134.258182" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="203.145546" y="143.993448" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="207.233568" y="158.271111" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="211.32159" y="186.495043" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="215.409612" y="190.278779" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="219.497634" y="210.585172" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="223.585656" y="226.338557" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="227.673678" y="241.964" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="231.7617" y="259.01113" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="235.849722" y="271.342222" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="239.937744" y="292.75936" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="244.025766" y="294.056393" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="248.113788" y="308.635" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="252.20181" y="304.106667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="256.289832" y="302.690492" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="260.377855" y="300.25451" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="264.465877" y="295.227119" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="268.553899" y="285.753103" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="272.641921" y="263.895327" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="276.729943" y="245.688" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="280.817965" y="230.009915" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="284.905987" y="216.224715" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="288.994009" y="204.6575" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="293.082031" y="168.488889" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="297.170053" y="160.733945" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="301.258075" y="145.293462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="305.346097" y="151.171089" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="309.434119" y="129.425538" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="313.522141" y="124.40065" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="317.610163" y="120.535" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="321.698185" y="109.968889" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="325.786207" y="99.077667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="329.874229" y="97.06848" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="333.962251" y="101.370909" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="338.050273" y="90.149615" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="342.138295" y="86.05" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="346.226317" y="83.96" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="350.314339" y="73.165049" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="354.402361" y="81.792593" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="358.490383" y="75.244255" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="362.578405" y="68.423717" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="366.666427" y="64.293443" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="370.754449" y="59.045545" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="374.842471" y="57.460377" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="378.930493" y="63.305882" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="383.018515" y="62.344505" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="387.106537" y="57.531613" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="391.194559" y="54.195517" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="395.282581" y="56.989913" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="399.370603" y="54.195517" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="403.458626" y="54.7" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="407.546648" y="53.306667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="411.63467" y="52.449231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="415.722692" y="51.072727" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="419.810714" y="54.43156" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="423.898736" y="46.849756" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="427.986758" y="38.273333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="432.07478" y="41.256216" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="436.162802" y="47.025246" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="440.250824" y="47.321391" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="444.338846" y="45.3368" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="448.426868" y="46.222804" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="452.51489" y="38.766337" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="456.602912" y="39.674595" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="460.690934" y="35.617391" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="464.778956" y="39.112897" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="468.866978" y="47.066957" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m80172c8fe4" x="472.955" y="42.779259" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p35cf3a6bba)">
+     <use xlink:href="#m709140e92d" x="68.055" y="45.304587" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="72.328841" y="47.203636" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="76.416863" y="52.133333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="80.504885" y="55.675333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="84.592907" y="52.327568" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="88.680929" y="59.16339" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="92.768951" y="54.212333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="96.856973" y="55.505321" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="100.944995" y="58.790108" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="105.033017" y="53.986341" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="109.121039" y="65.537037" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="113.209061" y="63.797647" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="117.297084" y="55.490811" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="121.385106" y="57.74304" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="125.473128" y="64.285172" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="129.56115" y="69.834483" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="133.649172" y="66.91534" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="137.737194" y="69.817667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="141.825216" y="72.366415" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="145.913238" y="76.126614" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="150.00126" y="74.997477" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="154.089282" y="77.770385" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="158.177304" y="81.119223" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="162.265326" y="94.797037" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="166.353348" y="96.330081" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="170.44137" y="95.15513" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="174.529392" y="96.681739" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="178.617414" y="106.207273" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="182.705436" y="116.471111" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="186.793458" y="125.687304" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="190.88148" y="124.669565" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="194.969502" y="134.426789" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="199.057524" y="143.930909" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="203.145546" y="156.605517" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="207.233568" y="165.237778" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="211.32159" y="186.995214" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="215.409612" y="207.254046" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="219.497634" y="221.17931" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="223.585656" y="233.578144" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="227.673678" y="247.365846" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="231.7617" y="265.626435" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="235.849722" y="283.755556" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="239.937744" y="296.9728" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="244.025766" y="299.812459" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="248.113788" y="309.68" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="252.20181" y="305.964444" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="256.289832" y="306.527869" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="260.377855" y="301.401961" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="264.465877" y="298.202712" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="268.553899" y="288.78" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="272.641921" y="267.176822" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="276.729943" y="252.604" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="280.817965" y="234.011282" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="284.905987" y="223.837073" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="288.994009" y="210.405" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="293.082031" y="185.994872" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="297.170053" y="168.250275" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="301.258075" y="152.045769" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="305.346097" y="166.235644" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="309.434119" y="142.029846" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="313.522141" y="137.246504" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="317.610163" y="127.392812" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="321.698185" y="122.431481" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="325.786207" y="108.343333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="329.874229" y="105.96352" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="333.962251" y="108.141818" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="338.050273" y="99.152692" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="342.138295" y="97.0225" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="346.226317" y="89.656637" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="350.314339" y="79.982913" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="354.402361" y="85.260444" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="358.490383" y="80.847234" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="362.578405" y="72.566726" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="366.666427" y="67.171475" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="370.754449" y="67.736634" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="374.842471" y="67.397736" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="378.930493" y="68.899706" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="383.018515" y="68.143784" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="387.106537" y="63.194839" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="391.194559" y="61.762759" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="395.282581" y="62.587478" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="399.370603" y="63.78069" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="403.458626" y="59.744828" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="407.546648" y="57.208" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="411.63467" y="54.378462" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="415.722692" y="52.523636" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="419.810714" y="59.263486" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="423.898736" y="51.60748" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="427.986758" y="41.353333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="432.07478" y="43.892252" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="436.162802" y="51.821967" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="440.250824" y="51.901217" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="444.338846" y="50.0184" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="448.426868" y="46.222804" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="452.51489" y="43.401584" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="456.602912" y="41.256216" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="460.690934" y="39.179478" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="464.778956" y="42.394393" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="468.866978" y="48.33913" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m709140e92d" x="472.955" y="44.404815" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_16">
     <path d="M 68.055 27.587523 
-L 72.328841 28.341818 
+L 72.328841 28.825455 
 L 76.416863 29.546667 
 L 80.504885 27.390667 
-L 84.592907 29.13045 
+L 84.592907 30.184865 
 L 88.680929 28.415593 
-L 92.768951 29.829 
+L 92.768951 30.316667 
 L 96.856973 29.198165 
-L 100.944995 29.844731 
+L 100.944995 30.473978 
 L 105.033017 32.576585 
-L 109.121039 31.40037 
-L 113.209061 30.849412 
+L 109.121039 32.484074 
+L 113.209061 32.324706 
 L 117.297084 32.293694 
-L 121.385106 28.24896 
-L 125.473128 29.980345 
-L 129.56115 29.980345 
-L 133.649172 33.394175 
-L 137.737194 30.804333 
-L 141.825216 29.304528 
-L 145.913238 30.969449 
+L 121.385106 28.71712 
+L 125.473128 30.484828 
+L 129.56115 30.484828 
+L 133.649172 33.96233 
+L 137.737194 32.755 
+L 141.825216 30.960755 
+L 145.913238 31.430236 
 L 150.00126 37.038559 
-L 154.089282 32.192308 
-L 158.177304 33.96233 
+L 154.089282 33.317692 
+L 158.177304 34.530485 
 L 162.265326 38.986296 
-L 166.353348 31.149268 
+L 166.353348 31.625041 
 L 170.44137 32.564174 
-L 174.529392 32.055304 
-L 178.617414 36.563636 
-L 182.705436 36.943932 
-L 186.793458 39.179478 
-L 190.88148 41.723826 
-L 194.969502 34.566972 
-L 199.057524 36.563636 
-L 203.145546 43.096897 
-L 207.233568 38.908889 
-L 211.32159 46.94735 
-L 215.409612 46.882443 
-L 219.497634 54.195517 
-L 223.585656 62.241237 
-L 227.673678 63.252923 
-L 231.7617 73.273739 
-L 235.849722 103.466667 
-L 239.937744 127.03072 
-L 244.025766 187.089508 
-L 248.113788 276.7625 
-L 252.20181 305.035556 
-L 256.289832 263.837049 
-L 260.377855 175.756078 
-L 264.465877 134.049153 
-L 268.553899 89.004828 
-L 272.641921 86.694579 
-L 276.729943 63.744 
-L 280.817965 56.950769 
-L 284.905987 50.180163 
-L 288.994009 46.34 
-L 293.082031 45.947009 
-L 297.170053 40.472661 
-L 301.258075 36.693846 
-L 305.346097 42.822178 
-L 309.434119 36.693846 
+L 174.529392 34.599652 
+L 178.617414 38.014545 
+L 182.705436 39.444786 
+L 186.793458 40.706087 
+L 190.88148 43.250435 
+L 194.969502 35.640734 
+L 199.057524 40.432727 
+L 203.145546 43.601379 
+L 207.233568 41.695556 
+L 211.32159 48.447863 
+L 215.409612 49.116031 
+L 219.497634 58.735862 
+L 223.585656 67.670928 
+L 227.673678 70.455385 
+L 231.7617 78.871304 
+L 235.849722 108.195556 
+L 239.937744 132.64864 
+L 244.025766 198.121967 
+L 248.113788 280.9425 
+L 252.20181 309.215556 
+L 256.289832 267.194754 
+L 260.377855 186.083137 
+L 264.465877 139.504407 
+L 268.553899 97.581034 
+L 272.641921 88.335327 
+L 276.729943 65.872 
+L 280.817965 58.451282 
+L 284.905987 52.559024 
+L 288.994009 47.9075 
+L 293.082031 45.446838 
+L 297.170053 44.767706 
+L 301.258075 38.381923 
+L 305.346097 43.401584 
+L 309.434119 37.144 
 L 313.522141 36.382764 
 L 317.610163 31.840625 
-L 321.698185 33.567778 
-L 325.786207 34.218 
-L 329.874229 31.05792 
-L 333.962251 35.596364 
-L 338.050273 33.880385 
+L 321.698185 35.193333 
+L 325.786207 34.705667 
+L 329.874229 31.52608 
+L 333.962251 36.08 
+L 338.050273 35.568462 
 L 342.138295 33.8 
-L 346.226317 32.172389 
-L 350.314339 30.553398 
-L 354.402361 30.208296 
-L 358.490383 28.552766 
-L 362.578405 33.208142 
-L 366.666427 31.196066 
-L 370.754449 31.234059 
+L 346.226317 33.726018 
+L 350.314339 34.530485 
+L 354.402361 31.075259 
+L 358.490383 31.665532 
+L 362.578405 34.243894 
+L 366.666427 33.594426 
+L 370.754449 32.392871 
 L 374.842471 29.856604 
-L 378.930493 30.173235 
+L 378.930493 31.033824 
 L 383.018515 32.293694 
-L 387.106537 27.327742 
-L 391.194559 29.475862 
+L 387.106537 29.215484 
+L 391.194559 30.98931 
 L 395.282581 27.984348 
-L 399.370603 29.475862 
-L 403.458626 30.484828 
+L 399.370603 29.980345 
+L 403.458626 30.98931 
 L 407.546648 31.570667 
-L 411.63467 29.298462 
-L 415.722692 26.407273 
-L 419.810714 30.271927 
-L 423.898736 28.770407 
+L 411.63467 28.655385 
+L 415.722692 25.923636 
+L 419.810714 31.345688 
+L 423.898736 28.294634 
 L 427.986758 28.006667 
 L 432.07478 27.548829 
 L 436.162802 28.797705 
 L 440.250824 28.493217 
-L 444.338846 28.366 
+L 444.338846 28.9512 
 L 448.426868 26.533832 
-L 452.51489 28.33703 
-L 456.602912 27.021622 
-L 460.690934 26.966609 
-L 464.778956 26.533832 
-L 468.866978 28.620435 
-L 472.955 29.774815 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
+L 452.51489 28.916436 
+L 456.602912 27.548829 
+L 460.690934 27.475478 
+L 464.778956 27.627664 
+L 468.866978 29.256522 
+L 472.955 30.316667 
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
     <defs>
-     <path id="m7c80a999db" d="M 0 1 
+     <path id="mf85e2c9af9" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1580,118 +1580,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p877c0b4f0d)">
-     <use xlink:href="#m7c80a999db" x="68.055" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="72.328841" y="28.341818" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="76.416863" y="29.546667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="80.504885" y="27.390667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="84.592907" y="29.13045" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="88.680929" y="28.415593" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="92.768951" y="29.829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="96.856973" y="29.198165" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="100.944995" y="29.844731" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="105.033017" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="109.121039" y="31.40037" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="113.209061" y="30.849412" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="117.297084" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="121.385106" y="28.24896" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="125.473128" y="29.980345" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="129.56115" y="29.980345" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="133.649172" y="33.394175" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="137.737194" y="30.804333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="141.825216" y="29.304528" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="145.913238" y="30.969449" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="150.00126" y="37.038559" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="154.089282" y="32.192308" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="158.177304" y="33.96233" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="162.265326" y="38.986296" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="166.353348" y="31.149268" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="170.44137" y="32.564174" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="174.529392" y="32.055304" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="178.617414" y="36.563636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="182.705436" y="36.943932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="186.793458" y="39.179478" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="190.88148" y="41.723826" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="194.969502" y="34.566972" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="199.057524" y="36.563636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="203.145546" y="43.096897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="207.233568" y="38.908889" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="211.32159" y="46.94735" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="215.409612" y="46.882443" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="219.497634" y="54.195517" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="223.585656" y="62.241237" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="227.673678" y="63.252923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="231.7617" y="73.273739" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="235.849722" y="103.466667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="239.937744" y="127.03072" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="244.025766" y="187.089508" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="248.113788" y="276.7625" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="252.20181" y="305.035556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="256.289832" y="263.837049" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="260.377855" y="175.756078" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="264.465877" y="134.049153" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="268.553899" y="89.004828" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="272.641921" y="86.694579" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="276.729943" y="63.744" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="280.817965" y="56.950769" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="284.905987" y="50.180163" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="288.994009" y="46.34" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="293.082031" y="45.947009" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="297.170053" y="40.472661" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="301.258075" y="36.693846" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="305.346097" y="42.822178" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="309.434119" y="36.693846" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="313.522141" y="36.382764" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="317.610163" y="31.840625" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="321.698185" y="33.567778" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="325.786207" y="34.218" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="329.874229" y="31.05792" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="333.962251" y="35.596364" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="338.050273" y="33.880385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="342.138295" y="33.8" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="346.226317" y="32.172389" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="350.314339" y="30.553398" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="354.402361" y="30.208296" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="358.490383" y="28.552766" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="362.578405" y="33.208142" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="366.666427" y="31.196066" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="370.754449" y="31.234059" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="374.842471" y="29.856604" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="378.930493" y="30.173235" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="383.018515" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="387.106537" y="27.327742" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="391.194559" y="29.475862" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="395.282581" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="399.370603" y="29.475862" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="403.458626" y="30.484828" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="407.546648" y="31.570667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="411.63467" y="29.298462" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="415.722692" y="26.407273" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="419.810714" y="30.271927" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="423.898736" y="28.770407" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="427.986758" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="432.07478" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="436.162802" y="28.797705" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="440.250824" y="28.493217" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="444.338846" y="28.366" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="448.426868" y="26.533832" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="452.51489" y="28.33703" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="456.602912" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="460.690934" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="464.778956" y="26.533832" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="468.866978" y="28.620435" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m7c80a999db" x="472.955" y="29.774815" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p35cf3a6bba)">
+     <use xlink:href="#mf85e2c9af9" x="68.055" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="72.328841" y="28.825455" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="76.416863" y="29.546667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="80.504885" y="27.390667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="84.592907" y="30.184865" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="88.680929" y="28.415593" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="92.768951" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="96.856973" y="29.198165" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="100.944995" y="30.473978" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="105.033017" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="109.121039" y="32.484074" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="113.209061" y="32.324706" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="117.297084" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="121.385106" y="28.71712" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="125.473128" y="30.484828" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="129.56115" y="30.484828" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="133.649172" y="33.96233" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="137.737194" y="32.755" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="141.825216" y="30.960755" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="145.913238" y="31.430236" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="150.00126" y="37.038559" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="154.089282" y="33.317692" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="158.177304" y="34.530485" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="162.265326" y="38.986296" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="166.353348" y="31.625041" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="170.44137" y="32.564174" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="174.529392" y="34.599652" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="178.617414" y="38.014545" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="182.705436" y="39.444786" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="186.793458" y="40.706087" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="190.88148" y="43.250435" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="194.969502" y="35.640734" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="199.057524" y="40.432727" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="203.145546" y="43.601379" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="207.233568" y="41.695556" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="211.32159" y="48.447863" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="215.409612" y="49.116031" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="219.497634" y="58.735862" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="223.585656" y="67.670928" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="227.673678" y="70.455385" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="231.7617" y="78.871304" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="235.849722" y="108.195556" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="239.937744" y="132.64864" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="244.025766" y="198.121967" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="248.113788" y="280.9425" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="252.20181" y="309.215556" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="256.289832" y="267.194754" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="260.377855" y="186.083137" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="264.465877" y="139.504407" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="268.553899" y="97.581034" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="272.641921" y="88.335327" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="276.729943" y="65.872" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="280.817965" y="58.451282" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="284.905987" y="52.559024" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="288.994009" y="47.9075" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="293.082031" y="45.446838" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="297.170053" y="44.767706" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="301.258075" y="38.381923" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="305.346097" y="43.401584" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="309.434119" y="37.144" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="313.522141" y="36.382764" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="317.610163" y="31.840625" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="321.698185" y="35.193333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="325.786207" y="34.705667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="329.874229" y="31.52608" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="333.962251" y="36.08" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="338.050273" y="35.568462" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="342.138295" y="33.8" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="346.226317" y="33.726018" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="350.314339" y="34.530485" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="354.402361" y="31.075259" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="358.490383" y="31.665532" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="362.578405" y="34.243894" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="366.666427" y="33.594426" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="370.754449" y="32.392871" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="374.842471" y="29.856604" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="378.930493" y="31.033824" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="383.018515" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="387.106537" y="29.215484" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="391.194559" y="30.98931" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="395.282581" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="399.370603" y="29.980345" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="403.458626" y="30.98931" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="407.546648" y="31.570667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="411.63467" y="28.655385" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="415.722692" y="25.923636" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="419.810714" y="31.345688" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="423.898736" y="28.294634" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="427.986758" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="432.07478" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="436.162802" y="28.797705" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="440.250824" y="28.493217" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="444.338846" y="28.9512" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="448.426868" y="26.533832" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="452.51489" y="28.916436" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="456.602912" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="460.690934" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="464.778956" y="27.627664" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="468.866978" y="29.256522" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mf85e2c9af9" x="472.955" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_17">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_18">
     <path d="M 252.015991 318.04 
 L 252.015991 25.44 
-" clip-path="url(#p877c0b4f0d)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -1890,7 +1890,7 @@ L 63.01 271.14875
 L 71.01 271.14875 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8a97c86d7c" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m01ead28dd5" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_17">
@@ -1945,7 +1945,7 @@ L 63.01 282.89125
 L 71.01 282.89125 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m350ca17da6" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m0a4af889ee" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_18">
@@ -2001,7 +2001,7 @@ L 63.01 294.63375
 L 71.01 294.63375 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m80172c8fe4" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#m709140e92d" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_19">
@@ -2070,7 +2070,7 @@ L 63.01 306.37625
 L 71.01 306.37625 
 " style="fill: none; stroke: #d62728; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7c80a999db" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
+      <use xlink:href="#mf85e2c9af9" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_20">
@@ -2085,7 +2085,7 @@ L 71.01 306.37625
   </g>
  </g>
  <defs>
-  <clipPath id="p877c0b4f0d">
+  <clipPath id="p35cf3a6bba">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:39.344609</dc:date>
+    <dc:date>2026-08-16T17:12:22.831861</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma627e9dbb8" d="M 0 0 
+       <path id="mcde95ff51b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma627e9dbb8" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -121,7 +121,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma627e9dbb8" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,7 +177,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma627e9dbb8" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -208,7 +208,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma627e9dbb8" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -249,7 +249,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma627e9dbb8" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -285,7 +285,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma627e9dbb8" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcde95ff51b" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -582,12 +582,12 @@ z
     <g id="ytick_1">
      <g id="line2d_7">
       <defs>
-       <path id="m9f3be55944" d="M 0 0 
+       <path id="m9ade53a94b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -602,7 +602,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,7 +617,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -632,7 +632,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -647,7 +647,7 @@ L -3.5 0
     <g id="ytick_5">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -662,7 +662,7 @@ L -3.5 0
     <g id="ytick_6">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9f3be55944" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ade53a94b" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -813,108 +813,108 @@ z
    </g>
    <g id="line2d_13">
     <path d="M 68.055 30.362243 
-L 72.328841 33.8 
-L 76.416863 36.22 
-L 80.504885 36.656333 
-L 84.592907 36.177615 
-L 88.680929 35.94359 
-L 92.768951 40.192941 
-L 96.856973 35.193333 
-L 100.944995 35.507957 
-L 105.033017 38.981818 
-L 109.121039 37.58566 
-L 113.209061 40.684706 
-L 117.297084 39.804 
-L 121.385106 38.54848 
+L 72.328841 34.783529 
+L 76.416863 36.733333 
+L 80.504885 39.094667 
+L 84.592907 37.251376 
+L 88.680929 36.443761 
+L 92.768951 40.684706 
+L 96.856973 35.735185 
+L 100.944995 36.137204 
+L 105.033017 39.949091 
+L 109.121039 40.898113 
+L 113.209061 40.192941 
+L 117.297084 40.336 
+L 121.385106 38.08032 
 L 125.473128 41.583448 
-L 129.56115 43.759304 
+L 129.56115 44.268174 
 L 133.649172 46.461748 
-L 137.737194 47.569412 
-L 141.825216 39.930667 
+L 137.737194 49.536471 
+L 141.825216 42.717333 
 L 145.913238 48.943934 
-L 150.00126 50.218739 
-L 154.089282 48.734369 
-L 158.177304 51.831373 
-L 162.265326 59.576667 
-L 166.353348 58.744065 
-L 170.44137 61.886667 
-L 174.529392 58.066195 
-L 178.617414 63.797647 
-L 182.705436 72.956239 
-L 186.793458 70.220522 
-L 190.88148 76.773333 
-L 194.969502 79.128073 
-L 199.057524 89.369412 
-L 203.145546 93.713333 
-L 207.233568 104.253226 
-L 211.32159 112.469744 
-L 215.409612 123.88062 
-L 219.497634 150.621913 
-L 223.585656 177.47134 
-L 227.673678 181.946977 
-L 231.7617 208.768142 
-L 235.849722 239.814286 
-L 239.937744 258.58368 
-L 244.025766 291.484706 
-L 248.113788 304.208 
+L 150.00126 52.327568 
+L 154.089282 51.575146 
+L 158.177304 54.126275 
+L 162.265326 62.285926 
+L 166.353348 61.122927 
+L 170.44137 65.48 
+L 174.529392 62.209204 
+L 178.617414 64.781176 
+L 182.705436 73.956581 
+L 186.793458 74.800348 
+L 190.88148 80.88 
+L 194.969502 85.570642 
+L 199.057524 97.729412 
+L 203.145546 99.873333 
+L 207.233568 108.500645 
+L 211.32159 116.471111 
+L 215.409612 130.685271 
+L 219.497634 149.604174 
+L 223.585656 184.107629 
+L 227.673678 188.297984 
+L 231.7617 218.089912 
+L 235.849722 245.785714 
+L 239.937744 263.73344 
+L 244.025766 293.943529 
+L 248.113788 305.804 
 L 252.20181 299.162581 
-L 256.289832 299.178182 
-L 260.377855 281.982222 
-L 264.465877 265.02188 
-L 268.553899 239.674087 
-L 272.641921 212.704 
-L 276.729943 185.967339 
-L 280.817965 169.722069 
-L 284.905987 138.673821 
-L 288.994009 129.94 
-L 293.082031 128.740522 
-L 297.170053 110.510741 
-L 301.258075 96.581961 
-L 305.346097 100.9308 
-L 309.434119 89.361846 
-L 313.522141 86.358361 
-L 317.610163 82.566667 
-L 321.698185 77.397009 
-L 325.786207 75.669667 
-L 329.874229 61.95648 
-L 333.962251 66.954188 
-L 338.050273 67.641923 
-L 342.138295 59.708468 
-L 346.226317 61.616 
-L 350.314339 56.994902 
-L 354.402361 56.217185 
-L 358.490383 60.302979 
-L 362.578405 48.43 
-L 366.666427 50.798667 
-L 370.754449 48.616238 
-L 374.842471 43.106415 
-L 378.930493 51.88237 
-L 383.018515 50.976 
-L 387.106537 44.317419 
-L 391.194559 43.096897 
-L 395.282581 38.904779 
-L 399.370603 45.973333 
-L 403.458626 43.759304 
-L 407.546648 44.757282 
-L 411.63467 41.695556 
-L 415.722692 41.4 
-L 419.810714 44.230826 
-L 423.898736 39.350492 
-L 427.986758 35.193333 
-L 432.07478 35.548 
-L 436.162802 40.309836 
-L 440.250824 42.232696 
-L 444.338846 40.217778 
-L 448.426868 38.019065 
-L 452.51489 36.90268 
-L 456.602912 39.147387 
+L 256.289832 302.08 
+L 260.377855 282.573333 
+L 264.465877 269.523419 
+L 268.553899 242.218435 
+L 272.641921 219.392 
+L 276.729943 189.188624 
+L 280.817965 173.757931 
+L 284.905987 147.237724 
+L 288.994009 135.165 
+L 293.082031 127.722783 
+L 297.170053 116.471111 
+L 301.258075 99.450588 
+L 305.346097 106.7828 
+L 309.434119 91.162462 
+L 313.522141 88.756721 
+L 317.610163 85.353333 
+L 321.698185 82.866168 
+L 325.786207 76.157333 
+L 329.874229 62.8928 
+L 333.962251 68.454701 
+L 338.050273 68.204615 
+L 342.138295 62.344505 
+L 346.226317 61.084 
+L 350.314339 58.142353 
+L 354.402361 57.084148 
+L 358.490383 64.038298 
+L 362.578405 47.385 
+L 366.666427 53.724667 
+L 370.754449 48.036832 
+L 374.842471 44.210566 
+L 378.930493 52.749333 
+L 383.018515 50.444 
+L 387.106537 44.789355 
+L 391.194559 43.601379 
+L 395.282581 39.940531 
+L 399.370603 48.54 
+L 403.458626 44.777043 
+L 407.546648 45.893592 
+L 411.63467 44.946667 
+L 415.722692 43.818182 
+L 419.810714 42.620183 
+L 423.898736 39.830164 
+L 427.986758 35.706667 
+L 432.07478 36.08 
+L 436.162802 39.350492 
+L 440.250824 40.197217 
+L 444.338846 38.444444 
+L 448.426868 36.925234 
+L 452.51489 37.505979 
+L 456.602912 39.674595 
 L 460.690934 33.581913 
-L 464.778956 37.033585 
-L 468.866978 39.433913 
-L 472.955 37.360741 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+L 464.778956 37.58566 
+L 468.866978 41.342174 
+L 472.955 37.902593 
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="mdff914914b" d="M 0 1 
+     <path id="m5a2f7c6181" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -926,213 +926,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p7d9a958ad9)">
-     <use xlink:href="#mdff914914b" x="68.055" y="30.362243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="72.328841" y="33.8" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="76.416863" y="36.22" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="80.504885" y="36.656333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="84.592907" y="36.177615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="88.680929" y="35.94359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="92.768951" y="40.192941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="96.856973" y="35.193333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="100.944995" y="35.507957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="105.033017" y="38.981818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="109.121039" y="37.58566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="113.209061" y="40.684706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="117.297084" y="39.804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="121.385106" y="38.54848" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="125.473128" y="41.583448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="129.56115" y="43.759304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="133.649172" y="46.461748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="137.737194" y="47.569412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="141.825216" y="39.930667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="145.913238" y="48.943934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="150.00126" y="50.218739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="154.089282" y="48.734369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="158.177304" y="51.831373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="162.265326" y="59.576667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="166.353348" y="58.744065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="170.44137" y="61.886667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="174.529392" y="58.066195" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="178.617414" y="63.797647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="182.705436" y="72.956239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="186.793458" y="70.220522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="190.88148" y="76.773333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="194.969502" y="79.128073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="199.057524" y="89.369412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="203.145546" y="93.713333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="207.233568" y="104.253226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="211.32159" y="112.469744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="215.409612" y="123.88062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="219.497634" y="150.621913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="223.585656" y="177.47134" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="227.673678" y="181.946977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="231.7617" y="208.768142" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="235.849722" y="239.814286" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="239.937744" y="258.58368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="244.025766" y="291.484706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="248.113788" y="304.208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="252.20181" y="299.162581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="256.289832" y="299.178182" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="260.377855" y="281.982222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="264.465877" y="265.02188" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="268.553899" y="239.674087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="272.641921" y="212.704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="276.729943" y="185.967339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="280.817965" y="169.722069" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="284.905987" y="138.673821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="288.994009" y="129.94" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="293.082031" y="128.740522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="297.170053" y="110.510741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="301.258075" y="96.581961" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="305.346097" y="100.9308" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="309.434119" y="89.361846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="313.522141" y="86.358361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="317.610163" y="82.566667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="321.698185" y="77.397009" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="325.786207" y="75.669667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="329.874229" y="61.95648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="333.962251" y="66.954188" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="338.050273" y="67.641923" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="342.138295" y="59.708468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="346.226317" y="61.616" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="350.314339" y="56.994902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="354.402361" y="56.217185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="358.490383" y="60.302979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="362.578405" y="48.43" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="366.666427" y="50.798667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="370.754449" y="48.616238" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="374.842471" y="43.106415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="378.930493" y="51.88237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="383.018515" y="50.976" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="387.106537" y="44.317419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="391.194559" y="43.096897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="395.282581" y="38.904779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="399.370603" y="45.973333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="403.458626" y="43.759304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="407.546648" y="44.757282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="411.63467" y="41.695556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="415.722692" y="41.4" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="419.810714" y="44.230826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="423.898736" y="39.350492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="427.986758" y="35.193333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="432.07478" y="35.548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="436.162802" y="40.309836" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="440.250824" y="42.232696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="444.338846" y="40.217778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="448.426868" y="38.019065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="452.51489" y="36.90268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="456.602912" y="39.147387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="460.690934" y="33.581913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="464.778956" y="37.033585" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="468.866978" y="39.433913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdff914914b" x="472.955" y="37.360741" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pd0e5ecd757)">
+     <use xlink:href="#m5a2f7c6181" x="68.055" y="30.362243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="72.328841" y="34.783529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="76.416863" y="36.733333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="80.504885" y="39.094667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="84.592907" y="37.251376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="88.680929" y="36.443761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="92.768951" y="40.684706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="96.856973" y="35.735185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="100.944995" y="36.137204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="105.033017" y="39.949091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="109.121039" y="40.898113" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="113.209061" y="40.192941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="117.297084" y="40.336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="121.385106" y="38.08032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="125.473128" y="41.583448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="129.56115" y="44.268174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="133.649172" y="46.461748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="137.737194" y="49.536471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="141.825216" y="42.717333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="145.913238" y="48.943934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="150.00126" y="52.327568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="154.089282" y="51.575146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="158.177304" y="54.126275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="162.265326" y="62.285926" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="166.353348" y="61.122927" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="170.44137" y="65.48" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="174.529392" y="62.209204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="178.617414" y="64.781176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="182.705436" y="73.956581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="186.793458" y="74.800348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="190.88148" y="80.88" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="194.969502" y="85.570642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="199.057524" y="97.729412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="203.145546" y="99.873333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="207.233568" y="108.500645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="211.32159" y="116.471111" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="215.409612" y="130.685271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="219.497634" y="149.604174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="223.585656" y="184.107629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="227.673678" y="188.297984" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="231.7617" y="218.089912" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="235.849722" y="245.785714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="239.937744" y="263.73344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="244.025766" y="293.943529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="248.113788" y="305.804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="252.20181" y="299.162581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="256.289832" y="302.08" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="260.377855" y="282.573333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="264.465877" y="269.523419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="268.553899" y="242.218435" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="272.641921" y="219.392" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="276.729943" y="189.188624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="280.817965" y="173.757931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="284.905987" y="147.237724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="288.994009" y="135.165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="293.082031" y="127.722783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="297.170053" y="116.471111" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="301.258075" y="99.450588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="305.346097" y="106.7828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="309.434119" y="91.162462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="313.522141" y="88.756721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="317.610163" y="85.353333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="321.698185" y="82.866168" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="325.786207" y="76.157333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="329.874229" y="62.8928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="333.962251" y="68.454701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="338.050273" y="68.204615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="342.138295" y="62.344505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="346.226317" y="61.084" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="350.314339" y="58.142353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="354.402361" y="57.084148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="358.490383" y="64.038298" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="362.578405" y="47.385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="366.666427" y="53.724667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="370.754449" y="48.036832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="374.842471" y="44.210566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="378.930493" y="52.749333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="383.018515" y="50.444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="387.106537" y="44.789355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="391.194559" y="43.601379" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="395.282581" y="39.940531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="399.370603" y="48.54" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="403.458626" y="44.777043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="407.546648" y="45.893592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="411.63467" y="44.946667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="415.722692" y="43.818182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="419.810714" y="42.620183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="423.898736" y="39.830164" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="427.986758" y="35.706667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="432.07478" y="36.08" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="436.162802" y="39.350492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="440.250824" y="40.197217" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="444.338846" y="38.444444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="448.426868" y="36.925234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="452.51489" y="37.505979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="456.602912" y="39.674595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="460.690934" y="33.581913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="464.778956" y="37.58566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="468.866978" y="41.342174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5a2f7c6181" x="472.955" y="37.902593" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_14">
-    <path d="M 68.055 29.198165 
-L 72.328841 33.661818 
-L 76.416863 33.14 
+    <path d="M 68.055 29.735046 
+L 72.328841 33.178182 
+L 76.416863 34.166667 
 L 80.504885 34.705667 
-L 84.592907 36.511351 
-L 88.680929 35.358644 
-L 92.768951 36.656333 
+L 84.592907 34.92973 
+L 88.680929 36.350508 
+L 92.768951 37.144 
 L 96.856973 32.95633 
-L 100.944995 34.87871 
+L 100.944995 35.507957 
 L 105.033017 36.382764 
-L 109.121039 36.818889 
-L 113.209061 36.258824 
-L 117.297084 37.038559 
-L 121.385106 36.20768 
-L 125.473128 38.052069 
-L 129.56115 35.025172 
-L 133.649172 42.48466 
-L 137.737194 37.631667 
+L 109.121039 38.444444 
+L 113.209061 37.734118 
+L 117.297084 37.565766 
+L 121.385106 35.27136 
+L 125.473128 38.556552 
+L 129.56115 38.052069 
+L 133.649172 45.325437 
+L 137.737194 38.119333 
 L 141.825216 39.241887 
-L 145.913238 43.410709 
-L 150.00126 44.946667 
-L 154.089282 40.632692 
-L 158.177304 51.00699 
-L 162.265326 49.823333 
-L 166.353348 53.034797 
-L 170.44137 56.481043 
-L 174.529392 55.972174 
-L 178.617414 53.490909 
-L 182.705436 59.451624 
-L 186.793458 60.552 
-L 190.88148 65.640696 
-L 194.969502 62.484771 
-L 199.057524 75.738182 
-L 203.145546 76.392759 
-L 207.233568 94.177778 
-L 211.32159 89.46188 
-L 215.409612 109.869618 
-L 219.497634 120.282759 
-L 223.585656 138.256907 
-L 227.673678 159.135692 
-L 231.7617 177.08313 
-L 235.849722 222.28 
-L 239.937744 250.1568 
-L 244.025766 280.625574 
-L 248.113788 300.7975 
-L 252.20181 307.822222 
-L 256.289832 303.170164 
-L 260.377855 279.026667 
-L 264.465877 254.560678 
-L 268.553899 224.71069 
-L 272.641921 182.951776 
-L 276.729943 162.164 
-L 280.817965 138.478632 
-L 284.905987 120.594472 
-L 288.994009 106.4275 
-L 293.082031 91.462564 
-L 297.170053 92.013211 
-L 301.258075 76.645 
-L 305.346097 86.277624 
-L 309.434119 68.654769 
-L 313.522141 65.88065 
-L 317.610163 62.929375 
-L 321.698185 56.325556 
-L 325.786207 56.163 
-L 329.874229 57.27488 
-L 333.962251 56.392727 
-L 338.050273 60.326923 
-L 342.138295 52.61 
-L 346.226317 48.226549 
-L 350.314339 46.461748 
-L 354.402361 49.281481 
-L 358.490383 48.474468 
-L 362.578405 43.047788 
-L 366.666427 46.545574 
-L 370.754449 42.242772 
+L 145.913238 45.253858 
+L 150.00126 46.528288 
+L 154.089282 44.008846 
+L 158.177304 52.143301 
+L 162.265326 54.158148 
+L 166.353348 55.889431 
+L 170.44137 57.498783 
+L 174.529392 58.007652 
+L 178.617414 55.909091 
+L 182.705436 59.951795 
+L 186.793458 66.149565 
+L 190.88148 71.74713 
+L 194.969502 66.779817 
+L 199.057524 80.574545 
+L 203.145546 82.951034 
+L 207.233568 97.893333 
+L 211.32159 96.964444 
+L 215.409612 112.996641 
+L 219.497634 127.345517 
+L 223.585656 146.703093 
+L 227.673678 163.637231 
+L 231.7617 185.225043 
+L 235.849722 227.6 
+L 239.937744 253.43392 
+L 244.025766 281.105246 
+L 248.113788 295.05 
+L 252.20181 307.357778 
+L 256.289832 303.649836 
+L 260.377855 284.190196 
+L 264.465877 257.536271 
+L 268.553899 224.206207 
+L 272.641921 188.420935 
+L 276.729943 168.548 
+L 280.817965 140.979487 
+L 284.905987 123.449106 
+L 288.994009 113.7425 
+L 293.082031 94.963761 
+L 297.170053 94.697615 
+L 301.258075 76.082308 
+L 305.346097 87.436436 
+L 309.434119 71.805846 
+L 313.522141 66.356423 
+L 317.610163 61.100625 
+L 321.698185 56.867407 
+L 325.786207 56.650667 
+L 329.874229 54.46592 
+L 333.962251 55.425455 
+L 338.050273 56.950769 
+L 342.138295 47.9075 
+L 346.226317 48.744425 
+L 350.314339 47.598058 
+L 354.402361 49.714963 
+L 358.490383 47.851915 
+L 362.578405 42.012035 
+L 366.666427 46.065902 
+L 370.754449 43.401584 
 L 374.842471 39.241887 
 L 378.930493 40.500294 
-L 383.018515 44.946667 
-L 387.106537 39.598065 
+L 383.018515 45.473874 
+L 387.106537 40.541935 
 L 391.194559 39.565517 
-L 395.282581 35.108522 
+L 395.282581 35.617391 
 L 399.370603 42.592414 
-L 403.458626 39.061034 
-L 407.546648 37.701333 
-L 411.63467 40.230769 
-L 415.722692 36.08 
+L 403.458626 38.556552 
+L 407.546648 37.144 
+L 411.63467 38.944615 
+L 415.722692 34.145455 
 L 419.810714 39.398899 
-L 423.898736 38.285854 
+L 423.898736 37.334309 
 L 427.986758 31.6 
-L 432.07478 33.348108 
-L 436.162802 38.391148 
+L 432.07478 33.875315 
+L 436.162802 39.350492 
 L 440.250824 38.670609 
-L 444.338846 37.7292 
-L 448.426868 35.831402 
-L 452.51489 34.131089 
+L 444.338846 38.3144 
+L 448.426868 34.73757 
+L 452.51489 36.448713 
 L 456.602912 33.875315 
-L 460.690934 31.037565 
-L 464.778956 35.284486 
+L 460.690934 33.073043 
+L 464.778956 36.378318 
 L 468.866978 38.161739 
-L 472.955 35.193333 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+L 472.955 36.818889 
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="me2283fd27b" d="M 0 1 
+     <path id="m729b46263b" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1144,213 +1144,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p7d9a958ad9)">
-     <use xlink:href="#me2283fd27b" x="68.055" y="29.198165" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="72.328841" y="33.661818" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="76.416863" y="33.14" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="80.504885" y="34.705667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="84.592907" y="36.511351" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="88.680929" y="35.358644" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="92.768951" y="36.656333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="96.856973" y="32.95633" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="100.944995" y="34.87871" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="105.033017" y="36.382764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="109.121039" y="36.818889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="113.209061" y="36.258824" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="117.297084" y="37.038559" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="121.385106" y="36.20768" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="125.473128" y="38.052069" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="129.56115" y="35.025172" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="133.649172" y="42.48466" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="137.737194" y="37.631667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="141.825216" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="145.913238" y="43.410709" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="150.00126" y="44.946667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="154.089282" y="40.632692" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="158.177304" y="51.00699" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="162.265326" y="49.823333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="166.353348" y="53.034797" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="170.44137" y="56.481043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="174.529392" y="55.972174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="178.617414" y="53.490909" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="182.705436" y="59.451624" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="186.793458" y="60.552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="190.88148" y="65.640696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="194.969502" y="62.484771" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="199.057524" y="75.738182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="203.145546" y="76.392759" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="207.233568" y="94.177778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="211.32159" y="89.46188" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="215.409612" y="109.869618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="219.497634" y="120.282759" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="223.585656" y="138.256907" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="227.673678" y="159.135692" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="231.7617" y="177.08313" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="235.849722" y="222.28" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="239.937744" y="250.1568" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="244.025766" y="280.625574" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="248.113788" y="300.7975" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="252.20181" y="307.822222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="256.289832" y="303.170164" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="260.377855" y="279.026667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="264.465877" y="254.560678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="268.553899" y="224.71069" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="272.641921" y="182.951776" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="276.729943" y="162.164" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="280.817965" y="138.478632" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="284.905987" y="120.594472" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="288.994009" y="106.4275" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="293.082031" y="91.462564" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="297.170053" y="92.013211" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="301.258075" y="76.645" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="305.346097" y="86.277624" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="309.434119" y="68.654769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="313.522141" y="65.88065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="317.610163" y="62.929375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="321.698185" y="56.325556" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="325.786207" y="56.163" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="329.874229" y="57.27488" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="333.962251" y="56.392727" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="338.050273" y="60.326923" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="342.138295" y="52.61" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="346.226317" y="48.226549" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="350.314339" y="46.461748" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="354.402361" y="49.281481" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="358.490383" y="48.474468" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="362.578405" y="43.047788" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="366.666427" y="46.545574" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="370.754449" y="42.242772" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="374.842471" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="378.930493" y="40.500294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="383.018515" y="44.946667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="387.106537" y="39.598065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="391.194559" y="39.565517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="395.282581" y="35.108522" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="399.370603" y="42.592414" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="403.458626" y="39.061034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="407.546648" y="37.701333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="411.63467" y="40.230769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="415.722692" y="36.08" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="419.810714" y="39.398899" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="423.898736" y="38.285854" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="427.986758" y="31.6" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="432.07478" y="33.348108" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="436.162802" y="38.391148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="440.250824" y="38.670609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="444.338846" y="37.7292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="448.426868" y="35.831402" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="452.51489" y="34.131089" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="456.602912" y="33.875315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="460.690934" y="31.037565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="464.778956" y="35.284486" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="468.866978" y="38.161739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#me2283fd27b" x="472.955" y="35.193333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#pd0e5ecd757)">
+     <use xlink:href="#m729b46263b" x="68.055" y="29.735046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="72.328841" y="33.178182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="76.416863" y="34.166667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="80.504885" y="34.705667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="84.592907" y="34.92973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="88.680929" y="36.350508" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="92.768951" y="37.144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="96.856973" y="32.95633" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="100.944995" y="35.507957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="105.033017" y="36.382764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="109.121039" y="38.444444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="113.209061" y="37.734118" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="117.297084" y="37.565766" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="121.385106" y="35.27136" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="125.473128" y="38.556552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="129.56115" y="38.052069" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="133.649172" y="45.325437" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="137.737194" y="38.119333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="141.825216" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="145.913238" y="45.253858" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="150.00126" y="46.528288" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="154.089282" y="44.008846" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="158.177304" y="52.143301" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="162.265326" y="54.158148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="166.353348" y="55.889431" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="170.44137" y="57.498783" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="174.529392" y="58.007652" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="178.617414" y="55.909091" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="182.705436" y="59.951795" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="186.793458" y="66.149565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="190.88148" y="71.74713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="194.969502" y="66.779817" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="199.057524" y="80.574545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="203.145546" y="82.951034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="207.233568" y="97.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="211.32159" y="96.964444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="215.409612" y="112.996641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="219.497634" y="127.345517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="223.585656" y="146.703093" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="227.673678" y="163.637231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="231.7617" y="185.225043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="235.849722" y="227.6" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="239.937744" y="253.43392" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="244.025766" y="281.105246" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="248.113788" y="295.05" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="252.20181" y="307.357778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="256.289832" y="303.649836" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="260.377855" y="284.190196" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="264.465877" y="257.536271" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="268.553899" y="224.206207" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="272.641921" y="188.420935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="276.729943" y="168.548" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="280.817965" y="140.979487" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="284.905987" y="123.449106" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="288.994009" y="113.7425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="293.082031" y="94.963761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="297.170053" y="94.697615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="301.258075" y="76.082308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="305.346097" y="87.436436" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="309.434119" y="71.805846" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="313.522141" y="66.356423" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="317.610163" y="61.100625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="321.698185" y="56.867407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="325.786207" y="56.650667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="329.874229" y="54.46592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="333.962251" y="55.425455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="338.050273" y="56.950769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="342.138295" y="47.9075" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="346.226317" y="48.744425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="350.314339" y="47.598058" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="354.402361" y="49.714963" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="358.490383" y="47.851915" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="362.578405" y="42.012035" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="366.666427" y="46.065902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="370.754449" y="43.401584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="374.842471" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="378.930493" y="40.500294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="383.018515" y="45.473874" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="387.106537" y="40.541935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="391.194559" y="39.565517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="395.282581" y="35.617391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="399.370603" y="42.592414" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="403.458626" y="38.556552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="407.546648" y="37.144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="411.63467" y="38.944615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="415.722692" y="34.145455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="419.810714" y="39.398899" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="423.898736" y="37.334309" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="427.986758" y="31.6" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="432.07478" y="33.875315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="436.162802" y="39.350492" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="440.250824" y="38.670609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="444.338846" y="38.3144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="448.426868" y="34.73757" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="452.51489" y="36.448713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="456.602912" y="33.875315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="460.690934" y="33.073043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="464.778956" y="36.378318" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="468.866978" y="38.161739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m729b46263b" x="472.955" y="36.818889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_15">
-    <path d="M 68.055 32.95633 
+    <path d="M 68.055 32.41945 
 L 72.328841 33.661818 
-L 76.416863 39.813333 
-L 80.504885 35.193333 
-L 84.592907 37.565766 
-L 88.680929 37.838305 
-L 92.768951 37.144 
-L 96.856973 36.714495 
-L 100.944995 39.283441 
-L 105.033017 38.761626 
-L 109.121039 42.237407 
-L 113.209061 40.192941 
-L 117.297084 39.147387 
-L 121.385106 38.54848 
-L 125.473128 41.583448 
-L 129.56115 41.583448 
-L 133.649172 46.461748 
-L 137.737194 40.07 
-L 141.825216 46.970943 
-L 145.913238 53.087244 
+L 76.416863 39.3 
+L 80.504885 37.631667 
+L 84.592907 36.511351 
+L 88.680929 38.334237 
+L 92.768951 39.094667 
+L 96.856973 39.398899 
+L 100.944995 40.541935 
+L 105.033017 39.713171 
+L 109.121039 42.779259 
+L 113.209061 42.651765 
+L 117.297084 40.201802 
+L 121.385106 40.42112 
+L 125.473128 44.105862 
+L 129.56115 42.592414 
+L 133.649172 45.893592 
+L 137.737194 42.508333 
+L 141.825216 48.075094 
+L 145.913238 51.704882 
 L 150.00126 50.218739 
-L 154.089282 48.510385 
-L 158.177304 51.575146 
-L 162.265326 59.034815 
-L 166.353348 56.365203 
-L 170.44137 59.025391 
-L 174.529392 61.06087 
-L 178.617414 58.810909 
-L 182.705436 63.953162 
-L 186.793458 68.693913 
-L 190.88148 74.800348 
-L 194.969502 80.738716 
-L 199.057524 83.476364 
-L 203.145546 87.491379 
-L 207.233568 93.713333 
-L 211.32159 105.46735 
-L 215.409612 117.910534 
-L 219.497634 135.417241 
-L 223.585656 162.992165 
-L 227.673678 178.492308 
-L 231.7617 196.929043 
-L 235.849722 225.826667 
-L 239.937744 260.45632 
-L 244.025766 280.145902 
-L 248.113788 297.14 
-L 252.20181 301.784444 
-L 256.289832 299.812459 
-L 260.377855 286.485098 
-L 264.465877 272.910169 
-L 268.553899 243.376552 
-L 272.641921 213.03215 
-L 276.729943 186.104 
-L 280.817965 161.486496 
-L 284.905987 139.149593 
-L 288.994009 138.3 
-L 293.082031 123.473504 
-L 297.170053 102.750826 
-L 301.258075 98.027308 
-L 305.346097 103.080396 
-L 309.434119 82.159385 
-L 313.522141 86.814634 
-L 317.610163 72.530312 
-L 321.698185 76.915926 
-L 325.786207 65.428667 
-L 329.874229 63.36096 
-L 333.962251 64.130909 
-L 338.050273 63.703077 
-L 342.138295 54.1775 
-L 346.226317 53.923186 
-L 350.314339 52.143301 
-L 354.402361 47.981037 
-L 358.490383 53.454894 
-L 362.578405 44.08354 
-L 366.666427 47.504918 
-L 370.754449 41.08396 
-L 374.842471 40.346038 
-L 378.930493 43.082059 
-L 383.018515 48.10991 
+L 154.089282 49.073077 
+L 158.177304 53.847767 
+L 162.265326 55.241852 
+L 166.353348 60.171382 
+L 170.44137 60.04313 
+L 174.529392 62.587478 
+L 178.617414 65.098182 
+L 182.705436 70.955556 
+L 186.793458 71.238261 
+L 190.88148 78.362435 
+L 194.969502 82.886239 
+L 199.057524 86.861818 
+L 203.145546 92.536207 
+L 207.233568 101.608889 
+L 211.32159 110.46906 
+L 215.409612 124.611298 
+L 219.497634 143.993448 
+L 223.585656 172.644948 
+L 227.673678 182.543692 
+L 231.7617 205.070957 
+L 235.849722 230.555556 
+L 239.937744 261.39264 
+L 244.025766 285.422295 
+L 248.113788 300.7975 
+L 252.20181 303.177778 
+L 256.289832 302.21082 
+L 260.377855 287.058824 
+L 264.465877 274.397966 
+L 268.553899 248.925862 
+L 272.641921 221.782804 
+L 276.729943 190.892 
+L 280.817965 165.487863 
+L 284.905987 146.761951 
+L 288.994009 140.39 
+L 293.082031 129.475556 
+L 297.170053 108.119633 
+L 301.258075 99.715385 
+L 305.346097 106.556832 
+L 309.434119 87.561231 
+L 313.522141 90.145041 
+L 317.610163 76.645 
+L 321.698185 80.708889 
+L 325.786207 67.867 
+L 329.874229 65.2336 
+L 333.962251 68 
+L 338.050273 67.079231 
+L 342.138295 56.79 
+L 346.226317 55.99469 
+L 350.314339 53.847767 
+L 354.402361 50.581926 
+L 358.490383 54.7 
+L 362.578405 47.708673 
+L 366.666427 52.781311 
+L 370.754449 43.98099 
+L 374.842471 42.002264 
+L 378.930493 42.651765 
+L 383.018515 49.164324 
 L 387.106537 42.429677 
-L 391.194559 42.087931 
-L 395.282581 36.63513 
-L 399.370603 43.601379 
-L 403.458626 42.592414 
-L 407.546648 43.274667 
-L 411.63467 36.372308 
-L 415.722692 36.08 
-L 419.810714 43.693945 
-L 423.898736 40.188943 
-L 427.986758 33.653333 
-L 432.07478 34.402523 
-L 436.162802 38.87082 
-L 440.250824 39.179478 
-L 444.338846 36.5588 
-L 448.426868 38.019065 
-L 452.51489 34.131089 
-L 456.602912 37.038559 
-L 460.690934 32.564174 
-L 464.778956 35.284486 
-L 468.866978 38.797826 
+L 391.194559 41.078966 
+L 395.282581 38.161739 
+L 399.370603 45.114828 
+L 403.458626 43.096897 
+L 407.546648 42.16 
+L 411.63467 38.301538 
+L 415.722692 36.563636 
+L 419.810714 45.304587 
+L 423.898736 39.237398 
+L 427.986758 35.193333 
+L 432.07478 34.92973 
+L 436.162802 42.228525 
+L 440.250824 37.65287 
+L 444.338846 37.7292 
+L 448.426868 36.378318 
+L 452.51489 34.710495 
+L 456.602912 37.565766 
+L 460.690934 32.055304 
+L 464.778956 34.190654 
+L 468.866978 37.525652 
 L 472.955 36.818889 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m870e4290c9" d="M 0 1 
+     <path id="m8f8606c64b" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1362,125 +1362,125 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p7d9a958ad9)">
-     <use xlink:href="#m870e4290c9" x="68.055" y="32.95633" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="72.328841" y="33.661818" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="76.416863" y="39.813333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="80.504885" y="35.193333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="84.592907" y="37.565766" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="88.680929" y="37.838305" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="92.768951" y="37.144" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="96.856973" y="36.714495" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="100.944995" y="39.283441" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="105.033017" y="38.761626" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="109.121039" y="42.237407" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="113.209061" y="40.192941" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="117.297084" y="39.147387" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="121.385106" y="38.54848" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="125.473128" y="41.583448" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="129.56115" y="41.583448" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="133.649172" y="46.461748" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="137.737194" y="40.07" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="141.825216" y="46.970943" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="145.913238" y="53.087244" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="150.00126" y="50.218739" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="154.089282" y="48.510385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="158.177304" y="51.575146" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="162.265326" y="59.034815" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="166.353348" y="56.365203" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="170.44137" y="59.025391" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="174.529392" y="61.06087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="178.617414" y="58.810909" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="182.705436" y="63.953162" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="186.793458" y="68.693913" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="190.88148" y="74.800348" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="194.969502" y="80.738716" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="199.057524" y="83.476364" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="203.145546" y="87.491379" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="207.233568" y="93.713333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="211.32159" y="105.46735" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="215.409612" y="117.910534" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="219.497634" y="135.417241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="223.585656" y="162.992165" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="227.673678" y="178.492308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="231.7617" y="196.929043" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="235.849722" y="225.826667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="239.937744" y="260.45632" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="244.025766" y="280.145902" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="248.113788" y="297.14" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="252.20181" y="301.784444" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="256.289832" y="299.812459" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="260.377855" y="286.485098" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="264.465877" y="272.910169" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="268.553899" y="243.376552" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="272.641921" y="213.03215" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="276.729943" y="186.104" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="280.817965" y="161.486496" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="284.905987" y="139.149593" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="288.994009" y="138.3" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="293.082031" y="123.473504" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="297.170053" y="102.750826" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="301.258075" y="98.027308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="305.346097" y="103.080396" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="309.434119" y="82.159385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="313.522141" y="86.814634" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="317.610163" y="72.530312" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="321.698185" y="76.915926" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="325.786207" y="65.428667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="329.874229" y="63.36096" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="333.962251" y="64.130909" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="338.050273" y="63.703077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="342.138295" y="54.1775" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="346.226317" y="53.923186" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="350.314339" y="52.143301" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="354.402361" y="47.981037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="358.490383" y="53.454894" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="362.578405" y="44.08354" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="366.666427" y="47.504918" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="370.754449" y="41.08396" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="374.842471" y="40.346038" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="378.930493" y="43.082059" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="383.018515" y="48.10991" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="387.106537" y="42.429677" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="391.194559" y="42.087931" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="395.282581" y="36.63513" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="399.370603" y="43.601379" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="403.458626" y="42.592414" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="407.546648" y="43.274667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="411.63467" y="36.372308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="415.722692" y="36.08" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="419.810714" y="43.693945" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="423.898736" y="40.188943" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="427.986758" y="33.653333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="432.07478" y="34.402523" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="436.162802" y="38.87082" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="440.250824" y="39.179478" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="444.338846" y="36.5588" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="448.426868" y="38.019065" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="452.51489" y="34.131089" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="456.602912" y="37.038559" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="460.690934" y="32.564174" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="464.778956" y="35.284486" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="468.866978" y="38.797826" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m870e4290c9" x="472.955" y="36.818889" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pd0e5ecd757)">
+     <use xlink:href="#m8f8606c64b" x="68.055" y="32.41945" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="72.328841" y="33.661818" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="76.416863" y="39.3" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="80.504885" y="37.631667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="84.592907" y="36.511351" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="88.680929" y="38.334237" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="92.768951" y="39.094667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="96.856973" y="39.398899" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="100.944995" y="40.541935" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="105.033017" y="39.713171" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="109.121039" y="42.779259" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="113.209061" y="42.651765" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="117.297084" y="40.201802" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="121.385106" y="40.42112" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="125.473128" y="44.105862" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="129.56115" y="42.592414" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="133.649172" y="45.893592" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="137.737194" y="42.508333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="141.825216" y="48.075094" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="145.913238" y="51.704882" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="150.00126" y="50.218739" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="154.089282" y="49.073077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="158.177304" y="53.847767" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="162.265326" y="55.241852" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="166.353348" y="60.171382" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="170.44137" y="60.04313" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="174.529392" y="62.587478" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="178.617414" y="65.098182" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="182.705436" y="70.955556" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="186.793458" y="71.238261" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="190.88148" y="78.362435" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="194.969502" y="82.886239" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="199.057524" y="86.861818" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="203.145546" y="92.536207" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="207.233568" y="101.608889" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="211.32159" y="110.46906" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="215.409612" y="124.611298" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="219.497634" y="143.993448" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="223.585656" y="172.644948" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="227.673678" y="182.543692" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="231.7617" y="205.070957" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="235.849722" y="230.555556" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="239.937744" y="261.39264" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="244.025766" y="285.422295" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="248.113788" y="300.7975" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="252.20181" y="303.177778" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="256.289832" y="302.21082" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="260.377855" y="287.058824" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="264.465877" y="274.397966" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="268.553899" y="248.925862" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="272.641921" y="221.782804" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="276.729943" y="190.892" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="280.817965" y="165.487863" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="284.905987" y="146.761951" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="288.994009" y="140.39" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="293.082031" y="129.475556" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="297.170053" y="108.119633" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="301.258075" y="99.715385" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="305.346097" y="106.556832" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="309.434119" y="87.561231" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="313.522141" y="90.145041" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="317.610163" y="76.645" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="321.698185" y="80.708889" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="325.786207" y="67.867" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="329.874229" y="65.2336" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="333.962251" y="68" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="338.050273" y="67.079231" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="342.138295" y="56.79" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="346.226317" y="55.99469" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="350.314339" y="53.847767" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="354.402361" y="50.581926" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="358.490383" y="54.7" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="362.578405" y="47.708673" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="366.666427" y="52.781311" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="370.754449" y="43.98099" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="374.842471" y="42.002264" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="378.930493" y="42.651765" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="383.018515" y="49.164324" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="387.106537" y="42.429677" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="391.194559" y="41.078966" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="395.282581" y="38.161739" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="399.370603" y="45.114828" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="403.458626" y="43.096897" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="407.546648" y="42.16" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="411.63467" y="38.301538" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="415.722692" y="36.563636" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="419.810714" y="45.304587" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="423.898736" y="39.237398" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="427.986758" y="35.193333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="432.07478" y="34.92973" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="436.162802" y="42.228525" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="440.250824" y="37.65287" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="444.338846" y="37.7292" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="448.426868" y="36.378318" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="452.51489" y="34.710495" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="456.602912" y="37.565766" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="460.690934" y="32.055304" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="464.778956" y="34.190654" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="468.866978" y="37.525652" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m8f8606c64b" x="472.955" y="36.818889" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 68.055 27.050642 
-L 72.328841 27.858182 
+    <path d="M 68.055 27.587523 
+L 72.328841 28.341818 
 L 76.416863 28.006667 
-L 80.504885 25.927667 
-L 84.592907 28.603243 
+L 80.504885 26.415333 
+L 84.592907 27.548829 
 L 88.680929 26.927797 
 L 92.768951 28.853667 
-L 96.856973 28.661284 
+L 96.856973 28.124404 
 L 100.944995 27.956989 
-L 105.033017 29.721951 
+L 105.033017 30.197724 
 L 109.121039 28.691111 
-L 113.209061 28.390588 
-L 117.297084 28.603243 
+L 113.209061 28.882353 
+L 117.297084 28.076036 
 L 121.385106 27.7808 
-L 125.473128 27.962414 
+L 125.473128 28.466897 
 L 129.56115 28.466897 
 L 133.649172 28.848932 
 L 137.737194 27.878333 
@@ -1490,71 +1490,71 @@ L 150.00126 31.239279
 L 154.089282 28.253462 
 L 158.177304 33.394175 
 L 162.265326 32.484074 
-L 166.353348 27.818862 
-L 170.44137 28.493217 
-L 174.529392 29.002087 
+L 166.353348 27.343089 
+L 170.44137 29.002087 
+L 174.529392 29.510957 
 L 178.617414 33.178182 
 L 182.705436 31.442051 
-L 186.793458 32.055304 
-L 190.88148 34.599652 
-L 194.969502 32.95633 
-L 199.057524 31.727273 
-L 203.145546 37.043103 
-L 207.233568 33.8 
-L 211.32159 36.443761 
-L 215.409612 37.501374 
-L 219.497634 39.565517 
-L 223.585656 40.522474 
-L 227.673678 44.796615 
-L 231.7617 52.918957 
-L 235.849722 63.271111 
-L 239.937744 73.66048 
-L 244.025766 125.211803 
-L 248.113788 228.17 
-L 252.20181 298.068889 
-L 256.289832 220.186885 
-L 260.377855 113.22 
+L 186.793458 31.546435 
+L 190.88148 36.126261 
+L 194.969502 33.493211 
+L 199.057524 31.243636 
+L 203.145546 35.025172 
+L 207.233568 34.264444 
+L 211.32159 36.943932 
+L 215.409612 37.948092 
+L 219.497634 38.556552 
+L 223.585656 43.538969 
+L 227.673678 46.597231 
+L 231.7617 54.445565 
+L 235.849722 65.635556 
+L 239.937744 76.9376 
+L 244.025766 134.325574 
+L 248.113788 229.215 
+L 252.20181 297.14 
+L 256.289832 225.942951 
+L 260.377855 112.646275 
 L 264.465877 82.472203 
-L 268.553899 59.240345 
-L 272.641921 61.536449 
-L 276.729943 38.74 
-L 280.817965 40.945299 
-L 284.905987 34.955447 
-L 288.994009 37.4575 
-L 293.082031 35.94359 
-L 297.170053 34.566972 
-L 301.258075 33.317692 
-L 305.346097 38.766337 
-L 309.434119 33.542769 
+L 268.553899 60.24931 
+L 272.641921 60.989533 
+L 276.729943 39.804 
+L 280.817965 40.445128 
+L 284.905987 36.858537 
+L 288.994009 36.935 
+L 293.082031 37.444103 
+L 297.170053 36.177615 
+L 301.258075 33.880385 
+L 305.346097 39.345743 
+L 309.434119 33.992923 
 L 313.522141 32.576585 
-L 317.610163 29.554688 
-L 321.698185 31.942222 
-L 325.786207 29.829 
-L 329.874229 28.71712 
-L 333.962251 31.243636 
-L 338.050273 31.066923 
+L 317.610163 30.011875 
+L 321.698185 31.40037 
+L 325.786207 30.316667 
+L 329.874229 29.18528 
+L 333.962251 31.727273 
+L 338.050273 31.629615 
 L 342.138295 32.2325 
-L 346.226317 31.136637 
-L 350.314339 30.553398 
-L 354.402361 29.341333 
-L 358.490383 28.552766 
-L 362.578405 26.993628 
+L 346.226317 32.172389 
+L 350.314339 29.985243 
+L 354.402361 28.907852 
+L 358.490383 27.930213 
+L 362.578405 28.547257 
 L 366.666427 30.236721 
-L 370.754449 30.075248 
+L 370.754449 28.33703 
 L 374.842471 27.648302 
 L 378.930493 28.021765 
-L 383.018515 28.603243 
-L 387.106537 25.911935 
-L 391.194559 28.466897 
-L 395.282581 27.475478 
-L 399.370603 27.457931 
-L 403.458626 28.466897 
-L 407.546648 29.898667 
+L 383.018515 27.548829 
+L 387.106537 26.855806 
+L 391.194559 27.962414 
+L 395.282581 26.966609 
+L 399.370603 27.962414 
+L 403.458626 28.971379 
+L 407.546648 29.341333 
 L 411.63467 28.012308 
-L 415.722692 26.407273 
-L 419.810714 27.587523 
+L 415.722692 25.923636 
+L 419.810714 28.124404 
 L 423.898736 28.294634 
-L 427.986758 26.98 
+L 427.986758 26.466667 
 L 432.07478 27.021622 
 L 436.162802 27.358689 
 L 440.250824 27.475478 
@@ -1566,9 +1566,9 @@ L 460.690934 26.966609
 L 464.778956 25.986916 
 L 468.866978 27.984348 
 L 472.955 29.232963 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
     <defs>
-     <path id="m4d6def73d5" d="M 0 1 
+     <path id="m765811db94" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1580,118 +1580,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p7d9a958ad9)">
-     <use xlink:href="#m4d6def73d5" x="68.055" y="27.050642" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="72.328841" y="27.858182" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="76.416863" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="80.504885" y="25.927667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="84.592907" y="28.603243" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="88.680929" y="26.927797" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="92.768951" y="28.853667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="96.856973" y="28.661284" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="100.944995" y="27.956989" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="105.033017" y="29.721951" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="109.121039" y="28.691111" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="113.209061" y="28.390588" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="117.297084" y="28.603243" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="121.385106" y="27.7808" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="125.473128" y="27.962414" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="129.56115" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="133.649172" y="28.848932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="137.737194" y="27.878333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="141.825216" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="145.913238" y="29.126299" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="150.00126" y="31.239279" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="154.089282" y="28.253462" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="158.177304" y="33.394175" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="162.265326" y="32.484074" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="166.353348" y="27.818862" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="170.44137" y="28.493217" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="174.529392" y="29.002087" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="178.617414" y="33.178182" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="182.705436" y="31.442051" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="186.793458" y="32.055304" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="190.88148" y="34.599652" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="194.969502" y="32.95633" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="199.057524" y="31.727273" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="203.145546" y="37.043103" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="207.233568" y="33.8" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="211.32159" y="36.443761" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="215.409612" y="37.501374" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="219.497634" y="39.565517" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="223.585656" y="40.522474" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="227.673678" y="44.796615" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="231.7617" y="52.918957" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="235.849722" y="63.271111" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="239.937744" y="73.66048" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="244.025766" y="125.211803" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="248.113788" y="228.17" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="252.20181" y="298.068889" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="256.289832" y="220.186885" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="260.377855" y="113.22" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="264.465877" y="82.472203" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="268.553899" y="59.240345" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="272.641921" y="61.536449" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="276.729943" y="38.74" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="280.817965" y="40.945299" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="284.905987" y="34.955447" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="288.994009" y="37.4575" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="293.082031" y="35.94359" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="297.170053" y="34.566972" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="301.258075" y="33.317692" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="305.346097" y="38.766337" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="309.434119" y="33.542769" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="313.522141" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="317.610163" y="29.554688" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="321.698185" y="31.942222" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="325.786207" y="29.829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="329.874229" y="28.71712" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="333.962251" y="31.243636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="338.050273" y="31.066923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="342.138295" y="32.2325" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="346.226317" y="31.136637" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="350.314339" y="30.553398" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="354.402361" y="29.341333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="358.490383" y="28.552766" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="362.578405" y="26.993628" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="366.666427" y="30.236721" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="370.754449" y="30.075248" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="374.842471" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="378.930493" y="28.021765" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="383.018515" y="28.603243" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="387.106537" y="25.911935" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="391.194559" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="395.282581" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="399.370603" y="27.457931" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="403.458626" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="407.546648" y="29.898667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="411.63467" y="28.012308" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="415.722692" y="26.407273" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="419.810714" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="423.898736" y="28.294634" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="427.986758" y="26.98" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="432.07478" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="436.162802" y="27.358689" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="440.250824" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="444.338846" y="26.6104" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="448.426868" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="452.51489" y="27.757624" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="456.602912" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="460.690934" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="464.778956" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="468.866978" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m4d6def73d5" x="472.955" y="29.232963" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pd0e5ecd757)">
+     <use xlink:href="#m765811db94" x="68.055" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="72.328841" y="28.341818" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="76.416863" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="80.504885" y="26.415333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="84.592907" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="88.680929" y="26.927797" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="92.768951" y="28.853667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="96.856973" y="28.124404" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="100.944995" y="27.956989" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="105.033017" y="30.197724" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="109.121039" y="28.691111" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="113.209061" y="28.882353" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="117.297084" y="28.076036" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="121.385106" y="27.7808" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="125.473128" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="129.56115" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="133.649172" y="28.848932" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="137.737194" y="27.878333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="141.825216" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="145.913238" y="29.126299" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="150.00126" y="31.239279" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="154.089282" y="28.253462" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="158.177304" y="33.394175" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="162.265326" y="32.484074" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="166.353348" y="27.343089" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="170.44137" y="29.002087" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="174.529392" y="29.510957" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="178.617414" y="33.178182" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="182.705436" y="31.442051" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="186.793458" y="31.546435" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="190.88148" y="36.126261" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="194.969502" y="33.493211" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="199.057524" y="31.243636" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="203.145546" y="35.025172" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="207.233568" y="34.264444" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="211.32159" y="36.943932" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="215.409612" y="37.948092" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="219.497634" y="38.556552" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="223.585656" y="43.538969" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="227.673678" y="46.597231" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="231.7617" y="54.445565" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="235.849722" y="65.635556" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="239.937744" y="76.9376" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="244.025766" y="134.325574" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="248.113788" y="229.215" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="252.20181" y="297.14" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="256.289832" y="225.942951" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="260.377855" y="112.646275" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="264.465877" y="82.472203" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="268.553899" y="60.24931" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="272.641921" y="60.989533" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="276.729943" y="39.804" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="280.817965" y="40.445128" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="284.905987" y="36.858537" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="288.994009" y="36.935" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="293.082031" y="37.444103" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="297.170053" y="36.177615" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="301.258075" y="33.880385" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="305.346097" y="39.345743" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="309.434119" y="33.992923" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="313.522141" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="317.610163" y="30.011875" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="321.698185" y="31.40037" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="325.786207" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="329.874229" y="29.18528" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="333.962251" y="31.727273" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="338.050273" y="31.629615" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="342.138295" y="32.2325" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="346.226317" y="32.172389" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="350.314339" y="29.985243" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="354.402361" y="28.907852" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="358.490383" y="27.930213" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="362.578405" y="28.547257" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="366.666427" y="30.236721" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="370.754449" y="28.33703" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="374.842471" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="378.930493" y="28.021765" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="383.018515" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="387.106537" y="26.855806" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="391.194559" y="27.962414" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="395.282581" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="399.370603" y="27.962414" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="403.458626" y="28.971379" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="407.546648" y="29.341333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="411.63467" y="28.012308" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="415.722692" y="25.923636" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="419.810714" y="28.124404" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="423.898736" y="28.294634" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="427.986758" y="26.466667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="432.07478" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="436.162802" y="27.358689" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="440.250824" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="444.338846" y="26.6104" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="448.426868" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="452.51489" y="27.757624" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="456.602912" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="460.690934" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="464.778956" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="468.866978" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m765811db94" x="472.955" y="29.232963" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_17">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_18">
     <path d="M 252.015991 318.04 
 L 252.015991 25.44 
-" clip-path="url(#p7d9a958ad9)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -1845,7 +1845,7 @@ L 63.01 271.14875
 L 71.01 271.14875 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdff914914b" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m5a2f7c6181" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_17">
@@ -1900,7 +1900,7 @@ L 63.01 282.89125
 L 71.01 282.89125 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me2283fd27b" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m729b46263b" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_18">
@@ -1956,7 +1956,7 @@ L 63.01 294.63375
 L 71.01 294.63375 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m870e4290c9" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#m8f8606c64b" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_19">
@@ -2025,7 +2025,7 @@ L 63.01 306.37625
 L 71.01 306.37625 
 " style="fill: none; stroke: #d62728; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4d6def73d5" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
+      <use xlink:href="#m765811db94" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_20">
@@ -2068,7 +2068,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p7d9a958ad9">
+  <clipPath id="pd0e5ecd757">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/main_figs_power_at_fc.py
+++ b/analyses/simulation/activity_power/main_figs_power_at_fc.py
@@ -46,16 +46,22 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 OUT_DIR = SCRIPT_DIR / "output"
 OUT_DIR.mkdir(exist_ok=True)
 
+# The reporter/deflated pair is MWU. Measuring the reporter's power benefit
+# with the t-test confounds it: the t-test over-rejects in exactly the deflated
+# condition, so part of the apparent benefit is that miscalibration rather than
+# the reporter. The 2026-08-13 run added the MWU arms for this reason -- see the
+# ARMS comment in shendure/shendure_power_ttest_all_cell_types.py.
+# Yin et al. is still t-test: no MWU arm has been run on its power sims.
 DATASETS = {
     "cohen": {
-        "reporter": SCRIPT_DIR / "cohen/output/cohen_power_df_reporter.parquet",
-        "deflated": SCRIPT_DIR / "cohen/output/cohen_power_df_deflated.parquet",
+        "reporter": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu.parquet",
+        "deflated": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu_deflated.parquet",
         "ref_display": "Rod",
         "title": "Cohen (episomal, CRE-reporter)",
     },
     "shendure": {
-        "reporter": SCRIPT_DIR / "shendure/output/power_df_reporter.parquet",
-        "deflated": SCRIPT_DIR / "shendure/output/power_df_deflated.parquet",
+        "reporter": SCRIPT_DIR / "shendure/output/power_df_mwu_2026-08-13.parquet",
+        "deflated": SCRIPT_DIR / "shendure/output/power_df_mwu_deflated_2026-08-13.parquet",
         "ref_display": "Pluripotent",
         "title": "Shendure (piggyBac, oBC reporter)",
     },

--- a/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
+++ b/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-08T17:01:02.301456</dc:date>
+    <dc:date>2026-08-16T17:12:28.460945</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -38,40 +38,40 @@ z
 " style="fill: #ffffff"/>
    </g>
    <g id="line2d_1">
-    <path d="M 387.004005 104.434266 
+    <path d="M 383.550673 104.434266 
 L 397.018666 104.434266 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_2">
-    <path d="M 391.453429 82.735565 
-L 398.967004 82.735565 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 388.249671 82.735565 
+L 398.471184 82.735565 
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_3">
-    <path d="M 391.682269 61.036864 
-L 399.920503 61.036864 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 389.96597 61.036864 
+L 399.729803 61.036864 
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_4">
-    <path d="M 407.777338 39.338162 
-L 408.578277 39.338162 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 407.586638 39.338162 
+L 408.616417 39.338162 
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_5">
       <path d="M 124.397338 107.689071 
 L 124.397338 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mcd2db2518c" d="M 0 0 
+       <path id="mfb62cb133b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd2db2518c" x="124.397338" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="124.397338" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -79,11 +79,11 @@ L 0 3.5
      <g id="line2d_7">
       <path d="M 181.569158 107.689071 
 L 181.569158 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcd2db2518c" x="181.569158" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="181.569158" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -91,11 +91,11 @@ L 181.569158 36.083357
      <g id="line2d_9">
       <path d="M 238.740977 107.689071 
 L 238.740977 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcd2db2518c" x="238.740977" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="238.740977" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -103,11 +103,11 @@ L 238.740977 36.083357
      <g id="line2d_11">
       <path d="M 295.912797 107.689071 
 L 295.912797 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcd2db2518c" x="295.912797" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="295.912797" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -115,11 +115,11 @@ L 295.912797 36.083357
      <g id="line2d_13">
       <path d="M 353.084616 107.689071 
 L 353.084616 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcd2db2518c" x="353.084616" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="353.084616" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -127,11 +127,11 @@ L 353.084616 36.083357
      <g id="line2d_15">
       <path d="M 410.256436 107.689071 
 L 410.256436 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcd2db2518c" x="410.256436" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="410.256436" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -140,12 +140,12 @@ L 410.256436 36.083357
     <g id="ytick_1">
      <g id="line2d_17">
       <defs>
-       <path id="m639141658d" d="M 0 0 
+       <path id="mc9a84769e1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="104.434266" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="104.434266" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -155,7 +155,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="82.735565" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="82.735565" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -165,7 +165,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="61.036864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="61.036864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -175,7 +175,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="39.338162" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="39.338162" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -186,7 +186,7 @@ L -3.5 0
    <g id="line2d_21">
     <path d="M 353.084616 107.689071 
 L 353.084616 36.083357 
-" clip-path="url(#p7c88fa51af)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#pc85e101941)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_3">
     <path d="M 118.680156 107.689071 
@@ -210,7 +210,7 @@ L 415.973618 36.083357
    </g>
    <g id="PathCollection_1">
     <defs>
-     <path id="mcf0c9b1970" d="M 0 3.708099 
+     <path id="mee568a0668" d="M 0 3.708099 
 C 0.983399 3.708099 1.926654 3.317391 2.622022 2.622022 
 C 3.317391 1.926654 3.708099 0.983399 3.708099 0 
 C 3.708099 -0.983399 3.317391 -1.926654 2.622022 -2.622022 
@@ -222,16 +222,16 @@ C -1.926654 3.317391 -0.983399 3.708099 0 3.708099
 z
 " style="stroke: #ffffff; stroke-width: 0.6"/>
     </defs>
-    <g clip-path="url(#p7c88fa51af)">
-     <use xlink:href="#mcf0c9b1970" x="387.004005" y="104.434266" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="391.453429" y="82.735565" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="391.682269" y="61.036864" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="407.777338" y="39.338162" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+    <g clip-path="url(#pc85e101941)">
+     <use xlink:href="#mee568a0668" x="383.550673" y="104.434266" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="388.249671" y="82.735565" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="389.96597" y="61.036864" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="407.586638" y="39.338162" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
     </g>
    </g>
    <g id="PathCollection_2">
     <defs>
-     <path id="m3b7d279854" d="M 0 3.708099 
+     <path id="ma1fdce544a" d="M 0 3.708099 
 C 0.983399 3.708099 1.926654 3.317391 2.622022 2.622022 
 C 3.317391 1.926654 3.708099 0.983399 3.708099 0 
 C 3.708099 -0.983399 3.317391 -1.926654 2.622022 -2.622022 
@@ -243,11 +243,11 @@ C -1.926654 3.317391 -0.983399 3.708099 0 3.708099
 z
 " style="stroke: #ffffff; stroke-width: 0.6"/>
     </defs>
-    <g clip-path="url(#p7c88fa51af)">
-     <use xlink:href="#m3b7d279854" x="397.018666" y="104.434266" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="398.967004" y="82.735565" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="399.920503" y="61.036864" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="408.578277" y="39.338162" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+    <g clip-path="url(#pc85e101941)">
+     <use xlink:href="#ma1fdce544a" x="397.018666" y="104.434266" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="398.471184" y="82.735565" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="399.729803" y="61.036864" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="408.616417" y="39.338162" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
     </g>
    </g>
    <g id="text_5">
@@ -269,7 +269,7 @@ z
     </g>
     <g id="PathCollection_3">
      <g>
-      <use xlink:href="#mcf0c9b1970" x="133.880156" y="14.37875" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+      <use xlink:href="#mee568a0668" x="133.880156" y="14.37875" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
      </g>
     </g>
     <g id="text_6">
@@ -277,7 +277,7 @@ z
     </g>
     <g id="PathCollection_4">
      <g>
-      <use xlink:href="#m3b7d279854" x="207.807656" y="14.37875" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+      <use xlink:href="#ma1fdce544a" x="207.807656" y="14.37875" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
      </g>
     </g>
     <g id="text_7">
@@ -295,65 +295,65 @@ z
 " style="fill: #ffffff"/>
    </g>
    <g id="line2d_22">
-    <path d="M 148.084578 306.786344 
-L 283.13905 306.786344 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 134.225617 306.786344 
+L 262.232962 306.786344 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_23">
-    <path d="M 153.579918 288.704093 
-L 317.392911 288.704093 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 138.980908 288.704093 
+L 307.643059 288.704093 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_24">
-    <path d="M 166.101065 270.621842 
-L 366.475721 270.621842 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 148.966615 270.621842 
+L 360.491914 270.621842 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_25">
-    <path d="M 162.91309 252.539591 
-L 373.54611 252.539591 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 152.321026 252.539591 
+L 369.750533 252.539591 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_26">
-    <path d="M 170.356441 234.45734 
-L 377.074616 234.45734 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 151.322081 234.45734 
+L 369.834714 234.45734 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_27">
-    <path d="M 175.432366 216.375089 
-L 389.433305 216.375089 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 160.374785 216.375089 
+L 385.406034 216.375089 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_28">
-    <path d="M 192.89565 198.292838 
-L 401.08737 198.292838 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 177.952449 198.292838 
+L 400.380039 198.292838 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
-    <path d="M 193.386262 180.210587 
-L 401.453411 180.210587 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 181.144965 180.210587 
+L 401.01845 180.210587 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
-    <path d="M 201.991618 162.128335 
-L 404.721894 162.128335 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 188.637879 162.128335 
+L 402.961515 162.128335 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_31">
-    <path d="M 209.274598 144.046084 
-L 406.147578 144.046084 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 183.527822 144.046084 
+L 403.162895 144.046084 
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_32">
       <path d="M 124.397338 314.923357 
 L 124.397338 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mcd2db2518c" x="124.397338" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="124.397338" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -364,11 +364,11 @@ L 124.397338 135.909071
      <g id="line2d_34">
       <path d="M 181.569158 314.923357 
 L 181.569158 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mcd2db2518c" x="181.569158" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="181.569158" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -379,11 +379,11 @@ L 181.569158 135.909071
      <g id="line2d_36">
       <path d="M 238.740977 314.923357 
 L 238.740977 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mcd2db2518c" x="238.740977" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="238.740977" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -394,11 +394,11 @@ L 238.740977 135.909071
      <g id="line2d_38">
       <path d="M 295.912797 314.923357 
 L 295.912797 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mcd2db2518c" x="295.912797" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="295.912797" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -409,11 +409,11 @@ L 295.912797 135.909071
      <g id="line2d_40">
       <path d="M 353.084616 314.923357 
 L 353.084616 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mcd2db2518c" x="353.084616" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="353.084616" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -424,11 +424,11 @@ L 353.084616 135.909071
      <g id="line2d_42">
       <path d="M 410.256436 314.923357 
 L 410.256436 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mcd2db2518c" x="410.256436" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb62cb133b" x="410.256436" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -443,7 +443,7 @@ L 410.256436 135.909071
     <g id="ytick_5">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="306.786344" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="306.786344" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -453,7 +453,7 @@ L 410.256436 135.909071
     <g id="ytick_6">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="288.704093" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="288.704093" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -463,7 +463,7 @@ L 410.256436 135.909071
     <g id="ytick_7">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="270.621842" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="270.621842" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -473,7 +473,7 @@ L 410.256436 135.909071
     <g id="ytick_8">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="252.539591" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="252.539591" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -483,7 +483,7 @@ L 410.256436 135.909071
     <g id="ytick_9">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="234.45734" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="234.45734" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -493,7 +493,7 @@ L 410.256436 135.909071
     <g id="ytick_10">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="216.375089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="216.375089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -503,7 +503,7 @@ L 410.256436 135.909071
     <g id="ytick_11">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="198.292838" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="198.292838" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -513,7 +513,7 @@ L 410.256436 135.909071
     <g id="ytick_12">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="180.210587" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="180.210587" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -523,28 +523,28 @@ L 410.256436 135.909071
     <g id="ytick_13">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="162.128335" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="162.128335" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="165.547632" transform="rotate(-0 111.680156 165.547632)">Mesoderm</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="165.547632" transform="rotate(-0 111.680156 165.547632)">NeuroectodermBrain</text>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m639141658d" x="118.680156" y="144.046084" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9a84769e1" x="118.680156" y="144.046084" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="147.465381" transform="rotate(-0 111.680156 147.465381)">NeuroectodermBrain</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="147.465381" transform="rotate(-0 111.680156 147.465381)">Mesoderm</text>
      </g>
     </g>
    </g>
    <g id="line2d_54">
     <path d="M 353.084616 314.923357 
 L 353.084616 135.909071 
-" clip-path="url(#pf7ea371ece)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p083e34ad85)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_9">
     <path d="M 118.680156 314.923357 
@@ -567,31 +567,31 @@ L 415.973618 135.909071
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="PathCollection_5">
-    <g clip-path="url(#pf7ea371ece)">
-     <use xlink:href="#mcf0c9b1970" x="148.084578" y="306.786344" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="153.579918" y="288.704093" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="166.101065" y="270.621842" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="162.91309" y="252.539591" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="170.356441" y="234.45734" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="175.432366" y="216.375089" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="192.89565" y="198.292838" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="193.386262" y="180.210587" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="201.991618" y="162.128335" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mcf0c9b1970" x="209.274598" y="144.046084" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+    <g clip-path="url(#p083e34ad85)">
+     <use xlink:href="#mee568a0668" x="134.225617" y="306.786344" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="138.980908" y="288.704093" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="148.966615" y="270.621842" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="152.321026" y="252.539591" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="151.322081" y="234.45734" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="160.374785" y="216.375089" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="177.952449" y="198.292838" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="181.144965" y="180.210587" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="188.637879" y="162.128335" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#mee568a0668" x="183.527822" y="144.046084" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
     </g>
    </g>
    <g id="PathCollection_6">
-    <g clip-path="url(#pf7ea371ece)">
-     <use xlink:href="#m3b7d279854" x="283.13905" y="306.786344" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="317.392911" y="288.704093" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="366.475721" y="270.621842" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="373.54611" y="252.539591" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="377.074616" y="234.45734" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="389.433305" y="216.375089" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="401.08737" y="198.292838" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="401.453411" y="180.210587" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="404.721894" y="162.128335" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#m3b7d279854" x="406.147578" y="144.046084" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+    <g clip-path="url(#p083e34ad85)">
+     <use xlink:href="#ma1fdce544a" x="262.232962" y="306.786344" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="307.643059" y="288.704093" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="360.491914" y="270.621842" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="369.750533" y="252.539591" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="369.834714" y="234.45734" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="385.406034" y="216.375089" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="400.380039" y="198.292838" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="401.01845" y="180.210587" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="402.961515" y="162.128335" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+     <use xlink:href="#ma1fdce544a" x="403.162895" y="144.046084" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
     </g>
    </g>
    <g id="text_25">
@@ -600,10 +600,10 @@ L 415.973618 135.909071
   </g>
  </g>
  <defs>
-  <clipPath id="p7c88fa51af">
+  <clipPath id="pc85e101941">
    <rect x="118.680156" y="36.083357" width="297.293462" height="71.605714"/>
   </clipPath>
-  <clipPath id="pf7ea371ece">
+  <clipPath id="p083e34ad85">
    <rect x="118.680156" y="135.909071" width="297.293462" height="179.014286"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
+++ b/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-08T17:01:02.461264</dc:date>
+    <dc:date>2026-08-16T17:12:28.529059</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,47 +43,47 @@ L 396.765037 23.164048
 L 396.765037 34.990093 
 L 118.680156 34.990093 
 z
-" clip-path="url(#p89c6edd0d0)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 118.680156 40.058397 
-L 398.752422 40.058397 
-L 398.752422 51.884441 
+L 398.246665 40.058397 
+L 398.246665 51.884441 
 L 118.680156 51.884441 
 z
-" clip-path="url(#p89c6edd0d0)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 118.680156 56.952746 
-L 399.72503 56.952746 
-L 399.72503 68.77879 
+L 399.530508 56.952746 
+L 399.530508 68.77879 
 L 118.680156 68.77879 
 z
-" clip-path="url(#p89c6edd0d0)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 118.680156 73.847095 
-L 408.556313 73.847095 
-L 408.556313 85.673139 
+L 408.595217 73.847095 
+L 408.595217 85.673139 
 L 118.680156 85.673139 
 z
-" clip-path="url(#p89c6edd0d0)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <path d="M 118.680156 88.798594 
 L 118.680156 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4504aadb06" d="M 0 0 
+       <path id="mf22de96625" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4504aadb06" x="118.680156" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="118.680156" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -91,11 +91,11 @@ L 0 3.5
      <g id="line2d_3">
       <path d="M 176.997746 88.798594 
 L 176.997746 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4504aadb06" x="176.997746" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="176.997746" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -103,11 +103,11 @@ L 176.997746 20.038594
      <g id="line2d_5">
       <path d="M 235.315335 88.798594 
 L 235.315335 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4504aadb06" x="235.315335" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="235.315335" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -115,11 +115,11 @@ L 235.315335 20.038594
      <g id="line2d_7">
       <path d="M 293.632924 88.798594 
 L 293.632924 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4504aadb06" x="293.632924" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="293.632924" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -127,11 +127,11 @@ L 293.632924 20.038594
      <g id="line2d_9">
       <path d="M 351.950514 88.798594 
 L 351.950514 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4504aadb06" x="351.950514" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="351.950514" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -139,11 +139,11 @@ L 351.950514 20.038594
      <g id="line2d_11">
       <path d="M 410.268103 88.798594 
 L 410.268103 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4504aadb06" x="410.268103" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="410.268103" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -152,12 +152,12 @@ L 410.268103 20.038594
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="madb55b69ca" d="M 0 0 
+       <path id="mbd02740f92" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="29.07707" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="29.07707" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -167,7 +167,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="45.971419" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="45.971419" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,7 +177,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="62.865768" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="62.865768" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -187,7 +187,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="79.760117" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="79.760117" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -198,7 +198,7 @@ L -3.5 0
    <g id="line2d_17">
     <path d="M 351.950514 88.798594 
 L 351.950514 20.038594 
-" clip-path="url(#p89c6edd0d0)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p35042fd7f6)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_7">
     <path d="M 118.680156 88.798594 
@@ -235,94 +235,94 @@ z
    </g>
    <g id="patch_12">
     <path d="M 118.680156 124.11223 
-L 280.603181 124.11223 
-L 280.603181 135.389643 
+L 259.278118 124.11223 
+L 259.278118 135.389643 
 L 118.680156 135.389643 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 118.680156 140.222821 
-L 315.543518 140.222821 
-L 315.543518 151.500234 
+L 305.598271 140.222821 
+L 305.598271 151.500234 
 L 118.680156 151.500234 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 118.680156 156.333411 
-L 365.609987 156.333411 
-L 365.609987 167.610824 
+L 359.50626 156.333411 
+L 359.50626 167.610824 
 L 118.680156 167.610824 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 118.680156 172.444001 
-L 372.822072 172.444001 
-L 372.822072 183.721415 
+L 368.950429 172.444001 
+L 368.950429 183.721415 
 L 118.680156 183.721415 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 118.680156 188.554592 
-L 376.421292 188.554592 
-L 376.421292 199.832005 
+L 369.036297 188.554592 
+L 369.036297 199.832005 
 L 118.680156 199.832005 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 118.680156 204.665182 
-L 389.02766 204.665182 
-L 389.02766 215.942596 
+L 384.919679 204.665182 
+L 384.919679 215.942596 
 L 118.680156 215.942596 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 118.680156 220.775773 
-L 400.915282 220.775773 
-L 400.915282 232.053186 
+L 400.193775 220.775773 
+L 400.193775 232.053186 
 L 118.680156 232.053186 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 118.680156 236.886363 
-L 401.288658 236.886363 
-L 401.288658 248.163777 
+L 400.844981 236.886363 
+L 400.844981 248.163777 
 L 118.680156 248.163777 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 118.680156 252.996954 
-L 404.622644 252.996954 
-L 404.622644 264.274367 
+L 402.826986 252.996954 
+L 402.826986 264.274367 
 L 118.680156 264.274367 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 118.680156 269.107544 
-L 406.076901 269.107544 
-L 406.076901 280.384957 
+L 403.032402 269.107544 
+L 403.032402 280.384957 
 L 118.680156 280.384957 
 z
-" clip-path="url(#p68ae70a65a)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
       <path d="M 118.680156 288.198594 
 L 118.680156 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m4504aadb06" x="118.680156" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="118.680156" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -330,11 +330,11 @@ L 118.680156 116.298594
      <g id="line2d_20">
       <path d="M 176.997746 288.198594 
 L 176.997746 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m4504aadb06" x="176.997746" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="176.997746" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -342,11 +342,11 @@ L 176.997746 116.298594
      <g id="line2d_22">
       <path d="M 235.315335 288.198594 
 L 235.315335 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4504aadb06" x="235.315335" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="235.315335" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -354,11 +354,11 @@ L 235.315335 116.298594
      <g id="line2d_24">
       <path d="M 293.632924 288.198594 
 L 293.632924 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4504aadb06" x="293.632924" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="293.632924" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -366,11 +366,11 @@ L 293.632924 116.298594
      <g id="line2d_26">
       <path d="M 351.950514 288.198594 
 L 351.950514 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4504aadb06" x="351.950514" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="351.950514" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -378,11 +378,11 @@ L 351.950514 116.298594
      <g id="line2d_28">
       <path d="M 410.268103 288.198594 
 L 410.268103 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m4504aadb06" x="410.268103" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="410.268103" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -391,7 +391,7 @@ L 410.268103 116.298594
     <g id="ytick_5">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="129.750937" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="129.750937" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -401,7 +401,7 @@ L 410.268103 116.298594
     <g id="ytick_6">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="145.861527" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="145.861527" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -411,7 +411,7 @@ L 410.268103 116.298594
     <g id="ytick_7">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="161.972118" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="161.972118" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -421,7 +421,7 @@ L 410.268103 116.298594
     <g id="ytick_8">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="178.082708" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="178.082708" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -431,7 +431,7 @@ L 410.268103 116.298594
     <g id="ytick_9">
      <g id="line2d_34">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="194.193299" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="194.193299" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -441,7 +441,7 @@ L 410.268103 116.298594
     <g id="ytick_10">
      <g id="line2d_35">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="210.303889" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="210.303889" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -451,7 +451,7 @@ L 410.268103 116.298594
     <g id="ytick_11">
      <g id="line2d_36">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="226.414479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="226.414479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -461,7 +461,7 @@ L 410.268103 116.298594
     <g id="ytick_12">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="242.52507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="242.52507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -471,28 +471,28 @@ L 410.268103 116.298594
     <g id="ytick_13">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="258.63566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="258.63566" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="262.054957" transform="rotate(-0 111.680156 262.054957)">Mesoderm</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="262.054957" transform="rotate(-0 111.680156 262.054957)">NeuroectodermBrain</text>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="274.746251" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="274.746251" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="278.165548" transform="rotate(-0 111.680156 278.165548)">NeuroectodermBrain</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="278.165548" transform="rotate(-0 111.680156 278.165548)">Mesoderm</text>
      </g>
     </g>
    </g>
    <g id="line2d_40">
     <path d="M 351.950514 288.198594 
 L 351.950514 116.298594 
-" clip-path="url(#p68ae70a65a)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_22">
     <path d="M 118.680156 288.198594 
@@ -533,7 +533,7 @@ L 167.723301 317.261321
 L 167.723301 330.13084 
 L 118.680156 330.13084 
 z
-" clip-path="url(#p50f2a7258b)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2c13193f54)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 118.680156 335.646348 
@@ -541,18 +541,18 @@ L 187.56258 335.646348
 L 187.56258 348.515866 
 L 118.680156 348.515866 
 z
-" clip-path="url(#p50f2a7258b)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+" clip-path="url(#p2c13193f54)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
       <path d="M 118.680156 350.078594 
 L 118.680156 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m4504aadb06" x="118.680156" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="118.680156" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -563,11 +563,11 @@ L 118.680156 315.698594
      <g id="line2d_43">
       <path d="M 176.997746 350.078594 
 L 176.997746 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m4504aadb06" x="176.997746" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="176.997746" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -578,11 +578,11 @@ L 176.997746 315.698594
      <g id="line2d_45">
       <path d="M 235.315335 350.078594 
 L 235.315335 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m4504aadb06" x="235.315335" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="235.315335" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -593,11 +593,11 @@ L 235.315335 315.698594
      <g id="line2d_47">
       <path d="M 293.632924 350.078594 
 L 293.632924 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m4504aadb06" x="293.632924" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="293.632924" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -608,11 +608,11 @@ L 293.632924 315.698594
      <g id="line2d_49">
       <path d="M 351.950514 350.078594 
 L 351.950514 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m4504aadb06" x="351.950514" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="351.950514" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -623,11 +623,11 @@ L 351.950514 315.698594
      <g id="line2d_51">
       <path d="M 410.268103 350.078594 
 L 410.268103 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m4504aadb06" x="410.268103" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf22de96625" x="410.268103" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -642,7 +642,7 @@ L 410.268103 315.698594
     <g id="ytick_15">
      <g id="line2d_53">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="323.69608" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="323.69608" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -652,7 +652,7 @@ L 410.268103 315.698594
     <g id="ytick_16">
      <g id="line2d_54">
       <g>
-       <use xlink:href="#madb55b69ca" x="118.680156" y="342.081107" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd02740f92" x="118.680156" y="342.081107" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
@@ -663,7 +663,7 @@ L 410.268103 315.698594
    <g id="line2d_55">
     <path d="M 351.950514 350.078594 
 L 351.950514 315.698594 
-" clip-path="url(#p50f2a7258b)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p2c13193f54)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_29">
     <path d="M 118.680156 350.078594 
@@ -691,13 +691,13 @@ L 416.099862 315.698594
   </g>
  </g>
  <defs>
-  <clipPath id="p89c6edd0d0">
+  <clipPath id="p35042fd7f6">
    <rect x="118.680156" y="20.038594" width="297.419706" height="68.76"/>
   </clipPath>
-  <clipPath id="p68ae70a65a">
+  <clipPath id="p2a019fcfcc">
    <rect x="118.680156" y="116.298594" width="297.419706" height="171.9"/>
   </clipPath>
-  <clipPath id="p50f2a7258b">
+  <clipPath id="p2c13193f54">
    <rect x="118.680156" y="315.698594" width="297.419706" height="34.38"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_slope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_slope.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-08T17:01:03.124539</dc:date>
+    <dc:date>2026-08-16T17:12:28.762273</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m61f3eb866c" d="M 0 0 
+       <path id="m8d20c1c007" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m61f3eb866c" x="62.47425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="62.47425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -56,7 +56,7 @@ L 0 3.5
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m61f3eb866c" x="137.24625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="137.24625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -66,7 +66,7 @@ L 0 3.5
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m61f3eb866c" x="212.01825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="212.01825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -82,16 +82,16 @@ L 0 3.5
      <g id="line2d_4">
       <path d="M 43.78125 214.718594 
 L 230.71125 214.718594 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_5">
       <defs>
-       <path id="mfb20d0f59d" d="M 0 0 
+       <path id="m0362dd7e1a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -102,11 +102,11 @@ L -3.5 0
      <g id="line2d_6">
       <path d="M 43.78125 177.636689 
 L 230.71125 177.636689 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -117,11 +117,11 @@ L 230.71125 177.636689
      <g id="line2d_8">
       <path d="M 43.78125 140.554784 
 L 230.71125 140.554784 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -132,11 +132,11 @@ L 230.71125 140.554784
      <g id="line2d_10">
       <path d="M 43.78125 103.472879 
 L 230.71125 103.472879 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -147,11 +147,11 @@ L 230.71125 103.472879
      <g id="line2d_12">
       <path d="M 43.78125 66.390975 
 L 230.71125 66.390975 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -162,11 +162,11 @@ L 230.71125 66.390975
      <g id="line2d_14">
       <path d="M 43.78125 29.30907 
 L 230.71125 29.30907 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="43.78125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="43.78125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -178,12 +178,12 @@ L 230.71125 29.30907
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 62.47425 104.095829 
-L 137.24625 60.667912 
-L 212.01825 46.734777 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <path d="M 62.47425 106.653202 
+L 137.24625 61.936426 
+L 212.01825 47.320281 
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
     <defs>
-     <path id="m8c91a75d44" d="M 0 2 
+     <path id="mc6e4128710" d="M 0 2 
 C 0.530406 2 1.03916 1.789267 1.414214 1.414214 
 C 1.789267 1.03916 2 0.530406 2 0 
 C 2 -0.530406 1.789267 -1.03916 1.414214 -1.414214 
@@ -195,38 +195,38 @@ C -1.03916 1.789267 -0.530406 2 0 2
 z
 " style="stroke: #4682b4; stroke-opacity: 0.55"/>
     </defs>
-    <g clip-path="url(#p40a3e39bbd)">
-     <use xlink:href="#m8c91a75d44" x="62.47425" y="104.095829" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="137.24625" y="60.667912" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="212.01825" y="46.734777" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <g clip-path="url(#pe91611f49b)">
+     <use xlink:href="#mc6e4128710" x="62.47425" y="106.653202" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="137.24625" y="61.936426" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="212.01825" y="47.320281" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_17">
-    <path d="M 62.47425 89.303107 
-L 137.24625 51.341975 
-L 212.01825 41.927987 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p40a3e39bbd)">
-     <use xlink:href="#m8c91a75d44" x="62.47425" y="89.303107" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="137.24625" y="51.341975" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="212.01825" y="41.927987" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 62.47425 91.480572 
+L 137.24625 50.903654 
+L 212.01825 41.789621 
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#pe91611f49b)">
+     <use xlink:href="#mc6e4128710" x="62.47425" y="91.480572" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="137.24625" y="50.903654" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="212.01825" y="41.789621" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_18">
-    <path d="M 62.47425 103.180384 
-L 137.24625 57.829116 
-L 212.01825 43.256294 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p40a3e39bbd)">
-     <use xlink:href="#m8c91a75d44" x="62.47425" y="103.180384" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="137.24625" y="57.829116" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="212.01825" y="43.256294" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 62.47425 106.300334 
+L 137.24625 59.991497 
+L 212.01825 44.639947 
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#pe91611f49b)">
+     <use xlink:href="#mc6e4128710" x="62.47425" y="106.300334" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="137.24625" y="59.991497" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="212.01825" y="44.639947" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_19">
     <path d="M 43.78125 66.390975 
 L 230.71125 66.390975 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_3">
     <path d="M 43.78125 214.718594 
@@ -249,12 +249,12 @@ L 230.71125 20.038594
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="line2d_20">
-    <path d="M 62.47425 38.408924 
-L 137.24625 33.253953 
-L 212.01825 31.66128 
-" clip-path="url(#p40a3e39bbd)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
+    <path d="M 62.47425 38.831417 
+L 137.24625 33.458503 
+L 212.01825 31.605934 
+" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
     <defs>
-     <path id="m412ab1f1b9" d="M 0 3 
+     <path id="m26197fd761" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -266,10 +266,10 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #000000"/>
     </defs>
-    <g clip-path="url(#p40a3e39bbd)">
-     <use xlink:href="#m412ab1f1b9" x="62.47425" y="38.408924" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="137.24625" y="33.253953" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="212.01825" y="31.66128" style="stroke: #000000"/>
+    <g clip-path="url(#pe91611f49b)">
+     <use xlink:href="#m26197fd761" x="62.47425" y="38.831417" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="137.24625" y="33.458503" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="212.01825" y="31.605934" style="stroke: #000000"/>
     </g>
    </g>
    <g id="text_12">
@@ -298,7 +298,7 @@ L 192.57 204.512812
 L 199.57 204.512812 
 " style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m412ab1f1b9" x="192.57" y="204.512812" style="stroke: #000000"/>
+      <use xlink:href="#m26197fd761" x="192.57" y="204.512812" style="stroke: #000000"/>
      </g>
     </g>
     <g id="text_14">
@@ -319,7 +319,7 @@ z
     <g id="xtick_4">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m61f3eb866c" x="263.70425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="263.70425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -329,7 +329,7 @@ z
     <g id="xtick_5">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m61f3eb866c" x="338.47625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="338.47625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -339,7 +339,7 @@ z
     <g id="xtick_6">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m61f3eb866c" x="413.24825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="413.24825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -355,11 +355,11 @@ z
      <g id="line2d_25">
       <path d="M 245.01125 214.718594 
 L 431.94125 214.718594 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -367,11 +367,11 @@ L 431.94125 214.718594
      <g id="line2d_27">
       <path d="M 245.01125 177.636689 
 L 431.94125 177.636689 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -379,11 +379,11 @@ L 431.94125 177.636689
      <g id="line2d_29">
       <path d="M 245.01125 140.554784 
 L 431.94125 140.554784 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -391,11 +391,11 @@ L 431.94125 140.554784
      <g id="line2d_31">
       <path d="M 245.01125 103.472879 
 L 431.94125 103.472879 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -403,11 +403,11 @@ L 431.94125 103.472879
      <g id="line2d_33">
       <path d="M 245.01125 66.390975 
 L 431.94125 66.390975 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -415,118 +415,118 @@ L 431.94125 66.390975
      <g id="line2d_35">
       <path d="M 245.01125 29.30907 
 L 431.94125 29.30907 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="245.01125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="245.01125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_37">
-    <path d="M 263.70425 189.897641 
-L 338.47625 111.757991 
-L 413.24825 42.726864 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="189.897641" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="111.757991" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="42.726864" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 189.218701 
+L 338.47625 125.317775 
+L 413.24825 45.65966 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="189.218701" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="125.317775" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="45.65966" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_38">
-    <path d="M 263.70425 164.519842 
-L 338.47625 57.705443 
-L 413.24825 30.160688 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="164.519842" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="57.705443" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="30.160688" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 169.396266 
+L 338.47625 61.586567 
+L 413.24825 30.787418 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="169.396266" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="61.586567" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="30.787418" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 263.70425 147.582225 
-L 338.47625 42.815048 
-L 413.24825 29.566762 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="147.582225" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="42.815048" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="29.566762" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 152.432217 
+L 338.47625 45.427155 
+L 413.24825 29.51872 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="152.432217" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="45.427155" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="29.51872" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_40">
-    <path d="M 263.70425 156.377832 
-L 338.47625 50.830951 
-L 413.24825 29.898657 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="156.377832" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="50.830951" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="29.898657" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 161.070513 
+L 338.47625 55.526785 
+L 413.24825 30.648646 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="161.070513" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="55.526785" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="30.648646" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_41">
-    <path d="M 263.70425 179.314603 
-L 338.47625 89.540779 
-L 413.24825 34.22163 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="179.314603" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="89.540779" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="34.22163" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 183.250005 
+L 338.47625 95.864577 
+L 413.24825 36.21748 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="183.250005" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="95.864577" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="36.21748" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_42">
-    <path d="M 263.70425 119.56583 
-L 338.47625 32.898799 
-L 413.24825 29.388192 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="119.56583" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="32.898799" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="29.388192" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 123.450258 
+L 338.47625 33.909973 
+L 413.24825 29.362541 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="123.450258" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="33.909973" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="29.362541" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_43">
-    <path d="M 263.70425 115.729142 
-L 338.47625 31.974094 
-L 413.24825 29.336558 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="115.729142" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="31.974094" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="29.336558" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 118.468242 
+L 338.47625 34.040589 
+L 413.24825 29.360969 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="118.468242" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="34.040589" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="29.360969" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_44">
-    <path d="M 263.70425 161.41905 
-L 338.47625 53.119556 
-L 413.24825 30.331236 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="161.41905" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="53.119556" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="30.331236" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 159.450587 
+L 338.47625 55.581385 
+L 413.24825 30.666999 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="159.450587" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="55.581385" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="30.666999" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_45">
-    <path d="M 263.70425 127.679123 
-L 338.47625 35.256168 
-L 413.24825 29.412171 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m8c91a75d44" x="263.70425" y="127.679123" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="338.47625" y="35.256168" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#m8c91a75d44" x="413.24825" y="29.412171" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+    <path d="M 263.70425 126.591845 
+L 338.47625 35.714946 
+L 413.24825 29.644653 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#mc6e4128710" x="263.70425" y="126.591845" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="338.47625" y="35.714946" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
+     <use xlink:href="#mc6e4128710" x="413.24825" y="29.644653" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_46">
     <path d="M 245.01125 66.390975 
 L 431.94125 66.390975 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_9">
     <path d="M 245.01125 214.718594 
@@ -549,14 +549,14 @@ L 431.94125 20.038594
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="line2d_47">
-    <path d="M 263.70425 123.190146 
-L 338.47625 35.018752 
-L 413.24825 29.442538 
-" clip-path="url(#p8096d6b042)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8096d6b042)">
-     <use xlink:href="#m412ab1f1b9" x="263.70425" y="123.190146" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="338.47625" y="35.018752" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="413.24825" y="29.442538" style="stroke: #000000"/>
+    <path d="M 263.70425 131.107914 
+L 338.47625 35.30087 
+L 413.24825 29.489298 
+" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
+    <g clip-path="url(#p20431dfcac)">
+     <use xlink:href="#m26197fd761" x="263.70425" y="131.107914" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="338.47625" y="35.30087" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="413.24825" y="29.489298" style="stroke: #000000"/>
     </g>
    </g>
    <g id="text_19">
@@ -585,7 +585,7 @@ L 374.658281 204.512812
 L 381.658281 204.512812 
 " style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m412ab1f1b9" x="374.658281" y="204.512812" style="stroke: #000000"/>
+      <use xlink:href="#m26197fd761" x="374.658281" y="204.512812" style="stroke: #000000"/>
      </g>
     </g>
     <g id="text_21">
@@ -606,7 +606,7 @@ z
     <g id="xtick_7">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m61f3eb866c" x="464.93425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="464.93425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -616,7 +616,7 @@ z
     <g id="xtick_8">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m61f3eb866c" x="539.70625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="539.70625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -626,7 +626,7 @@ z
     <g id="xtick_9">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m61f3eb866c" x="614.47825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d20c1c007" x="614.47825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -642,11 +642,11 @@ z
      <g id="line2d_52">
       <path d="M 446.24125 214.718594 
 L 633.17125 214.718594 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -654,11 +654,11 @@ L 633.17125 214.718594
      <g id="line2d_54">
       <path d="M 446.24125 177.636689 
 L 633.17125 177.636689 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -666,11 +666,11 @@ L 633.17125 177.636689
      <g id="line2d_56">
       <path d="M 446.24125 140.554784 
 L 633.17125 140.554784 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -678,11 +678,11 @@ L 633.17125 140.554784
      <g id="line2d_58">
       <path d="M 446.24125 103.472879 
 L 633.17125 103.472879 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -690,11 +690,11 @@ L 633.17125 103.472879
      <g id="line2d_60">
       <path d="M 446.24125 66.390975 
 L 633.17125 66.390975 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -702,11 +702,11 @@ L 633.17125 66.390975
      <g id="line2d_62">
       <path d="M 446.24125 29.30907 
 L 633.17125 29.30907 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#mfb20d0f59d" x="446.24125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0362dd7e1a" x="446.24125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -715,9 +715,9 @@ L 633.17125 29.30907
     <path d="M 464.93425 183.53395 
 L 539.70625 114.643759 
 L 614.47825 39.232497 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #ff7f50; stroke-opacity: 0.55; stroke-linecap: square"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #ff7f50; stroke-opacity: 0.55; stroke-linecap: square"/>
     <defs>
-     <path id="md3bca132a1" d="M 0 2 
+     <path id="mcff8c8ac15" d="M 0 2 
 C 0.530406 2 1.03916 1.789267 1.414214 1.414214 
 C 1.789267 1.03916 2 0.530406 2 0 
 C 2 -0.530406 1.789267 -1.03916 1.414214 -1.414214 
@@ -729,16 +729,16 @@ C -1.03916 1.789267 -0.530406 2 0 2
 z
 " style="stroke: #ff7f50; stroke-opacity: 0.55"/>
     </defs>
-    <g clip-path="url(#p22bd46477e)">
-     <use xlink:href="#md3bca132a1" x="464.93425" y="183.53395" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
-     <use xlink:href="#md3bca132a1" x="539.70625" y="114.643759" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
-     <use xlink:href="#md3bca132a1" x="614.47825" y="39.232497" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
+    <g clip-path="url(#pb3137e9c7f)">
+     <use xlink:href="#mcff8c8ac15" x="464.93425" y="183.53395" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
+     <use xlink:href="#mcff8c8ac15" x="539.70625" y="114.643759" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
+     <use xlink:href="#mcff8c8ac15" x="614.47825" y="39.232497" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
     </g>
    </g>
    <g id="line2d_65">
     <path d="M 446.24125 66.390975 
 L 633.17125 66.390975 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_15">
     <path d="M 446.24125 214.718594 
@@ -764,11 +764,11 @@ L 633.17125 20.038594
     <path d="M 464.93425 170.918919 
 L 539.70625 90.609074 
 L 614.47825 32.10184 
-" clip-path="url(#p22bd46477e)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-    <g clip-path="url(#p22bd46477e)">
-     <use xlink:href="#m412ab1f1b9" x="464.93425" y="170.918919" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="539.70625" y="90.609074" style="stroke: #000000"/>
-     <use xlink:href="#m412ab1f1b9" x="614.47825" y="32.10184" style="stroke: #000000"/>
+" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
+    <g clip-path="url(#pb3137e9c7f)">
+     <use xlink:href="#m26197fd761" x="464.93425" y="170.918919" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="539.70625" y="90.609074" style="stroke: #000000"/>
+     <use xlink:href="#m26197fd761" x="614.47825" y="32.10184" style="stroke: #000000"/>
     </g>
    </g>
    <g id="text_26">
@@ -797,7 +797,7 @@ L 589.721484 204.512812
 L 596.721484 204.512812 
 " style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m412ab1f1b9" x="589.721484" y="204.512812" style="stroke: #000000"/>
+      <use xlink:href="#m26197fd761" x="589.721484" y="204.512812" style="stroke: #000000"/>
      </g>
     </g>
     <g id="text_28">
@@ -807,13 +807,13 @@ L 596.721484 204.512812
   </g>
  </g>
  <defs>
-  <clipPath id="p40a3e39bbd">
+  <clipPath id="pe91611f49b">
    <rect x="43.78125" y="20.038594" width="186.93" height="194.68"/>
   </clipPath>
-  <clipPath id="p8096d6b042">
+  <clipPath id="p20431dfcac">
    <rect x="245.01125" y="20.038594" width="186.93" height="194.68"/>
   </clipPath>
-  <clipPath id="p22bd46477e">
+  <clipPath id="pb3137e9c7f">
    <rect x="446.24125" y="20.038594" width="186.93" height="194.68"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_telescope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_telescope.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-08T17:01:02.955745</dc:date>
+    <dc:date>2026-08-16T17:12:28.688235</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -39,115 +39,115 @@ z
    </g>
    <g id="patch_3">
     <path d="M 118.680156 23.573139 
-L 415.326147 23.573139 
-L 415.326147 37.711321 
+L 414.292194 23.573139 
+L 414.292194 37.711321 
 L 118.680156 37.711321 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 118.680156 42.424048 
-L 421.468871 42.424048 
-L 421.468871 56.56223 
+L 419.02545 42.424048 
+L 419.02545 56.56223 
 L 118.680156 56.56223 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 118.680156 61.274957 
-L 423.814555 61.274957 
-L 423.814555 75.413139 
+L 424.058897 61.274957 
+L 424.058897 75.413139 
 L 118.680156 75.413139 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 118.680156 80.125866 
-L 441.944738 80.125866 
-L 441.944738 94.264048 
+L 442.042474 80.125866 
+L 442.042474 94.264048 
 L 118.680156 94.264048 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 118.680156 23.573139 
-L 390.721344 23.573139 
-L 390.721344 37.711321 
+L 388.48125 23.573139 
+L 388.48125 37.711321 
 L 118.680156 37.711321 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 118.680156 42.424048 
-L 395.734431 42.424048 
-L 395.734431 56.56223 
+L 391.91584 42.424048 
+L 391.91584 56.56223 
 L 118.680156 56.56223 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 118.680156 61.274957 
-L 407.190205 61.274957 
-L 407.190205 75.413139 
+L 407.964243 61.274957 
+L 407.964243 75.413139 
 L 118.680156 75.413139 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 118.680156 80.125866 
-L 439.132204 80.125866 
-L 439.132204 94.264048 
+L 438.770986 80.125866 
+L 438.770986 94.264048 
 L 118.680156 94.264048 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 118.680156 23.573139 
-L 314.031115 23.573139 
-L 314.031115 37.711321 
+L 309.514999 23.573139 
+L 309.514999 37.711321 
 L 118.680156 37.711321 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 118.680156 42.424048 
-L 315.647718 42.424048 
-L 315.647718 56.56223 
+L 310.138136 42.424048 
+L 310.138136 56.56223 
 L 118.680156 56.56223 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 118.680156 61.274957 
-L 340.15388 61.274957 
-L 340.15388 75.413139 
+L 336.308651 61.274957 
+L 336.308651 75.413139 
 L 118.680156 75.413139 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 118.680156 80.125866 
-L 430.028938 80.125866 
-L 430.028938 94.264048 
+L 429.282849 80.125866 
+L 429.282849 94.264048 
 L 118.680156 94.264048 
 z
-" clip-path="url(#p30cf85e1c9)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <path d="M 118.680156 97.798594 
 L 118.680156 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6c2397d7c5" d="M 0 0 
+       <path id="m9c34bc6eda" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6c2397d7c5" x="118.680156" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="118.680156" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -155,11 +155,11 @@ L 0 3.5
      <g id="line2d_3">
       <path d="M 184.163836 97.798594 
 L 184.163836 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="184.163836" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="184.163836" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -167,11 +167,11 @@ L 184.163836 20.038594
      <g id="line2d_5">
       <path d="M 249.647515 97.798594 
 L 249.647515 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="249.647515" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="249.647515" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -179,11 +179,11 @@ L 249.647515 20.038594
      <g id="line2d_7">
       <path d="M 315.131194 97.798594 
 L 315.131194 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="315.131194" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="315.131194" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -191,11 +191,11 @@ L 315.131194 20.038594
      <g id="line2d_9">
       <path d="M 380.614874 97.798594 
 L 380.614874 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="380.614874" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="380.614874" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -203,11 +203,11 @@ L 380.614874 20.038594
      <g id="line2d_11">
       <path d="M 446.098553 97.798594 
 L 446.098553 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="446.098553" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="446.098553" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -216,12 +216,12 @@ L 446.098553 20.038594
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m0eb3a10a56" d="M 0 0 
+       <path id="mda24468226" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="30.64223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="30.64223" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -231,7 +231,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="49.493139" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="49.493139" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -241,7 +241,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="68.344048" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="68.344048" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -251,7 +251,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="87.194957" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="87.194957" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -262,7 +262,7 @@ L -3.5 0
    <g id="line2d_17">
     <path d="M 380.614874 97.798594 
 L 380.614874 20.038594 
-" clip-path="url(#p30cf85e1c9)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p11524b9682)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_15">
     <path d="M 118.680156 97.798594 
@@ -347,254 +347,254 @@ z
    </g>
    <g id="patch_24">
     <path d="M 118.680156 134.134957 
-L 422.403801 134.134957 
-L 422.403801 147.729363 
+L 417.224718 134.134957 
+L 417.224718 147.729363 
 L 118.680156 147.729363 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 118.680156 152.260832 
-L 437.423365 152.260832 
-L 437.423365 165.855237 
+L 433.898854 152.260832 
+L 433.898854 165.855237 
 L 118.680156 165.855237 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 118.680156 170.386706 
-L 444.29349 170.386706 
-L 444.29349 183.981111 
+L 443.487908 170.386706 
+L 443.487908 183.981111 
 L 118.680156 183.981111 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 118.680156 188.51258 
-L 444.594663 188.51258 
-L 444.594663 202.106985 
+L 443.700559 188.51258 
+L 443.700559 202.106985 
 L 118.680156 202.106985 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 118.680156 206.638454 
-L 445.05739 206.638454 
-L 445.05739 220.232859 
+L 443.732969 206.638454 
+L 443.732969 220.232859 
 L 118.680156 220.232859 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 118.680156 224.764328 
-L 445.643489 224.764328 
-L 445.643489 238.358734 
+L 445.505941 224.764328 
+L 445.505941 238.358734 
 L 118.680156 238.358734 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 118.680156 242.890202 
-L 445.862859 242.890202 
-L 445.862859 256.484608 
+L 445.728327 242.890202 
+L 445.728327 256.484608 
 L 118.680156 256.484608 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 118.680156 261.016076 
-L 445.916485 261.016076 
-L 445.916485 274.610482 
+L 445.780285 261.016076 
+L 445.780285 274.610482 
 L 118.680156 274.610482 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 118.680156 279.14195 
-L 445.95883 279.14195 
-L 445.95883 292.736356 
+L 446.004128 279.14195 
+L 446.004128 292.736356 
 L 118.680156 292.736356 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 118.680156 297.267825 
-L 446.050011 297.267825 
-L 446.050011 310.86223 
+L 446.006903 297.267825 
+L 446.006903 310.86223 
 L 118.680156 310.86223 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 118.680156 134.134957 
-L 300.500351 134.134957 
-L 300.500351 147.729363 
+L 276.554855 134.134957 
+L 276.554855 147.729363 
 L 118.680156 147.729363 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 118.680156 152.260832 
-L 339.734171 152.260832 
-L 339.734171 165.855237 
+L 328.566848 152.260832 
+L 328.566848 165.855237 
 L 118.680156 165.855237 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 118.680156 170.386706 
-L 404.051138 170.386706 
-L 404.051138 183.981111 
+L 389.099073 170.386706 
+L 389.099073 183.981111 
 L 118.680156 183.981111 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 118.680156 188.51258 
-L 395.952829 188.51258 
-L 395.952829 202.106985 
+L 399.703745 188.51258 
+L 399.703745 202.106985 
 L 118.680156 202.106985 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 118.680156 206.638454 
-L 408.092632 206.638454 
-L 408.092632 220.232859 
+L 399.800165 206.638454 
+L 399.800165 220.232859 
 L 118.680156 220.232859 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 118.680156 224.764328 
-L 422.248075 224.764328 
-L 422.248075 238.358734 
+L 434.786287 224.764328 
+L 434.786287 238.358734 
 L 118.680156 238.358734 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 118.680156 242.890202 
-L 436.01571 242.890202 
-L 436.01571 256.484608 
+L 417.635304 242.890202 
+L 417.635304 256.484608 
 L 118.680156 256.484608 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 118.680156 261.016076 
-L 435.596454 261.016076 
-L 435.596454 274.610482 
+L 435.517513 261.016076 
+L 435.517513 274.610482 
 L 118.680156 274.610482 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
     <path d="M 118.680156 279.14195 
-L 439.759378 279.14195 
-L 439.759378 292.736356 
+L 437.973726 279.14195 
+L 437.973726 292.736356 
 L 118.680156 292.736356 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
     <path d="M 118.680156 297.267825 
-L 441.392334 297.267825 
-L 441.392334 310.86223 
+L 437.743069 297.267825 
+L 437.743069 310.86223 
 L 118.680156 310.86223 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
     <path d="M 118.680156 134.134957 
-L 162.511974 134.134957 
-L 162.511974 147.729363 
+L 163.710928 134.134957 
+L 163.710928 147.729363 
 L 118.680156 147.729363 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
     <path d="M 118.680156 152.260832 
-L 181.200773 152.260832 
-L 181.200773 165.855237 
+L 174.251169 152.260832 
+L 174.251169 165.855237 
 L 118.680156 165.855237 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
     <path d="M 118.680156 170.386706 
-L 212.802889 170.386706 
-L 212.802889 183.981111 
+L 198.715764 170.386706 
+L 198.715764 183.981111 
 L 118.680156 183.981111 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
     <path d="M 118.680156 188.51258 
-L 207.327139 188.51258 
-L 207.327139 202.106985 
+L 216.279037 188.51258 
+L 216.279037 202.106985 
 L 118.680156 202.106985 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
     <path d="M 118.680156 206.638454 
-L 221.705277 206.638454 
-L 221.705277 220.232859 
+L 213.418379 206.638454 
+L 213.418379 220.232859 
 L 118.680156 220.232859 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
     <path d="M 118.680156 224.764328 
-L 237.237616 224.764328 
-L 237.237616 238.358734 
+L 274.30495 224.764328 
+L 274.30495 238.358734 
 L 118.680156 238.358734 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
     <path d="M 118.680156 242.890202 
-L 280.312078 242.890202 
-L 280.312078 256.484608 
+L 228.672919 242.890202 
+L 228.672919 256.484608 
 L 118.680156 256.484608 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
     <path d="M 118.680156 261.016076 
-L 272.384904 261.016076 
-L 272.384904 274.610482 
+L 266.329932 261.016076 
+L 266.329932 274.610482 
 L 118.680156 274.610482 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
     <path d="M 118.680156 279.14195 
-L 286.71233 279.14195 
-L 286.71233 292.736356 
+L 279.85274 279.14195 
+L 279.85274 292.736356 
 L 118.680156 292.736356 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
     <path d="M 118.680156 297.267825 
-L 293.487614 297.267825 
-L 293.487614 310.86223 
+L 288.650583 297.267825 
+L 288.650583 310.86223 
 L 118.680156 310.86223 
 z
-" clip-path="url(#p0f5f1d998a)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
       <path d="M 118.680156 319.698594 
 L 118.680156 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="118.680156" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="118.680156" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -602,11 +602,11 @@ L 118.680156 125.298594
      <g id="line2d_20">
       <path d="M 184.163836 319.698594 
 L 184.163836 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="184.163836" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="184.163836" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -614,11 +614,11 @@ L 184.163836 125.298594
      <g id="line2d_22">
       <path d="M 249.647515 319.698594 
 L 249.647515 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="249.647515" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="249.647515" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -626,11 +626,11 @@ L 249.647515 125.298594
      <g id="line2d_24">
       <path d="M 315.131194 319.698594 
 L 315.131194 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="315.131194" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="315.131194" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -638,11 +638,11 @@ L 315.131194 125.298594
      <g id="line2d_26">
       <path d="M 380.614874 319.698594 
 L 380.614874 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="380.614874" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="380.614874" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -650,11 +650,11 @@ L 380.614874 125.298594
      <g id="line2d_28">
       <path d="M 446.098553 319.698594 
 L 446.098553 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="446.098553" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="446.098553" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
     </g>
@@ -663,7 +663,7 @@ L 446.098553 125.298594
     <g id="ytick_5">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="140.93216" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="140.93216" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -673,7 +673,7 @@ L 446.098553 125.298594
     <g id="ytick_6">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="159.058034" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="159.058034" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -683,27 +683,27 @@ L 446.098553 125.298594
     <g id="ytick_7">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="177.183908" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="177.183908" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="180.603205" transform="rotate(-0 111.680156 180.603205)">NeuroectodermRostral</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="180.603205" transform="rotate(-0 111.680156 180.603205)">EpiblastPrimitiveStreak</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="195.309783" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="195.309783" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="198.729079" transform="rotate(-0 111.680156 198.729079)">EpiblastPrimitiveStreak</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="198.729079" transform="rotate(-0 111.680156 198.729079)">NeuroectodermRostral</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="213.435657" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="213.435657" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -713,37 +713,37 @@ L 446.098553 125.298594
     <g id="ytick_10">
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="231.561531" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="231.561531" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="234.980828" transform="rotate(-0 111.680156 234.980828)">ExEndodermParietal</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="234.980828" transform="rotate(-0 111.680156 234.980828)">SurfaceEctoderm</text>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="249.687405" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="249.687405" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="253.106702" transform="rotate(-0 111.680156 253.106702)">Pluripotent</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="253.106702" transform="rotate(-0 111.680156 253.106702)">ExEndodermParietal</text>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="267.813279" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="267.813279" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="271.232576" transform="rotate(-0 111.680156 271.232576)">SurfaceEctoderm</text>
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="271.232576" transform="rotate(-0 111.680156 271.232576)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="285.939153" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="285.939153" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -753,7 +753,7 @@ L 446.098553 125.298594
     <g id="ytick_14">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="304.065027" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="304.065027" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -764,7 +764,7 @@ L 446.098553 125.298594
    <g id="line2d_40">
     <path d="M 380.614874 319.698594 
 L 380.614874 125.298594 
-" clip-path="url(#p0f5f1d998a)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#p0ccffbd026)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_54">
     <path d="M 118.680156 319.698594 
@@ -853,7 +853,7 @@ L 428.574574 348.965866
 L 428.574574 364.113918 
 L 118.680156 364.113918 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_64">
     <path d="M 118.680156 369.163269 
@@ -861,7 +861,7 @@ L 441.166745 369.163269
 L 441.166745 384.311321 
 L 118.680156 384.311321 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_65">
     <path d="M 118.680156 348.965866 
@@ -869,7 +869,7 @@ L 295.404315 348.965866
 L 295.404315 364.113918 
 L 118.680156 364.113918 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_66">
     <path d="M 118.680156 369.163269 
@@ -877,7 +877,7 @@ L 337.847646 369.163269
 L 337.847646 384.311321 
 L 118.680156 384.311321 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_67">
     <path d="M 118.680156 348.965866 
@@ -885,7 +885,7 @@ L 173.749743 348.965866
 L 173.749743 364.113918 
 L 118.680156 364.113918 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_68">
     <path d="M 118.680156 369.163269 
@@ -893,18 +893,18 @@ L 196.026881 369.163269
 L 196.026881 384.311321 
 L 118.680156 384.311321 
 z
-" clip-path="url(#p9f2202b154)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
       <path d="M 118.680156 386.078594 
 L 118.680156 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="118.680156" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="118.680156" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -915,11 +915,11 @@ L 118.680156 347.198594
      <g id="line2d_43">
       <path d="M 184.163836 386.078594 
 L 184.163836 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="184.163836" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="184.163836" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -930,11 +930,11 @@ L 184.163836 347.198594
      <g id="line2d_45">
       <path d="M 249.647515 386.078594 
 L 249.647515 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="249.647515" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="249.647515" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
@@ -945,11 +945,11 @@ L 249.647515 347.198594
      <g id="line2d_47">
       <path d="M 315.131194 386.078594 
 L 315.131194 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="315.131194" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="315.131194" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
@@ -960,11 +960,11 @@ L 315.131194 347.198594
      <g id="line2d_49">
       <path d="M 380.614874 386.078594 
 L 380.614874 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="380.614874" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="380.614874" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
@@ -975,11 +975,11 @@ L 380.614874 347.198594
      <g id="line2d_51">
       <path d="M 446.098553 386.078594 
 L 446.098553 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6c2397d7c5" x="446.098553" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c34bc6eda" x="446.098553" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
@@ -994,7 +994,7 @@ L 446.098553 347.198594
     <g id="ytick_15">
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="356.539892" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="356.539892" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_30">
@@ -1004,7 +1004,7 @@ L 446.098553 347.198594
     <g id="ytick_16">
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0eb3a10a56" x="118.680156" y="376.737295" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda24468226" x="118.680156" y="376.737295" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
@@ -1015,7 +1015,7 @@ L 446.098553 347.198594
    <g id="line2d_55">
     <path d="M 380.614874 386.078594 
 L 380.614874 347.198594 
-" clip-path="url(#p9f2202b154)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
    </g>
    <g id="patch_69">
     <path d="M 118.680156 386.078594 
@@ -1091,13 +1091,13 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p30cf85e1c9">
+  <clipPath id="p11524b9682">
    <rect x="118.680156" y="20.038594" width="333.966765" height="77.76"/>
   </clipPath>
-  <clipPath id="p0f5f1d998a">
+  <clipPath id="p0ccffbd026">
    <rect x="118.680156" y="125.298594" width="333.966765" height="194.4"/>
   </clipPath>
-  <clipPath id="p9f2202b154">
+  <clipPath id="pa5ae2cb02e">
    <rect x="118.680156" y="347.198594" width="333.966765" height="38.88"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/replot_overlay_ct.py
+++ b/analyses/simulation/activity_power/replot_overlay_ct.py
@@ -16,16 +16,20 @@ REFERENCE_NAMES = {
     "takeshi": "HepG2",
 }
 
+# The reporter/deflated pair is MWU. Measuring the reporter's power benefit
+# with the t-test confounds it: the t-test over-rejects in exactly the deflated
+# condition, so part of the apparent benefit is that miscalibration rather than
+# the reporter. The 2026-08-13 run added the MWU arms for this reason -- see the
+# ARMS comment in shendure/shendure_power_ttest_all_cell_types.py.
+# Yin et al. is still t-test: no MWU arm has been run on its power sims.
 DATASETS = {
     "cohen": [
-        ("reporter", "cohen/output/cohen_power_df_reporter.parquet"),
-        ("deflated", "cohen/output/cohen_power_df_deflated.parquet"),
-        ("mwu", "cohen/output/cohen_power_df.parquet"),
+        ("reporter", "output/cohen_power_df_2026-08-13_mwu.parquet"),
+        ("deflated", "output/cohen_power_df_2026-08-13_mwu_deflated.parquet"),
     ],
     "shendure": [
-        ("reporter", "shendure/output/power_df_reporter.parquet"),
-        ("deflated", "shendure/output/power_df_deflated.parquet"),
-        ("mwu", "shendure/output/power_df.parquet"),
+        ("reporter", "shendure/output/power_df_mwu_2026-08-13.parquet"),
+        ("deflated", "shendure/output/power_df_mwu_deflated_2026-08-13.parquet"),
     ],
     "seelig": [
         ("deflated", "seelig/output/seelig_power_df_deflated.parquet"),

--- a/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:40.757350</dc:date>
+    <dc:date>2026-08-16T17:12:23.310488</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma1aee1171a" d="M 0 0 
+       <path id="m816f56c484" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma1aee1171a" x="66.196481" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="66.196481" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -91,7 +91,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma1aee1171a" x="117.296798" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="117.296798" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -133,7 +133,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma1aee1171a" x="168.397114" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="168.397114" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -164,7 +164,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma1aee1171a" x="219.497431" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="219.497431" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -179,7 +179,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma1aee1171a" x="270.597747" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="270.597747" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -220,7 +220,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma1aee1171a" x="321.698063" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="321.698063" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -235,7 +235,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma1aee1171a" x="372.79838" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="372.79838" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -284,7 +284,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma1aee1171a" x="423.898696" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="423.898696" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -299,7 +299,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma1aee1171a" x="474.999013" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m816f56c484" x="474.999013" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,12 +617,12 @@ z
     <g id="ytick_1">
      <g id="line2d_10">
       <defs>
-       <path id="m0fae8cfd8b" d="M 0 0 
+       <path id="mea4e0467f6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -637,7 +637,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -652,7 +652,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -667,7 +667,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -714,7 +714,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -770,7 +770,7 @@ z
     <g id="ytick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0fae8cfd8b" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea4e0467f6" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1020,9 +1020,9 @@ L 460.690924 27.992886
 L 464.778949 27.572653 
 L 468.866975 27.795739 
 L 472.955 27.582672 
-" clip-path="url(#p42ab325aaa)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+" clip-path="url(#pa2476b4595)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="m062d09d583" d="M 0 1 
+     <path id="mdcd64f80ad" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1034,107 +1034,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p42ab325aaa)">
-     <use xlink:href="#m062d09d583" x="68.055" y="180.32733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="72.34896" y="75.113288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="76.426765" y="88.848305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="80.50457" y="111.464105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="84.592595" y="136.454628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="88.680621" y="159.609766" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="92.768646" y="174.513797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="96.856671" y="192.813125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="100.944697" y="206.813965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="105.032722" y="217.435646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="109.120747" y="229.536459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="113.208773" y="243.597892" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="117.296798" y="253.390654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="121.384823" y="262.331855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="125.472849" y="270.762759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="129.560874" y="279.706815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="133.648899" y="285.831749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="137.736924" y="292.624792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="141.82495" y="296.261947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="145.912975" y="300.191124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="150.001" y="303.815224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="154.089026" y="306.448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="158.177051" y="308.076819" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="162.265076" y="309.238325" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="166.353102" y="308.974312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="170.441127" y="309.495758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="174.529152" y="308.391337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="178.617178" y="306.982694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="182.705203" y="306.205411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="186.793228" y="304.102823" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="190.881253" y="301.461565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="194.969279" y="298.928132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="199.057304" y="293.307335" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="203.145329" y="290.045989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="207.233355" y="285.489278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="211.32138" y="281.475596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="215.409405" y="277.404202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="219.497431" y="266.935023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="223.585456" y="261.920676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="227.673481" y="254.936772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="231.761507" y="247.472579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="235.849532" y="235.807931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="239.937557" y="229.387671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="244.025583" y="219.542917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="248.113608" y="211.68475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="252.201633" y="203.632292" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="256.289658" y="189.411881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="260.377684" y="182.355968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="264.465709" y="173.148389" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="268.553734" y="165.658729" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="272.64176" y="154.794161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="276.729785" y="146.617201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="280.81781" y="137.274409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="284.905836" y="129.036216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="288.993861" y="122.477401" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="293.081886" y="116.098256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="297.169912" y="107.721662" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="301.257937" y="101.349592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="305.345962" y="97.055385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="309.433988" y="88.668187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="313.522013" y="83.470065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="317.610038" y="77.820563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="321.698063" y="74.907644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="325.786089" y="72.079786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="329.874114" y="65.94502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="333.962139" y="61.689118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="338.050165" y="59.958574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="342.13819" y="56.797133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="346.226215" y="53.689071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="350.314241" y="50.121905" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="354.402266" y="48.655015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="358.490291" y="46.85583" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="362.578317" y="44.910358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="366.666342" y="43.338556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="370.754367" y="40.740695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="374.842393" y="39.234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="378.930418" y="38.760057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="383.018443" y="37.632811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="387.106468" y="37.588247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="391.194494" y="36.341058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="395.282519" y="34.143399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="399.370544" y="33.39872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="403.45857" y="32.831415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="407.546595" y="32.952703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="411.63462" y="32.037707" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="415.722646" y="30.881691" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="419.810671" y="30.873797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="423.898696" y="30.316667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="427.986722" y="29.801062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="432.074747" y="29.691229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="436.162772" y="28.681953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="440.250798" y="29.354571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="444.338823" y="29.015907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="448.426848" y="28.681633" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="452.514873" y="28.092542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="456.602899" y="28.540037" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="460.690924" y="27.992886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="464.778949" y="27.572653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="468.866975" y="27.795739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m062d09d583" x="472.955" y="27.582672" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pa2476b4595)">
+     <use xlink:href="#mdcd64f80ad" x="68.055" y="180.32733" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="72.34896" y="75.113288" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="76.426765" y="88.848305" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="80.50457" y="111.464105" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="84.592595" y="136.454628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="88.680621" y="159.609766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="92.768646" y="174.513797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="96.856671" y="192.813125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="100.944697" y="206.813965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="105.032722" y="217.435646" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="109.120747" y="229.536459" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="113.208773" y="243.597892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="117.296798" y="253.390654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="121.384823" y="262.331855" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="125.472849" y="270.762759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="129.560874" y="279.706815" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="133.648899" y="285.831749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="137.736924" y="292.624792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="141.82495" y="296.261947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="145.912975" y="300.191124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="150.001" y="303.815224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="154.089026" y="306.448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="158.177051" y="308.076819" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="162.265076" y="309.238325" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="166.353102" y="308.974312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="170.441127" y="309.495758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="174.529152" y="308.391337" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="178.617178" y="306.982694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="182.705203" y="306.205411" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="186.793228" y="304.102823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="190.881253" y="301.461565" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="194.969279" y="298.928132" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="199.057304" y="293.307335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="203.145329" y="290.045989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="207.233355" y="285.489278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="211.32138" y="281.475596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="215.409405" y="277.404202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="219.497431" y="266.935023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="223.585456" y="261.920676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="227.673481" y="254.936772" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="231.761507" y="247.472579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="235.849532" y="235.807931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="239.937557" y="229.387671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="244.025583" y="219.542917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="248.113608" y="211.68475" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="252.201633" y="203.632292" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="256.289658" y="189.411881" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="260.377684" y="182.355968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="264.465709" y="173.148389" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="268.553734" y="165.658729" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="272.64176" y="154.794161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="276.729785" y="146.617201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="280.81781" y="137.274409" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="284.905836" y="129.036216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="288.993861" y="122.477401" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="293.081886" y="116.098256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="297.169912" y="107.721662" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="301.257937" y="101.349592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="305.345962" y="97.055385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="309.433988" y="88.668187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="313.522013" y="83.470065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="317.610038" y="77.820563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="321.698063" y="74.907644" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="325.786089" y="72.079786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="329.874114" y="65.94502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="333.962139" y="61.689118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="338.050165" y="59.958574" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="342.13819" y="56.797133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="346.226215" y="53.689071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="350.314241" y="50.121905" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="354.402266" y="48.655015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="358.490291" y="46.85583" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="362.578317" y="44.910358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="366.666342" y="43.338556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="370.754367" y="40.740695" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="374.842393" y="39.234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="378.930418" y="38.760057" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="383.018443" y="37.632811" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="387.106468" y="37.588247" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="391.194494" y="36.341058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="395.282519" y="34.143399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="399.370544" y="33.39872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="403.45857" y="32.831415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="407.546595" y="32.952703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="411.63462" y="32.037707" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="415.722646" y="30.881691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="419.810671" y="30.873797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="423.898696" y="30.316667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="427.986722" y="29.801062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="432.074747" y="29.691229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="436.162772" y="28.681953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="440.250798" y="29.354571" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="444.338823" y="29.015907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="448.426848" y="28.681633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="452.514873" y="28.092542" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="456.602899" y="28.540037" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="460.690924" y="27.992886" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="464.778949" y="27.572653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="468.866975" y="27.795739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdcd64f80ad" x="472.955" y="27.582672" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_17">
@@ -1238,9 +1238,9 @@ L 460.690924 25.5236
 L 464.778949 25.555996 
 L 468.866975 25.556169 
 L 472.955 25.468546 
-" clip-path="url(#p42ab325aaa)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+" clip-path="url(#pa2476b4595)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="mc25b0376a3" d="M 0 1 
+     <path id="m94881d5317" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1252,118 +1252,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p42ab325aaa)">
-     <use xlink:href="#mc25b0376a3" x="68.056022" y="149.214113" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="72.34896" y="62.891704" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="76.426765" y="81.051505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="80.50457" y="105.97211" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="84.592595" y="122.927948" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="88.680621" y="139.112778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="92.768646" y="152.357492" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="96.856671" y="167.316505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="100.944697" y="179.288717" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="105.032722" y="191.190774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="109.120747" y="205.803881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="113.208773" y="219.674234" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="117.296798" y="234.860266" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="121.384823" y="243.352563" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="125.472849" y="258.626991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="129.560874" y="266.796518" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="133.648899" y="275.669036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="137.736924" y="285.1749" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="141.82495" y="290.325917" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="145.912975" y="296.596905" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="150.001" y="301.224216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="154.089026" y="304.260744" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="158.177051" y="306.626922" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="162.265076" y="306.927517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="166.353102" y="308.295973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="170.441127" y="307.736189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="174.529152" y="307.312745" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="178.617178" y="305.258452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="182.705203" y="304.33415" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="186.793228" y="300.76989" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="190.881253" y="295.58945" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="194.969279" y="293.070701" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="199.057304" y="287.023833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="203.145329" y="282.219831" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="207.233355" y="273.382184" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="211.32138" y="265.991493" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="215.409405" y="258.827292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="219.497431" y="249.6967" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="223.585456" y="239.007259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="227.673481" y="230.033398" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="231.761507" y="219.988308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="235.849532" y="209.724698" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="239.937557" y="196.985889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="244.025583" y="189.092021" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="248.113608" y="175.260913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="252.201633" y="165.951203" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="256.289658" y="152.555179" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="260.377684" y="145.699807" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="264.465709" y="136.673102" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="268.553734" y="127.823592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="272.64176" y="115.731119" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="276.729785" y="108.366315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="280.81781" y="98.023588" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="284.905836" y="88.938018" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="288.993861" y="84.383036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="293.081886" y="78.739098" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="297.169912" y="71.776754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="301.257937" y="66.794495" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="305.345962" y="61.734337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="309.433988" y="57.667986" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="313.522013" y="53.483814" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="317.610038" y="50.961452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="321.698063" y="47.523019" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="325.786089" y="43.018793" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="329.874114" y="41.954167" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="333.962139" y="41.283486" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="338.050165" y="39.434507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="342.13819" y="36.56849" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="346.226215" y="34.990826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="350.314241" y="34.276353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="354.402266" y="32.6296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="358.490291" y="31.456886" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="362.578317" y="31.710991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="366.666342" y="30.84356" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="370.754367" y="30.654653" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="374.842393" y="29.661461" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="378.930418" y="28.576932" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="383.018443" y="28.116475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="387.106468" y="27.973333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="391.194494" y="27.714725" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="395.282519" y="27.166254" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="399.370544" y="27.28597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="403.45857" y="26.784643" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="407.546595" y="26.646322" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="411.63462" y="26.428606" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="415.722646" y="26.080628" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="419.810671" y="26.182205" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="423.898696" y="26.277995" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="427.986722" y="25.949608" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="432.074747" y="25.831251" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="436.162772" y="25.887786" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="440.250798" y="25.636942" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="444.338823" y="25.74307" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="448.426848" y="25.631242" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="452.514873" y="25.584637" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="456.602899" y="25.552215" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="460.690924" y="25.5236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="464.778949" y="25.555996" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="468.866975" y="25.556169" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mc25b0376a3" x="472.955" y="25.468546" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#pa2476b4595)">
+     <use xlink:href="#m94881d5317" x="68.056022" y="149.214113" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="72.34896" y="62.891704" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="76.426765" y="81.051505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="80.50457" y="105.97211" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="84.592595" y="122.927948" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="88.680621" y="139.112778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="92.768646" y="152.357492" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="96.856671" y="167.316505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="100.944697" y="179.288717" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="105.032722" y="191.190774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="109.120747" y="205.803881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="113.208773" y="219.674234" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="117.296798" y="234.860266" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="121.384823" y="243.352563" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="125.472849" y="258.626991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="129.560874" y="266.796518" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="133.648899" y="275.669036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="137.736924" y="285.1749" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="141.82495" y="290.325917" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="145.912975" y="296.596905" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="150.001" y="301.224216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="154.089026" y="304.260744" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="158.177051" y="306.626922" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="162.265076" y="306.927517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="166.353102" y="308.295973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="170.441127" y="307.736189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="174.529152" y="307.312745" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="178.617178" y="305.258452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="182.705203" y="304.33415" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="186.793228" y="300.76989" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="190.881253" y="295.58945" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="194.969279" y="293.070701" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="199.057304" y="287.023833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="203.145329" y="282.219831" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="207.233355" y="273.382184" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="211.32138" y="265.991493" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="215.409405" y="258.827292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="219.497431" y="249.6967" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="223.585456" y="239.007259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="227.673481" y="230.033398" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="231.761507" y="219.988308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="235.849532" y="209.724698" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="239.937557" y="196.985889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="244.025583" y="189.092021" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="248.113608" y="175.260913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="252.201633" y="165.951203" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="256.289658" y="152.555179" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="260.377684" y="145.699807" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="264.465709" y="136.673102" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="268.553734" y="127.823592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="272.64176" y="115.731119" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="276.729785" y="108.366315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="280.81781" y="98.023588" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="284.905836" y="88.938018" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="288.993861" y="84.383036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="293.081886" y="78.739098" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="297.169912" y="71.776754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="301.257937" y="66.794495" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="305.345962" y="61.734337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="309.433988" y="57.667986" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="313.522013" y="53.483814" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="317.610038" y="50.961452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="321.698063" y="47.523019" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="325.786089" y="43.018793" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="329.874114" y="41.954167" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="333.962139" y="41.283486" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="338.050165" y="39.434507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="342.13819" y="36.56849" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="346.226215" y="34.990826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="350.314241" y="34.276353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="354.402266" y="32.6296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="358.490291" y="31.456886" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="362.578317" y="31.710991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="366.666342" y="30.84356" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="370.754367" y="30.654653" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="374.842393" y="29.661461" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="378.930418" y="28.576932" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="383.018443" y="28.116475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="387.106468" y="27.973333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="391.194494" y="27.714725" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="395.282519" y="27.166254" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="399.370544" y="27.28597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="403.45857" y="26.784643" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="407.546595" y="26.646322" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="411.63462" y="26.428606" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="415.722646" y="26.080628" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="419.810671" y="26.182205" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="423.898696" y="26.277995" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="427.986722" y="25.949608" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="432.074747" y="25.831251" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="436.162772" y="25.887786" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="440.250798" y="25.636942" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="444.338823" y="25.74307" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="448.426848" y="25.631242" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="452.514873" y="25.584637" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="456.602899" y="25.552215" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="460.690924" y="25.5236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="464.778949" y="25.555996" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="468.866975" y="25.556169" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m94881d5317" x="472.955" y="25.468546" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_18">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p42ab325aaa)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#pa2476b4595)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_19">
     <path d="M 168.397114 318.04 
 L 168.397114 25.44 
-" clip-path="url(#p42ab325aaa)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#pa2476b4595)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -1609,7 +1609,7 @@ L 444.29375 49.596875
 L 452.29375 49.596875 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m062d09d583" x="444.29375" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#mdcd64f80ad" x="444.29375" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
@@ -1643,7 +1643,7 @@ L 444.29375 61.339375
 L 452.29375 61.339375 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc25b0376a3" x="444.29375" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m94881d5317" x="444.29375" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
@@ -1702,7 +1702,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p42ab325aaa">
+  <clipPath id="pa2476b4595">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:40.208268</dc:date>
+    <dc:date>2026-08-16T17:12:23.160579</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m03f8dc64a6" d="M 0 0 
+       <path id="m8f9bc2e8d5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m03f8dc64a6" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -91,7 +91,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -133,7 +133,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -164,7 +164,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -179,7 +179,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -220,7 +220,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -235,7 +235,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -284,7 +284,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -299,7 +299,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m03f8dc64a6" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9bc2e8d5" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,12 +617,12 @@ z
     <g id="ytick_1">
      <g id="line2d_10">
       <defs>
-       <path id="m48f1458408" d="M 0 0 
+       <path id="m94fc6ad6a6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -637,7 +637,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -652,7 +652,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -667,7 +667,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -714,7 +714,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -770,7 +770,7 @@ z
     <g id="ytick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m48f1458408" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94fc6ad6a6" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -920,109 +920,109 @@ z
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 68.195835 244.671642 
-L 72.462607 248.837778 
-L 76.583329 249.623235 
-L 80.70405 257.484522 
-L 84.77261 266.022222 
-L 88.841171 269.344526 
-L 92.909731 277.330435 
-L 96.978291 273.692813 
-L 101.099013 277.414545 
-L 105.219734 283.503607 
-L 109.288295 289.723871 
-L 113.356855 291.732844 
-L 117.425415 302.662482 
-L 121.493976 297.36 
-L 125.614697 303.686038 
-L 129.735419 297.746774 
-L 133.803979 309.188235 
-L 137.872539 299.914336 
-L 141.9411 304.781563 
-L 146.00966 302.815285 
-L 150.130382 308.658931 
-L 154.251103 309.476098 
-L 158.319663 302.64 
-L 162.388224 305.964444 
-L 166.456784 305.804 
-L 170.577506 303.098723 
-L 174.698227 303.197971 
-L 178.766787 306.432727 
-L 182.835348 300.106452 
-L 186.903908 298.369412 
-L 190.972469 302.434667 
-L 195.09319 299.046667 
-L 199.213911 298.533333 
-L 203.282472 297.685217 
-L 207.351032 299.661818 
-L 211.419593 294.833793 
-L 215.488153 290.908 
-L 219.608874 290.90029 
-L 223.729596 291.86 
-L 227.798156 287.865625 
-L 231.866717 283.422535 
-L 235.935277 279.913333 
-L 240.003837 276.877627 
-L 244.124559 266.486667 
-L 248.24528 274.708397 
-L 252.313841 271.982593 
-L 256.382401 256.412743 
-L 260.450961 260.007667 
-L 264.519522 266.892598 
-L 268.640243 260.503529 
-L 272.760965 249.539845 
-L 276.829525 250.929908 
-L 280.898085 244.363741 
-L 284.966646 230.533458 
-L 289.035206 245.019469 
-L 293.155928 233.317015 
-L 297.276649 233.853333 
-L 301.345209 223.837073 
-L 305.41377 215.63 
-L 309.48233 232.92 
-L 313.55089 217.443636 
-L 317.671612 216.675 
-L 321.792333 201.46816 
-L 325.860894 205.501538 
-L 329.929454 201.790811 
-L 333.998014 201.943871 
-L 338.066575 198.455652 
-L 342.187296 196.420174 
-L 346.308018 194.893565 
-L 350.376578 188.097953 
-L 354.445138 167.902623 
-L 358.513699 172.766667 
-L 362.582259 176.097872 
-L 366.702981 169.989402 
-L 370.823702 176.074815 
-L 374.892262 158.053871 
-L 378.960823 160.128889 
-L 383.029383 169.563636 
-L 387.097944 153.390508 
-L 391.218665 148.767273 
-L 395.339386 149.795 
-L 399.407947 153.201221 
-L 403.476507 141.488136 
-L 407.545068 132.213333 
-L 411.613628 135.293333 
-L 415.734349 144.8208 
-L 419.855071 125.342 
-L 423.923631 129.089831 
-L 427.992192 111.469402 
-L 432.060752 133.075 
-L 436.129312 116.42365 
-L 440.250034 126.675328 
-L 444.370755 117.326667 
-L 448.439316 124 
-L 452.507876 119.697405 
-L 456.576436 112.748065 
-L 460.644997 103.659802 
-L 464.765718 98.59 
-L 468.88644 108.30432 
-L 472.955 102.979 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+    <path d="M 68.060216 318.04 
+L 72.358285 318.04 
+L 76.426845 318.04 
+L 80.495406 318.04 
+L 84.563966 317.606519 
+L 88.684688 317.173037 
+L 92.805409 318.04 
+L 96.873969 317.564228 
+L 100.94253 318.04 
+L 105.01109 317.503119 
+L 109.079651 318.04 
+L 113.200372 317.166567 
+L 117.321093 316.812308 
+L 121.389654 316.689538 
+L 125.458214 318.04 
+L 129.526775 316.589091 
+L 133.595335 317.535517 
+L 137.716056 317.039658 
+L 141.836778 316.729851 
+L 145.905338 315.789231 
+L 149.973899 316.526552 
+L 154.042459 315.275276 
+L 158.16318 316.368 
+L 162.283902 314.766154 
+L 166.352462 314.175472 
+L 170.421023 313.3375 
+L 174.489583 312.393333 
+L 178.558143 314.96 
+L 182.678865 311.804262 
+L 186.799586 315.904234 
+L 190.868147 311.128189 
+L 194.936707 308.635 
+L 199.005267 311.212667 
+L 203.073828 306.633559 
+L 207.194549 308.367273 
+L 211.315271 309.353438 
+L 215.383831 309.353438 
+L 219.452391 305.360667 
+L 223.520952 299.859029 
+L 227.589512 303.047273 
+L 231.710233 306.436897 
+L 235.830955 302.851603 
+L 239.899515 300.205333 
+L 243.968076 299.3136 
+L 248.036636 295.313786 
+L 252.157357 300.073333 
+L 256.278079 297.727273 
+L 260.346639 295.313786 
+L 264.4152 291.706 
+L 268.48376 295.418824 
+L 272.55232 290.530598 
+L 276.673042 288.78 
+L 280.793763 286.02906 
+L 284.862324 283.86432 
+L 288.930884 283.983279 
+L 292.999444 292.664071 
+L 297.068005 274.304 
+L 301.188726 276.973333 
+L 305.309448 278.185862 
+L 309.378008 275.992296 
+L 313.446568 272.06 
+L 317.515129 269.2 
+L 321.583689 272.70018 
+L 325.704411 271.127273 
+L 329.825132 262.220923 
+L 333.893692 264.021538 
+L 337.962253 263.121231 
+L 342.030813 262.374634 
+L 346.151535 250.885902 
+L 350.272256 255.309928 
+L 354.340816 255.585882 
+L 358.409377 248.665484 
+L 362.477937 240.170645 
+L 366.546498 247.816 
+L 370.667219 244.096124 
+L 374.78794 251.845246 
+L 378.856501 252.261705 
+L 382.925061 241.447647 
+L 386.993622 244.402333 
+L 391.062182 234.44 
+L 395.182903 238.524275 
+L 399.303625 241.313778 
+L 403.372185 231.174375 
+L 407.440746 239.853443 
+L 411.509306 223.61 
+L 415.577866 218.834667 
+L 419.698588 226.571765 
+L 423.819309 214.933333 
+L 427.88787 210.68 
+L 431.95643 220.356615 
+L 436.02499 220.341356 
+L 440.145712 225.688125 
+L 444.266433 220.506667 
+L 448.334994 213.075556 
+L 452.403554 214.3 
+L 456.472114 218.068333 
+L 460.540675 221.02 
+L 464.661396 216.490588 
+L 468.782118 225.215172 
+L 472.850678 212.980472 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="mcab563d38d" d="M 0 1 
+     <path id="mf4c2f13220" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1034,213 +1034,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#mcab563d38d" x="68.195835" y="244.671642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="72.462607" y="248.837778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="76.583329" y="249.623235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="80.70405" y="257.484522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="84.77261" y="266.022222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="88.841171" y="269.344526" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="92.909731" y="277.330435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="96.978291" y="273.692813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="101.099013" y="277.414545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="105.219734" y="283.503607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="109.288295" y="289.723871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="113.356855" y="291.732844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="117.425415" y="302.662482" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="121.493976" y="297.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="125.614697" y="303.686038" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="129.735419" y="297.746774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="133.803979" y="309.188235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="137.872539" y="299.914336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="141.9411" y="304.781563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="146.00966" y="302.815285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="150.130382" y="308.658931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="154.251103" y="309.476098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="158.319663" y="302.64" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="162.388224" y="305.964444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="166.456784" y="305.804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="170.577506" y="303.098723" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="174.698227" y="303.197971" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="178.766787" y="306.432727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="182.835348" y="300.106452" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="186.903908" y="298.369412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="190.972469" y="302.434667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="195.09319" y="299.046667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="199.213911" y="298.533333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="203.282472" y="297.685217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="207.351032" y="299.661818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="211.419593" y="294.833793" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="215.488153" y="290.908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="219.608874" y="290.90029" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="223.729596" y="291.86" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="227.798156" y="287.865625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="231.866717" y="283.422535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="235.935277" y="279.913333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="240.003837" y="276.877627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="244.124559" y="266.486667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="248.24528" y="274.708397" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="252.313841" y="271.982593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="256.382401" y="256.412743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="260.450961" y="260.007667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="264.519522" y="266.892598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="268.640243" y="260.503529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="272.760965" y="249.539845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="276.829525" y="250.929908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="280.898085" y="244.363741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="284.966646" y="230.533458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="289.035206" y="245.019469" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="293.155928" y="233.317015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="297.276649" y="233.853333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="301.345209" y="223.837073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="305.41377" y="215.63" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="309.48233" y="232.92" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="313.55089" y="217.443636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="317.671612" y="216.675" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="321.792333" y="201.46816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="325.860894" y="205.501538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="329.929454" y="201.790811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="333.998014" y="201.943871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="338.066575" y="198.455652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="342.187296" y="196.420174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="346.308018" y="194.893565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="350.376578" y="188.097953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="354.445138" y="167.902623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="358.513699" y="172.766667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="362.582259" y="176.097872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="366.702981" y="169.989402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="370.823702" y="176.074815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="374.892262" y="158.053871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="378.960823" y="160.128889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="383.029383" y="169.563636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="387.097944" y="153.390508" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="391.218665" y="148.767273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="395.339386" y="149.795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="399.407947" y="153.201221" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="403.476507" y="141.488136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="407.545068" y="132.213333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="411.613628" y="135.293333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="415.734349" y="144.8208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="419.855071" y="125.342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="423.923631" y="129.089831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="427.992192" y="111.469402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="432.060752" y="133.075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="436.129312" y="116.42365" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="440.250034" y="126.675328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="444.370755" y="117.326667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="448.439316" y="124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="452.507876" y="119.697405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="456.576436" y="112.748065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="460.644997" y="103.659802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="464.765718" y="98.59" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="468.88644" y="108.30432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcab563d38d" x="472.955" y="102.979" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#mf4c2f13220" x="68.060216" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="72.358285" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="76.426845" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="80.495406" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="84.563966" y="317.606519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="88.684688" y="317.173037" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="92.805409" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="96.873969" y="317.564228" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="100.94253" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="105.01109" y="317.503119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="109.079651" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="113.200372" y="317.166567" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="117.321093" y="316.812308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="121.389654" y="316.689538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="125.458214" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="129.526775" y="316.589091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="133.595335" y="317.535517" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="137.716056" y="317.039658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="141.836778" y="316.729851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="145.905338" y="315.789231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="149.973899" y="316.526552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="154.042459" y="315.275276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="158.16318" y="316.368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="162.283902" y="314.766154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="166.352462" y="314.175472" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="170.421023" y="313.3375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="174.489583" y="312.393333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="178.558143" y="314.96" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="182.678865" y="311.804262" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="186.799586" y="315.904234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="190.868147" y="311.128189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="194.936707" y="308.635" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="199.005267" y="311.212667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="203.073828" y="306.633559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="207.194549" y="308.367273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="211.315271" y="309.353438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="215.383831" y="309.353438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="219.452391" y="305.360667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="223.520952" y="299.859029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="227.589512" y="303.047273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="231.710233" y="306.436897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="235.830955" y="302.851603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="239.899515" y="300.205333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="243.968076" y="299.3136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="248.036636" y="295.313786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="252.157357" y="300.073333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="256.278079" y="297.727273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="260.346639" y="295.313786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="264.4152" y="291.706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="268.48376" y="295.418824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="272.55232" y="290.530598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="276.673042" y="288.78" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="280.793763" y="286.02906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="284.862324" y="283.86432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="288.930884" y="283.983279" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="292.999444" y="292.664071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="297.068005" y="274.304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="301.188726" y="276.973333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="305.309448" y="278.185862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="309.378008" y="275.992296" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="313.446568" y="272.06" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="317.515129" y="269.2" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="321.583689" y="272.70018" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="325.704411" y="271.127273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="329.825132" y="262.220923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="333.893692" y="264.021538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="337.962253" y="263.121231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="342.030813" y="262.374634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="346.151535" y="250.885902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="350.272256" y="255.309928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="354.340816" y="255.585882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="358.409377" y="248.665484" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="362.477937" y="240.170645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="366.546498" y="247.816" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="370.667219" y="244.096124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="374.78794" y="251.845246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="378.856501" y="252.261705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="382.925061" y="241.447647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="386.993622" y="244.402333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="391.062182" y="234.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="395.182903" y="238.524275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="399.303625" y="241.313778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="403.372185" y="231.174375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="407.440746" y="239.853443" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="411.509306" y="223.61" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="415.577866" y="218.834667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="419.698588" y="226.571765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="423.819309" y="214.933333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="427.88787" y="210.68" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="431.95643" y="220.356615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="436.02499" y="220.341356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="440.145712" y="225.688125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="444.266433" y="220.506667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="448.334994" y="213.075556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="452.403554" y="214.3" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="456.472114" y="218.068333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="460.540675" y="221.02" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="464.661396" y="216.490588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="468.782118" y="225.215172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mf4c2f13220" x="472.850678" y="212.980472" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_17">
-    <path d="M 68.065432 121.482791 
-L 72.358285 144.935385 
-L 76.426845 163.035412 
-L 80.495406 175.460344 
-L 84.616127 193.375915 
-L 88.736849 209.121993 
-L 92.805409 231.856 
-L 96.873969 237.094453 
-L 100.94253 253.176923 
-L 105.01109 263.822941 
-L 109.131812 267.171025 
-L 113.252533 268.610485 
-L 117.321093 282.186197 
-L 121.389654 289.216716 
-L 125.458214 295.58214 
-L 129.578936 300.999693 
-L 133.699657 297.527835 
-L 137.768217 305.864698 
-L 141.836778 305.080554 
-L 145.905338 304.878062 
-L 149.973899 306.611852 
-L 154.09462 307.996964 
-L 158.215341 309.542046 
-L 162.283902 310.615821 
-L 166.352462 309.814297 
-L 170.421023 309.9 
-L 174.541744 305.117603 
-L 178.662465 304.584672 
-L 182.731026 305.730621 
-L 186.799586 298.029935 
-L 190.868147 298.094277 
-L 194.936707 297.155539 
-L 199.057428 289.626752 
-L 203.17815 286.514074 
-L 207.24671 283.764 
-L 211.315271 282.336462 
-L 215.383831 274.095613 
-L 219.504552 264.608696 
-L 223.625274 267.017224 
-L 227.693834 256.70237 
-L 231.762395 250.560912 
-L 235.830955 239.798974 
-L 239.951676 237.6016 
-L 244.072398 232.725128 
-L 248.140958 224.059205 
-L 252.209519 221.677067 
-L 256.278079 208.193488 
-L 260.346639 201.953094 
-L 264.467361 208.169669 
-L 268.588082 195.848592 
-L 272.656643 192.55169 
-L 276.725203 182.915694 
-L 280.793763 176.16679 
-L 284.914485 168.068593 
-L 289.035206 156.952688 
-L 293.103767 150.404583 
-L 297.172327 153.853145 
-L 301.240887 147.86384 
-L 305.309448 132.823234 
-L 309.430169 139.183099 
-L 313.55089 128.865972 
-L 317.619451 126.060719 
-L 321.688011 115.937 
-L 325.756572 118.11205 
-L 329.877293 104.648889 
-L 333.998014 100.238451 
-L 338.066575 100.430861 
-L 342.135135 95.891262 
-L 346.203696 85.608451 
-L 350.272256 80.329197 
-L 354.392977 87.921354 
-L 358.513699 80.549325 
-L 362.582259 80.253733 
-L 366.65082 76.082308 
-L 370.71938 69.686829 
-L 374.840101 67.96015 
-L 378.960823 69.009635 
-L 383.029383 61.604045 
-L 387.097944 59.84027 
-L 391.166504 62.376578 
-L 395.235064 59.247162 
-L 399.355786 60.002148 
-L 403.476507 51.947317 
-L 407.545068 54.102857 
-L 411.613628 59.193857 
-L 415.682188 54.396263 
-L 419.80291 50.667703 
-L 423.923631 50.403077 
-L 427.992192 48.889504 
-L 432.060752 45.398808 
-L 436.129312 50.655935 
-L 440.197873 44.32345 
-L 444.318594 46.300442 
-L 448.439316 46.929311 
-L 452.507876 42.464 
-L 456.576436 42.517011 
-L 460.644997 39.195697 
-L 464.765718 39.851642 
-L 468.88644 41.695556 
-L 472.955 40.958083 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+    <path d="M 68.065432 317.806853 
+L 72.358285 318.04 
+L 76.426845 317.430417 
+L 80.495406 316.956296 
+L 84.563966 316.705668 
+L 88.684688 314.32791 
+L 92.805409 313.66252 
+L 96.873969 312.247918 
+L 100.94253 311.891159 
+L 105.01109 311.068303 
+L 109.131812 313.752821 
+L 113.252533 313.675797 
+L 117.321093 311.869524 
+L 121.389654 314.420206 
+L 125.458214 313.623396 
+L 129.526775 313.408921 
+L 133.647496 313.874875 
+L 137.768217 315.038974 
+L 141.836778 314.938233 
+L 145.905338 315.14297 
+L 149.973899 314.24 
+L 154.09462 313.86 
+L 158.215341 313.646007 
+L 162.283902 313.163333 
+L 166.352462 313.04439 
+L 170.421023 312.600641 
+L 174.489583 311.008527 
+L 178.610304 308.353931 
+L 182.731026 310.039219 
+L 186.799586 307.870951 
+L 190.868147 305.5 
+L 194.936707 303.560825 
+L 199.057428 301.772708 
+L 203.17815 300.740292 
+L 207.24671 297.732687 
+L 211.315271 298.195848 
+L 215.383831 291.092646 
+L 219.452391 287.893333 
+L 223.573113 288.259359 
+L 227.693834 285.681882 
+L 231.762395 282.928 
+L 235.830955 270.4925 
+L 239.899515 273.893333 
+L 243.968076 268.899512 
+L 248.088797 262.579869 
+L 252.209519 255.437209 
+L 256.278079 248.713171 
+L 260.346639 248.180484 
+L 264.4152 247.048525 
+L 268.535921 234.88 
+L 272.656643 234.308553 
+L 276.725203 220.104467 
+L 280.793763 219.313813 
+L 284.862324 211.021774 
+L 288.930884 208.482885 
+L 293.051605 203.105036 
+L 297.172327 206.962415 
+L 301.240887 197.005461 
+L 305.309448 194.290701 
+L 309.378008 187.624 
+L 313.498729 177.959024 
+L 317.619451 175.283599 
+L 321.688011 163.523151 
+L 325.756572 162.467465 
+L 329.825132 163.481951 
+L 333.893692 150.228293 
+L 338.014414 149.104906 
+L 342.135135 157.459522 
+L 346.203696 144.970213 
+L 350.272256 138.961392 
+L 354.340816 141.661538 
+L 358.461538 136.755217 
+L 362.582259 128.844272 
+L 366.65082 125.23404 
+L 370.71938 123.367407 
+L 374.78794 117.4 
+L 378.856501 119.072 
+L 382.977222 115.740524 
+L 387.097944 111.690732 
+L 391.166504 110.538805 
+L 395.235064 112.429189 
+L 399.303625 113.417703 
+L 403.424346 104.432941 
+L 407.545068 96.127525 
+L 411.613628 103.064467 
+L 415.682188 99.050063 
+L 419.750749 89.595259 
+L 423.819309 98.346977 
+L 427.940031 99.628258 
+L 432.060752 91.824348 
+L 436.129312 92.997838 
+L 440.197873 91.462564 
+L 444.266433 91.361739 
+L 448.334994 87.133966 
+L 452.455715 87.211111 
+L 456.576436 88.728296 
+L 460.644997 83.559178 
+L 464.713557 88.836667 
+L 468.782118 84.352752 
+L 472.902839 84.724967 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="macc6760856" d="M 0 1 
+     <path id="m942f1f9cbb" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1252,213 +1252,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#macc6760856" x="68.065432" y="121.482791" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="72.358285" y="144.935385" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="76.426845" y="163.035412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="80.495406" y="175.460344" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="84.616127" y="193.375915" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="88.736849" y="209.121993" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="92.805409" y="231.856" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="96.873969" y="237.094453" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="100.94253" y="253.176923" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="105.01109" y="263.822941" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="109.131812" y="267.171025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="113.252533" y="268.610485" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="117.321093" y="282.186197" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="121.389654" y="289.216716" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="125.458214" y="295.58214" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="129.578936" y="300.999693" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="133.699657" y="297.527835" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="137.768217" y="305.864698" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="141.836778" y="305.080554" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="145.905338" y="304.878062" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="149.973899" y="306.611852" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="154.09462" y="307.996964" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="158.215341" y="309.542046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="162.283902" y="310.615821" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="166.352462" y="309.814297" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="170.421023" y="309.9" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="174.541744" y="305.117603" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="178.662465" y="304.584672" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="182.731026" y="305.730621" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="186.799586" y="298.029935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="190.868147" y="298.094277" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="194.936707" y="297.155539" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="199.057428" y="289.626752" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="203.17815" y="286.514074" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="207.24671" y="283.764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="211.315271" y="282.336462" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="215.383831" y="274.095613" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="219.504552" y="264.608696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="223.625274" y="267.017224" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="227.693834" y="256.70237" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="231.762395" y="250.560912" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="235.830955" y="239.798974" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="239.951676" y="237.6016" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="244.072398" y="232.725128" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="248.140958" y="224.059205" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="252.209519" y="221.677067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="256.278079" y="208.193488" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="260.346639" y="201.953094" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="264.467361" y="208.169669" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="268.588082" y="195.848592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="272.656643" y="192.55169" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="276.725203" y="182.915694" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="280.793763" y="176.16679" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="284.914485" y="168.068593" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="289.035206" y="156.952688" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="293.103767" y="150.404583" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="297.172327" y="153.853145" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="301.240887" y="147.86384" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="305.309448" y="132.823234" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="309.430169" y="139.183099" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="313.55089" y="128.865972" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="317.619451" y="126.060719" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="321.688011" y="115.937" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="325.756572" y="118.11205" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="329.877293" y="104.648889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="333.998014" y="100.238451" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="338.066575" y="100.430861" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="342.135135" y="95.891262" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="346.203696" y="85.608451" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="350.272256" y="80.329197" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="354.392977" y="87.921354" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="358.513699" y="80.549325" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="362.582259" y="80.253733" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="366.65082" y="76.082308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="370.71938" y="69.686829" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="374.840101" y="67.96015" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="378.960823" y="69.009635" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="383.029383" y="61.604045" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="387.097944" y="59.84027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="391.166504" y="62.376578" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="395.235064" y="59.247162" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="399.355786" y="60.002148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="403.476507" y="51.947317" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="407.545068" y="54.102857" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="411.613628" y="59.193857" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="415.682188" y="54.396263" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="419.80291" y="50.667703" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="423.923631" y="50.403077" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="427.992192" y="48.889504" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="432.060752" y="45.398808" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="436.129312" y="50.655935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="440.197873" y="44.32345" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="444.318594" y="46.300442" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="448.439316" y="46.929311" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="452.507876" y="42.464" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="456.576436" y="42.517011" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="460.644997" y="39.195697" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="464.765718" y="39.851642" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="468.88644" y="41.695556" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#macc6760856" x="472.955" y="40.958083" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m942f1f9cbb" x="68.065432" y="317.806853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="72.358285" y="318.04" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="76.426845" y="317.430417" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="80.495406" y="316.956296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="84.563966" y="316.705668" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="88.684688" y="314.32791" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="92.805409" y="313.66252" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="96.873969" y="312.247918" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="100.94253" y="311.891159" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="105.01109" y="311.068303" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="109.131812" y="313.752821" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="113.252533" y="313.675797" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="117.321093" y="311.869524" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="121.389654" y="314.420206" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="125.458214" y="313.623396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="129.526775" y="313.408921" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="133.647496" y="313.874875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="137.768217" y="315.038974" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="141.836778" y="314.938233" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="145.905338" y="315.14297" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="149.973899" y="314.24" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="154.09462" y="313.86" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="158.215341" y="313.646007" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="162.283902" y="313.163333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="166.352462" y="313.04439" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="170.421023" y="312.600641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="174.489583" y="311.008527" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="178.610304" y="308.353931" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="182.731026" y="310.039219" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="186.799586" y="307.870951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="190.868147" y="305.5" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="194.936707" y="303.560825" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="199.057428" y="301.772708" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="203.17815" y="300.740292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="207.24671" y="297.732687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="211.315271" y="298.195848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="215.383831" y="291.092646" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="219.452391" y="287.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="223.573113" y="288.259359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="227.693834" y="285.681882" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="231.762395" y="282.928" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="235.830955" y="270.4925" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="239.899515" y="273.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="243.968076" y="268.899512" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="248.088797" y="262.579869" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="252.209519" y="255.437209" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="256.278079" y="248.713171" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="260.346639" y="248.180484" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="264.4152" y="247.048525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="268.535921" y="234.88" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="272.656643" y="234.308553" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="276.725203" y="220.104467" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="280.793763" y="219.313813" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="284.862324" y="211.021774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="288.930884" y="208.482885" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="293.051605" y="203.105036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="297.172327" y="206.962415" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="301.240887" y="197.005461" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="305.309448" y="194.290701" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="309.378008" y="187.624" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="313.498729" y="177.959024" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="317.619451" y="175.283599" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="321.688011" y="163.523151" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="325.756572" y="162.467465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="329.825132" y="163.481951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="333.893692" y="150.228293" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="338.014414" y="149.104906" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="342.135135" y="157.459522" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="346.203696" y="144.970213" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="350.272256" y="138.961392" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="354.340816" y="141.661538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="358.461538" y="136.755217" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="362.582259" y="128.844272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="366.65082" y="125.23404" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="370.71938" y="123.367407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="374.78794" y="117.4" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="378.856501" y="119.072" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="382.977222" y="115.740524" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="387.097944" y="111.690732" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="391.166504" y="110.538805" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="395.235064" y="112.429189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="399.303625" y="113.417703" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="403.424346" y="104.432941" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="407.545068" y="96.127525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="411.613628" y="103.064467" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="415.682188" y="99.050063" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="419.750749" y="89.595259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="423.819309" y="98.346977" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="427.940031" y="99.628258" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="432.060752" y="91.824348" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="436.129312" y="92.997838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="440.197873" y="91.462564" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="444.266433" y="91.361739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="448.334994" y="87.133966" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="452.455715" y="87.211111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="456.576436" y="88.728296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="460.644997" y="83.559178" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="464.713557" y="88.836667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="468.782118" y="84.352752" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m942f1f9cbb" x="472.902839" y="84.724967" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_18">
-    <path d="M 68.060216 100.9 
-L 72.358285 120.481606 
-L 76.426845 138.784 
-L 80.495406 165.237778 
-L 84.563966 179.0816 
-L 88.684688 203.42 
-L 92.805409 204.238261 
-L 96.873969 218.003925 
-L 100.94253 230.555556 
-L 105.01109 241.605714 
-L 109.131812 254.021477 
-L 113.252533 261.958333 
-L 117.321093 266.91658 
-L 121.389654 277.23 
-L 125.458214 285.506154 
-L 129.526775 286.944502 
-L 133.647496 290.642996 
-L 137.768217 297.220385 
-L 141.836778 301.094054 
-L 145.905338 302.03453 
-L 149.973899 303.3568 
-L 154.09462 305.252296 
-L 158.215341 307.59 
-L 162.283902 302.959846 
-L 166.352462 305.561471 
-L 170.421023 303.613194 
-L 174.541744 302.683688 
-L 178.662465 300.971667 
-L 182.731026 299.624615 
-L 186.799586 298.243271 
-L 190.868147 289.758959 
-L 194.936707 288.12 
-L 199.057428 282.55937 
-L 203.17815 280.906047 
-L 207.24671 273.055238 
-L 211.315271 271.032131 
-L 215.383831 264.292908 
-L 219.504552 257.37641 
-L 223.625274 256.362446 
-L 227.693834 242.028782 
-L 231.762395 237.474795 
-L 235.830955 225.774891 
-L 239.899515 218.886512 
-L 244.020237 213.658582 
-L 248.140958 203.15291 
-L 252.209519 196.033358 
-L 256.278079 181.705362 
-L 260.346639 176.446154 
-L 264.467361 169.489231 
-L 268.588082 166.494183 
-L 272.656643 149.723518 
-L 276.725203 154.445056 
-L 280.793763 140.194063 
-L 284.862324 130.53301 
-L 288.983045 126.396689 
-L 293.103767 124.023692 
-L 297.172327 114.86382 
-L 301.240887 111.873305 
-L 305.309448 100.936792 
-L 309.430169 97.400989 
-L 313.55089 96.76125 
-L 317.619451 86.035177 
-L 321.688011 90.88172 
-L 325.756572 82.761638 
-L 329.877293 77.534275 
-L 333.998014 75.333546 
-L 338.066575 69.279024 
-L 342.135135 69.111642 
-L 346.203696 60.247435 
-L 350.272256 62.599087 
-L 354.392977 59.690836 
-L 358.513699 55.461413 
-L 362.582259 54.315 
-L 366.65082 54.7 
-L 370.71938 53.028 
-L 374.840101 48.545683 
-L 378.960823 49.281481 
-L 383.029383 48.05 
-L 387.097944 47.224818 
-L 391.166504 41.43985 
-L 395.235064 42.582222 
-L 399.355786 41.496029 
-L 403.476507 38.78256 
-L 407.545068 37.794222 
-L 411.613628 39.626667 
-L 415.682188 40.122437 
-L 419.80291 36.061068 
-L 423.923631 38.208 
-L 427.992192 39.197333 
-L 432.060752 36.039849 
-L 436.129312 35.666796 
-L 440.197873 33.992923 
-L 444.318594 33.133865 
-L 448.439316 33.037333 
-L 452.507876 35.302921 
-L 456.576436 34.818205 
-L 460.644997 34.070647 
-L 464.765718 31.337364 
-L 468.88644 31.787932 
-L 472.955 31.501 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+    <path d="M 68.070648 318.04 
+L 72.358285 313.305372 
+L 76.426845 312.302745 
+L 80.495406 305.796454 
+L 84.616127 306.428889 
+L 88.736849 299.321481 
+L 92.805409 295.842759 
+L 96.873969 296.067807 
+L 100.94253 300.229565 
+L 105.063251 299.469077 
+L 109.183973 301.167445 
+L 113.252533 300.229565 
+L 117.321093 305.1425 
+L 121.389654 304.62 
+L 125.458214 306.872061 
+L 129.578936 308.876726 
+L 133.699657 308.73 
+L 137.768217 311.67913 
+L 141.836778 309.510769 
+L 145.905338 311.143 
+L 150.02606 310.698007 
+L 154.146781 310.1664 
+L 158.215341 312.739275 
+L 162.283902 312.902748 
+L 166.352462 309.422329 
+L 170.421023 309.49 
+L 174.541744 306.172308 
+L 178.662465 306.968649 
+L 182.731026 302.12256 
+L 186.799586 302.966667 
+L 190.868147 298.600137 
+L 194.988868 300.096585 
+L 199.109589 296.095 
+L 203.17815 291.065938 
+L 207.24671 284.687692 
+L 211.315271 286.179111 
+L 215.383831 277.03619 
+L 219.504552 277.033285 
+L 223.625274 269.648462 
+L 227.693834 263.066667 
+L 231.762395 259.06102 
+L 235.830955 249.729582 
+L 239.951676 252.433594 
+L 244.072398 235.599416 
+L 248.140958 235.87792 
+L 252.209519 225.649904 
+L 256.278079 217.478556 
+L 260.346639 209.201667 
+L 264.467361 197.28791 
+L 268.588082 199.71854 
+L 272.656643 193.992751 
+L 276.725203 189.205271 
+L 280.793763 181.572308 
+L 284.914485 170.22 
+L 289.035206 159.64311 
+L 293.103767 160.199203 
+L 297.172327 157.210897 
+L 301.240887 148.272082 
+L 305.309448 142.48 
+L 309.430169 135.399288 
+L 313.55089 138.770986 
+L 317.619451 122.628693 
+L 321.688011 121.109215 
+L 325.756572 118.096667 
+L 329.877293 108.542751 
+L 333.998014 114.737185 
+L 338.066575 106.011014 
+L 342.135135 100.087559 
+L 346.203696 94.699625 
+L 350.272256 101.306319 
+L 354.392977 94.359024 
+L 358.513699 87.68212 
+L 362.582259 86.874789 
+L 366.65082 80.66 
+L 370.71938 78.45812 
+L 374.840101 83.550769 
+L 378.960823 77.207692 
+L 383.029383 73.870345 
+L 387.097944 69.064 
+L 391.166504 69.33 
+L 395.235064 74.750295 
+L 399.355786 67.717714 
+L 403.476507 67.59957 
+L 407.545068 63.605217 
+L 411.613628 62.793191 
+L 415.682188 67.173386 
+L 419.80291 59.96259 
+L 423.923631 63.703077 
+L 427.992192 61.21371 
+L 432.060752 57.054253 
+L 436.129312 62.129655 
+L 440.197873 61.359172 
+L 444.318594 57.436547 
+L 448.439316 58.88 
+L 452.507876 57.685714 
+L 456.576436 56.707004 
+L 460.644997 55.350222 
+L 464.765718 56.96662 
+L 468.88644 55.659344 
+L 472.955 50.745946 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m822c9ce222" d="M 0 1 
+     <path id="m4d42af8b23" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1470,213 +1470,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#m822c9ce222" x="68.060216" y="100.9" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="72.358285" y="120.481606" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="76.426845" y="138.784" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="80.495406" y="165.237778" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="84.563966" y="179.0816" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="88.684688" y="203.42" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="92.805409" y="204.238261" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="96.873969" y="218.003925" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="100.94253" y="230.555556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="105.01109" y="241.605714" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="109.131812" y="254.021477" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="113.252533" y="261.958333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="117.321093" y="266.91658" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="121.389654" y="277.23" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="125.458214" y="285.506154" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="129.526775" y="286.944502" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="133.647496" y="290.642996" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="137.768217" y="297.220385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="141.836778" y="301.094054" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="145.905338" y="302.03453" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="149.973899" y="303.3568" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="154.09462" y="305.252296" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="158.215341" y="307.59" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="162.283902" y="302.959846" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="166.352462" y="305.561471" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="170.421023" y="303.613194" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="174.541744" y="302.683688" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="178.662465" y="300.971667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="182.731026" y="299.624615" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="186.799586" y="298.243271" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="190.868147" y="289.758959" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="194.936707" y="288.12" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="199.057428" y="282.55937" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="203.17815" y="280.906047" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="207.24671" y="273.055238" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="211.315271" y="271.032131" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="215.383831" y="264.292908" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="219.504552" y="257.37641" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="223.625274" y="256.362446" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="227.693834" y="242.028782" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="231.762395" y="237.474795" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="235.830955" y="225.774891" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="239.899515" y="218.886512" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="244.020237" y="213.658582" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="248.140958" y="203.15291" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="252.209519" y="196.033358" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="256.278079" y="181.705362" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="260.346639" y="176.446154" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="264.467361" y="169.489231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="268.588082" y="166.494183" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="272.656643" y="149.723518" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="276.725203" y="154.445056" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="280.793763" y="140.194063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="284.862324" y="130.53301" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="288.983045" y="126.396689" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="293.103767" y="124.023692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="297.172327" y="114.86382" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="301.240887" y="111.873305" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="305.309448" y="100.936792" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="309.430169" y="97.400989" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="313.55089" y="96.76125" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="317.619451" y="86.035177" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="321.688011" y="90.88172" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="325.756572" y="82.761638" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="329.877293" y="77.534275" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="333.998014" y="75.333546" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="338.066575" y="69.279024" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="342.135135" y="69.111642" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="346.203696" y="60.247435" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="350.272256" y="62.599087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="354.392977" y="59.690836" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="358.513699" y="55.461413" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="362.582259" y="54.315" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="366.65082" y="54.7" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="370.71938" y="53.028" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="374.840101" y="48.545683" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="378.960823" y="49.281481" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="383.029383" y="48.05" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="387.097944" y="47.224818" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="391.166504" y="41.43985" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="395.235064" y="42.582222" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="399.355786" y="41.496029" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="403.476507" y="38.78256" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="407.545068" y="37.794222" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="411.613628" y="39.626667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="415.682188" y="40.122437" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="419.80291" y="36.061068" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="423.923631" y="38.208" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="427.992192" y="39.197333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="432.060752" y="36.039849" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="436.129312" y="35.666796" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="440.197873" y="33.992923" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="444.318594" y="33.133865" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="448.439316" y="33.037333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="452.507876" y="35.302921" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="456.576436" y="34.818205" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="460.644997" y="34.070647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="464.765718" y="31.337364" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="468.88644" y="31.787932" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m822c9ce222" x="472.955" y="31.501" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m4d42af8b23" x="68.070648" y="318.04" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="72.358285" y="313.305372" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="76.426845" y="312.302745" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="80.495406" y="305.796454" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="84.616127" y="306.428889" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="88.736849" y="299.321481" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="92.805409" y="295.842759" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="96.873969" y="296.067807" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="100.94253" y="300.229565" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="105.063251" y="299.469077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="109.183973" y="301.167445" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="113.252533" y="300.229565" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="117.321093" y="305.1425" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="121.389654" y="304.62" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="125.458214" y="306.872061" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="129.578936" y="308.876726" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="133.699657" y="308.73" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="137.768217" y="311.67913" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="141.836778" y="309.510769" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="145.905338" y="311.143" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="150.02606" y="310.698007" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="154.146781" y="310.1664" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="158.215341" y="312.739275" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="162.283902" y="312.902748" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="166.352462" y="309.422329" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="170.421023" y="309.49" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="174.541744" y="306.172308" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="178.662465" y="306.968649" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="182.731026" y="302.12256" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="186.799586" y="302.966667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="190.868147" y="298.600137" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="194.988868" y="300.096585" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="199.109589" y="296.095" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="203.17815" y="291.065938" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="207.24671" y="284.687692" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="211.315271" y="286.179111" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="215.383831" y="277.03619" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="219.504552" y="277.033285" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="223.625274" y="269.648462" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="227.693834" y="263.066667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="231.762395" y="259.06102" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="235.830955" y="249.729582" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="239.951676" y="252.433594" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="244.072398" y="235.599416" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="248.140958" y="235.87792" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="252.209519" y="225.649904" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="256.278079" y="217.478556" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="260.346639" y="209.201667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="264.467361" y="197.28791" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="268.588082" y="199.71854" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="272.656643" y="193.992751" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="276.725203" y="189.205271" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="280.793763" y="181.572308" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="284.914485" y="170.22" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="289.035206" y="159.64311" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="293.103767" y="160.199203" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="297.172327" y="157.210897" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="301.240887" y="148.272082" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="305.309448" y="142.48" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="309.430169" y="135.399288" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="313.55089" y="138.770986" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="317.619451" y="122.628693" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="321.688011" y="121.109215" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="325.756572" y="118.096667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="329.877293" y="108.542751" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="333.998014" y="114.737185" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="338.066575" y="106.011014" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="342.135135" y="100.087559" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="346.203696" y="94.699625" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="350.272256" y="101.306319" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="354.392977" y="94.359024" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="358.513699" y="87.68212" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="362.582259" y="86.874789" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="366.65082" y="80.66" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="370.71938" y="78.45812" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="374.840101" y="83.550769" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="378.960823" y="77.207692" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="383.029383" y="73.870345" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="387.097944" y="69.064" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="391.166504" y="69.33" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="395.235064" y="74.750295" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="399.355786" y="67.717714" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="403.476507" y="67.59957" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="407.545068" y="63.605217" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="411.613628" y="62.793191" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="415.682188" y="67.173386" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="419.80291" y="59.96259" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="423.923631" y="63.703077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="427.992192" y="61.21371" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="432.060752" y="57.054253" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="436.129312" y="62.129655" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="440.197873" y="61.359172" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="444.318594" y="57.436547" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="448.439316" y="58.88" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="452.507876" y="57.685714" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="456.576436" y="56.707004" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="460.644997" y="55.350222" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="464.765718" y="56.96662" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="468.88644" y="55.659344" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m4d42af8b23" x="472.955" y="50.745946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_19">
-    <path d="M 68.060216 108.28 
-L 72.358285 133.515234 
-L 76.426845 150.693333 
-L 80.495406 172.560374 
-L 84.563966 193.112522 
-L 88.684688 212.226286 
-L 92.805409 216.255214 
-L 96.873969 236.689327 
-L 100.94253 239.840708 
-L 105.01109 256.410242 
-L 109.131812 267.130224 
-L 113.252533 277.570945 
-L 117.321093 282.817062 
-L 121.389654 287.796471 
-L 125.458214 293.313239 
-L 129.526775 291.797848 
-L 133.647496 297.931806 
-L 137.768217 303.284957 
-L 141.836778 302.666102 
-L 145.905338 305.669919 
-L 149.973899 305.971673 
-L 154.09462 305.090894 
-L 158.215341 305.48206 
-L 162.283902 309.611193 
-L 166.352462 302.966667 
-L 170.421023 306.336 
-L 174.541744 301.96018 
-L 178.662465 304.629167 
-L 182.731026 295.5725 
-L 186.799586 297.626047 
-L 190.868147 291.706 
-L 194.936707 287.529573 
-L 199.057428 287.433305 
-L 203.17815 284.422128 
-L 207.24671 275.433333 
-L 211.315271 270.945333 
-L 215.383831 271.661079 
-L 219.504552 268.845896 
-L 223.625274 254.475172 
-L 227.693834 250.781719 
-L 231.762395 246.943333 
-L 235.830955 241.054951 
-L 239.899515 233.172133 
-L 244.020237 223.04 
-L 248.140958 217.241233 
-L 252.209519 202.721176 
-L 256.278079 193.656314 
-L 260.346639 188.729677 
-L 264.467361 186.935107 
-L 268.588082 172.516814 
-L 272.656643 164.391598 
-L 276.725203 162.074932 
-L 280.793763 147.085741 
-L 284.862324 144.16 
-L 288.983045 145.207627 
-L 293.103767 131.195874 
-L 297.172327 124.974017 
-L 301.240887 115.646439 
-L 305.309448 108.6 
-L 309.430169 113.575385 
-L 313.55089 97.953913 
-L 317.619451 100.390615 
-L 321.688011 94.554138 
-L 325.756572 90.279061 
-L 329.825132 93.509289 
-L 333.945853 85.019186 
-L 338.066575 74.018378 
-L 342.135135 75.751312 
-L 346.203696 69.33 
-L 350.272256 65.027059 
-L 354.392977 65.189434 
-L 358.513699 62.209204 
-L 362.582259 66.273956 
-L 366.65082 57.588326 
-L 370.71938 55.350222 
-L 374.840101 52.293333 
-L 378.960823 50.452581 
-L 383.029383 51.137913 
-L 387.097944 48.05 
-L 391.166504 52.639437 
-L 395.235064 44.683063 
-L 399.355786 45.40891 
-L 403.476507 43.365045 
-L 407.545068 43.547085 
-L 411.613628 44.69 
-L 415.682188 44.774802 
-L 419.80291 41.533 
-L 423.923631 38.099429 
-L 427.992192 37.65287 
-L 432.060752 37.040881 
-L 436.129312 34.481717 
-L 440.197873 35.681 
-L 444.318594 35.193333 
-L 448.439316 36.623822 
-L 452.507876 39.837778 
-L 456.576436 35.033443 
-L 460.644997 33.942906 
-L 464.765718 34.512868 
-L 468.88644 32.103168 
-L 472.955 33.763966 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
+    <path d="M 68.060216 317.763962 
+L 72.358285 316.881188 
+L 76.426845 315.960609 
+L 80.495406 315.590326 
+L 84.563966 312.922281 
+L 88.684688 309.036923 
+L 92.805409 307.625424 
+L 96.873969 307.966885 
+L 100.94253 305.89434 
+L 105.01109 307.781514 
+L 109.131812 306.968649 
+L 113.252533 305.785812 
+L 117.321093 308.286667 
+L 121.389654 309.401333 
+L 125.458214 311.182187 
+L 129.526775 312.962922 
+L 133.647496 314.514699 
+L 137.768217 313.257115 
+L 141.836778 315.216667 
+L 145.905338 313.117757 
+L 149.973899 313.669212 
+L 154.042459 314.298995 
+L 158.16318 312.892407 
+L 162.283902 313.764566 
+L 166.352462 313.187122 
+L 170.421023 312.931111 
+L 174.489583 311.113143 
+L 178.610304 309.276135 
+L 182.731026 308.837258 
+L 186.799586 307.245049 
+L 190.868147 304.605447 
+L 194.936707 299.220793 
+L 199.005267 295.574976 
+L 203.125989 298.369412 
+L 207.24671 294.96169 
+L 211.315271 292.170644 
+L 215.383831 288.649956 
+L 219.452391 286.624 
+L 223.520952 277.663755 
+L 227.641673 285.074585 
+L 231.762395 268.623111 
+L 235.830955 269.100708 
+L 239.899515 260.467692 
+L 243.968076 254.386667 
+L 248.088797 252.333333 
+L 252.209519 250.914118 
+L 256.278079 244.760531 
+L 260.346639 237.322759 
+L 264.4152 227.853333 
+L 268.48376 234.097377 
+L 272.604481 217.17 
+L 276.725203 203.260429 
+L 280.793763 200.035385 
+L 284.862324 201.254435 
+L 288.930884 193.293663 
+L 293.051605 195.098824 
+L 297.172327 187.924103 
+L 301.240887 177.425592 
+L 305.309448 168.827867 
+L 309.378008 169.08 
+L 313.446568 161.986667 
+L 317.56729 157.235043 
+L 321.688011 147.643529 
+L 325.756572 142.931892 
+L 329.825132 144.32315 
+L 333.893692 144.44 
+L 337.962253 134.6425 
+L 342.082974 127.533333 
+L 346.203696 129.788916 
+L 350.272256 123.357323 
+L 354.340816 120.535 
+L 358.409377 111.21589 
+L 362.530098 117.440192 
+L 366.65082 107.866043 
+L 370.71938 104.784685 
+L 374.78794 109.475829 
+L 378.856501 106.313133 
+L 382.925061 96.776364 
+L 387.045783 100.984 
+L 391.166504 95.234495 
+L 395.235064 91.01375 
+L 399.303625 94.194439 
+L 403.372185 92.926774 
+L 407.492907 80.865192 
+L 411.613628 86.526667 
+L 415.682188 84.437714 
+L 419.750749 83.420645 
+L 423.819309 80.984407 
+L 427.88787 82.478481 
+L 432.008591 76.72973 
+L 436.129312 78.328368 
+L 440.197873 76.246 
+L 444.266433 72.097838 
+L 448.334994 73.255122 
+L 452.403554 72.151031 
+L 456.524275 82.018578 
+L 460.644997 72.053333 
+L 464.713557 73.615556 
+L 468.782118 72.121985 
+L 472.850678 69.268787 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
     <defs>
-     <path id="mbb0db5921f" d="M 0 1 
+     <path id="m75121de8ea" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1688,213 +1688,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#mbb0db5921f" x="68.060216" y="108.28" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="72.358285" y="133.515234" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="76.426845" y="150.693333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="80.495406" y="172.560374" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="84.563966" y="193.112522" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="88.684688" y="212.226286" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="92.805409" y="216.255214" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="96.873969" y="236.689327" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="100.94253" y="239.840708" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="105.01109" y="256.410242" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="109.131812" y="267.130224" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="113.252533" y="277.570945" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="117.321093" y="282.817062" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="121.389654" y="287.796471" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="125.458214" y="293.313239" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="129.526775" y="291.797848" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="133.647496" y="297.931806" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="137.768217" y="303.284957" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="141.836778" y="302.666102" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="145.905338" y="305.669919" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="149.973899" y="305.971673" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="154.09462" y="305.090894" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="158.215341" y="305.48206" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="162.283902" y="309.611193" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="166.352462" y="302.966667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="170.421023" y="306.336" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="174.541744" y="301.96018" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="178.662465" y="304.629167" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="182.731026" y="295.5725" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="186.799586" y="297.626047" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="190.868147" y="291.706" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="194.936707" y="287.529573" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="199.057428" y="287.433305" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="203.17815" y="284.422128" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="207.24671" y="275.433333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="211.315271" y="270.945333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="215.383831" y="271.661079" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="219.504552" y="268.845896" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="223.625274" y="254.475172" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="227.693834" y="250.781719" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="231.762395" y="246.943333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="235.830955" y="241.054951" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="239.899515" y="233.172133" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="244.020237" y="223.04" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="248.140958" y="217.241233" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="252.209519" y="202.721176" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="256.278079" y="193.656314" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="260.346639" y="188.729677" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="264.467361" y="186.935107" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="268.588082" y="172.516814" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="272.656643" y="164.391598" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="276.725203" y="162.074932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="280.793763" y="147.085741" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="284.862324" y="144.16" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="288.983045" y="145.207627" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="293.103767" y="131.195874" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="297.172327" y="124.974017" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="301.240887" y="115.646439" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="305.309448" y="108.6" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="309.430169" y="113.575385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="313.55089" y="97.953913" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="317.619451" y="100.390615" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="321.688011" y="94.554138" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="325.756572" y="90.279061" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="329.825132" y="93.509289" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="333.945853" y="85.019186" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="338.066575" y="74.018378" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="342.135135" y="75.751312" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="346.203696" y="69.33" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="350.272256" y="65.027059" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="354.392977" y="65.189434" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="358.513699" y="62.209204" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="362.582259" y="66.273956" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="366.65082" y="57.588326" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="370.71938" y="55.350222" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="374.840101" y="52.293333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="378.960823" y="50.452581" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="383.029383" y="51.137913" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="387.097944" y="48.05" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="391.166504" y="52.639437" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="395.235064" y="44.683063" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="399.355786" y="45.40891" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="403.476507" y="43.365045" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="407.545068" y="43.547085" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="411.613628" y="44.69" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="415.682188" y="44.774802" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="419.80291" y="41.533" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="423.923631" y="38.099429" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="427.992192" y="37.65287" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="432.060752" y="37.040881" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="436.129312" y="34.481717" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="440.197873" y="35.681" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="444.318594" y="35.193333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="448.439316" y="36.623822" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="452.507876" y="39.837778" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="456.576436" y="35.033443" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="460.644997" y="33.942906" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="464.765718" y="34.512868" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="468.88644" y="32.103168" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbb0db5921f" x="472.955" y="33.763966" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m75121de8ea" x="68.060216" y="317.763962" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="72.358285" y="316.881188" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="76.426845" y="315.960609" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="80.495406" y="315.590326" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="84.563966" y="312.922281" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="88.684688" y="309.036923" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="92.805409" y="307.625424" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="96.873969" y="307.966885" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="100.94253" y="305.89434" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="105.01109" y="307.781514" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="109.131812" y="306.968649" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="113.252533" y="305.785812" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="117.321093" y="308.286667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="121.389654" y="309.401333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="125.458214" y="311.182187" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="129.526775" y="312.962922" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="133.647496" y="314.514699" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="137.768217" y="313.257115" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="141.836778" y="315.216667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="145.905338" y="313.117757" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="149.973899" y="313.669212" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="154.042459" y="314.298995" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="158.16318" y="312.892407" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="162.283902" y="313.764566" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="166.352462" y="313.187122" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="170.421023" y="312.931111" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="174.489583" y="311.113143" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="178.610304" y="309.276135" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="182.731026" y="308.837258" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="186.799586" y="307.245049" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="190.868147" y="304.605447" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="194.936707" y="299.220793" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="199.005267" y="295.574976" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="203.125989" y="298.369412" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="207.24671" y="294.96169" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="211.315271" y="292.170644" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="215.383831" y="288.649956" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="219.452391" y="286.624" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="223.520952" y="277.663755" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="227.641673" y="285.074585" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="231.762395" y="268.623111" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="235.830955" y="269.100708" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="239.899515" y="260.467692" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="243.968076" y="254.386667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="248.088797" y="252.333333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="252.209519" y="250.914118" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="256.278079" y="244.760531" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="260.346639" y="237.322759" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="264.4152" y="227.853333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="268.48376" y="234.097377" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="272.604481" y="217.17" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="276.725203" y="203.260429" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="280.793763" y="200.035385" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="284.862324" y="201.254435" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="288.930884" y="193.293663" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="293.051605" y="195.098824" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="297.172327" y="187.924103" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="301.240887" y="177.425592" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="305.309448" y="168.827867" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="309.378008" y="169.08" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="313.446568" y="161.986667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="317.56729" y="157.235043" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="321.688011" y="147.643529" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="325.756572" y="142.931892" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="329.825132" y="144.32315" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="333.893692" y="144.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="337.962253" y="134.6425" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="342.082974" y="127.533333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="346.203696" y="129.788916" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="350.272256" y="123.357323" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="354.340816" y="120.535" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="358.409377" y="111.21589" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="362.530098" y="117.440192" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="366.65082" y="107.866043" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="370.71938" y="104.784685" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="374.78794" y="109.475829" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="378.856501" y="106.313133" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="382.925061" y="96.776364" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="387.045783" y="100.984" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="391.166504" y="95.234495" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="395.235064" y="91.01375" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="399.303625" y="94.194439" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="403.372185" y="92.926774" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="407.492907" y="80.865192" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="411.613628" y="86.526667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="415.682188" y="84.437714" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="419.750749" y="83.420645" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="423.819309" y="80.984407" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="427.88787" y="82.478481" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="432.008591" y="76.72973" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="436.129312" y="78.328368" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="440.197873" y="76.246" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="444.266433" y="72.097838" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="448.334994" y="73.255122" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="452.403554" y="72.151031" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="456.524275" y="82.018578" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="460.644997" y="72.053333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="464.713557" y="73.615556" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="468.782118" y="72.121985" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m75121de8ea" x="472.850678" y="69.268787" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_20">
-    <path d="M 68.060216 181.069275 
-L 72.358285 191.698808 
-L 76.426845 196.998632 
-L 80.495406 199.049333 
-L 84.563966 222.28 
-L 88.684688 238.4 
-L 92.805409 232.003974 
-L 96.873969 249.245496 
-L 100.94253 258.677986 
-L 105.01109 275.565806 
-L 109.131812 276.175692 
-L 113.252533 278.33 
-L 117.321093 288.40962 
-L 121.389654 287.742411 
-L 125.458214 292.577099 
-L 129.526775 299.49493 
-L 133.647496 300.600265 
-L 137.768217 304.475762 
-L 141.836778 305.932414 
-L 145.905338 301.118554 
-L 149.973899 302.407945 
-L 154.09462 305.918 
-L 158.215341 304.825806 
-L 162.283902 303.191642 
-L 166.352462 308.627692 
-L 170.421023 304.894203 
-L 174.489583 304.638473 
-L 178.610304 304.910513 
-L 182.731026 305.945867 
-L 186.799586 301.32 
-L 190.868147 302.662482 
-L 194.936707 295.21305 
-L 199.057428 294.867651 
-L 203.17815 293.331556 
-L 207.24671 295.43 
-L 211.315271 293.692263 
-L 215.383831 282.928 
-L 219.504552 284.532581 
-L 223.625274 278.883235 
-L 227.693834 274.846667 
-L 231.762395 275.731622 
-L 235.830955 280.327111 
-L 239.899515 268.998592 
-L 244.020237 267.695588 
-L 248.140958 263.730072 
-L 252.209519 255.285 
-L 256.278079 261.423089 
-L 260.346639 247.663007 
-L 264.467361 249.342609 
-L 268.588082 242.045278 
-L 272.656643 236.112 
-L 276.725203 227.559077 
-L 280.793763 227.887568 
-L 284.862324 223.057538 
-L 288.983045 227.821667 
-L 293.103767 214.318345 
-L 297.172327 209.866667 
-L 301.240887 205.876667 
-L 305.309448 202.219167 
-L 309.430169 198.99589 
-L 313.55089 196.203279 
-L 317.619451 184.218529 
-L 321.688011 185.843741 
-L 325.756572 174.05554 
-L 329.877293 166.863333 
-L 333.998014 169.996026 
-L 338.066575 159.320288 
-L 342.135135 151.420556 
-L 346.203696 156.508767 
-L 350.272256 144.457027 
-L 354.392977 147.111079 
-L 358.513699 147.1 
-L 362.582259 137.683279 
-L 366.65082 130.612308 
-L 370.71938 130.612308 
-L 374.840101 120.898156 
-L 378.960823 113.22 
-L 383.029383 118.471795 
-L 387.097944 115.592432 
-L 391.166504 109.641439 
-L 395.235064 104.001096 
-L 399.355786 103.023333 
-L 403.476507 96.816667 
-L 407.545068 101.147692 
-L 411.613628 90.417379 
-L 415.682188 87.352464 
-L 419.80291 93.646069 
-L 423.923631 89.812 
-L 427.992192 82.367619 
-L 432.060752 77.371656 
-L 436.129312 83.233043 
-L 440.197873 82.805 
-L 444.318594 71.508936 
-L 448.439316 71.286879 
-L 452.507876 79.226765 
-L 456.576436 67.24 
-L 460.644997 77.164129 
-L 464.765718 68 
-L 468.88644 70.421791 
-L 472.955 68.354667 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
+    <path d="M 68.060216 318.04 
+L 72.358285 318.04 
+L 76.426845 318.04 
+L 80.495406 318.04 
+L 84.563966 318.04 
+L 88.684688 317.146565 
+L 92.805409 318.04 
+L 96.873969 316.5 
+L 100.94253 316.861745 
+L 105.01109 318.04 
+L 109.131812 315.567324 
+L 113.252533 315.601667 
+L 117.321093 314.912977 
+L 121.389654 316.479467 
+L 125.458214 316.182222 
+L 129.526775 315.888529 
+L 133.647496 315.359695 
+L 137.768217 316.468993 
+L 141.836778 316.343768 
+L 145.905338 315.872593 
+L 149.973899 315.290738 
+L 154.09462 315.027941 
+L 158.215341 313.47461 
+L 162.283902 315.134752 
+L 166.352462 312.756944 
+L 170.421023 314.059048 
+L 174.489583 314.575 
+L 178.610304 310.825205 
+L 182.731026 309.552366 
+L 186.799586 308.661795 
+L 190.868147 310.454074 
+L 194.936707 308.561408 
+L 199.057428 307.636444 
+L 203.17815 307.014493 
+L 207.24671 300.666875 
+L 211.315271 307.0675 
+L 215.383831 304.222778 
+L 219.452391 299.805507 
+L 223.573113 301.808175 
+L 227.693834 297.685217 
+L 231.762395 296.958261 
+L 235.830955 299.23 
+L 239.899515 295.637812 
+L 244.020237 290.6192 
+L 248.140958 295.305612 
+L 252.209519 280.838 
+L 256.278079 286.590476 
+L 260.346639 280.298841 
+L 264.4152 282.45984 
+L 268.535921 278.084966 
+L 272.656643 273.873962 
+L 276.725203 263.76058 
+L 280.793763 269.771679 
+L 284.862324 266.835 
+L 288.983045 270.342192 
+L 293.103767 259.923586 
+L 297.172327 254.504 
+L 301.240887 253.017778 
+L 305.309448 253.668 
+L 309.378008 243.599118 
+L 313.498729 242.673333 
+L 317.619451 238.362769 
+L 321.688011 229.16 
+L 325.756572 233.471463 
+L 329.825132 235.678519 
+L 333.945853 239.058462 
+L 338.066575 227.264882 
+L 342.135135 217.17626 
+L 346.203696 219.778806 
+L 350.272256 218.703529 
+L 354.340816 212.429688 
+L 358.461538 214.743333 
+L 362.582259 209.640537 
+L 366.65082 207.700763 
+L 370.71938 201.88 
+L 374.78794 202.090435 
+L 378.856501 194.864839 
+L 382.977222 188.278261 
+L 387.097944 187.251325 
+L 391.166504 189.776986 
+L 395.235064 184.341022 
+L 399.303625 193.08 
+L 403.424346 184.28 
+L 407.545068 173.483974 
+L 411.613628 177.023056 
+L 415.682188 179.158028 
+L 419.750749 175.641333 
+L 423.819309 187.025075 
+L 427.940031 168.69696 
+L 432.060752 179.276667 
+L 436.129312 165.30695 
+L 440.197873 175.097705 
+L 444.266433 161.486496 
+L 448.387155 162.267338 
+L 452.507876 162.393056 
+L 456.576436 157.816276 
+L 460.644997 147.485 
+L 464.713557 154.867445 
+L 468.782118 160.116164 
+L 472.902839 152.370704 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
-     <path id="mef0e140f3f" d="M 0 1 
+     <path id="m593a170770" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1906,213 +1906,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#mef0e140f3f" x="68.060216" y="181.069275" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="72.358285" y="191.698808" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="76.426845" y="196.998632" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="80.495406" y="199.049333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="84.563966" y="222.28" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="88.684688" y="238.4" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="92.805409" y="232.003974" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="96.873969" y="249.245496" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="100.94253" y="258.677986" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="105.01109" y="275.565806" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="109.131812" y="276.175692" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="113.252533" y="278.33" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="117.321093" y="288.40962" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="121.389654" y="287.742411" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="125.458214" y="292.577099" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="129.526775" y="299.49493" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="133.647496" y="300.600265" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="137.768217" y="304.475762" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="141.836778" y="305.932414" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="145.905338" y="301.118554" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="149.973899" y="302.407945" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="154.09462" y="305.918" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="158.215341" y="304.825806" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="162.283902" y="303.191642" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="166.352462" y="308.627692" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="170.421023" y="304.894203" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="174.489583" y="304.638473" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="178.610304" y="304.910513" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="182.731026" y="305.945867" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="186.799586" y="301.32" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="190.868147" y="302.662482" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="194.936707" y="295.21305" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="199.057428" y="294.867651" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="203.17815" y="293.331556" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="207.24671" y="295.43" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="211.315271" y="293.692263" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="215.383831" y="282.928" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="219.504552" y="284.532581" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="223.625274" y="278.883235" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="227.693834" y="274.846667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="231.762395" y="275.731622" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="235.830955" y="280.327111" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="239.899515" y="268.998592" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="244.020237" y="267.695588" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="248.140958" y="263.730072" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="252.209519" y="255.285" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="256.278079" y="261.423089" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="260.346639" y="247.663007" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="264.467361" y="249.342609" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="268.588082" y="242.045278" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="272.656643" y="236.112" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="276.725203" y="227.559077" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="280.793763" y="227.887568" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="284.862324" y="223.057538" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="288.983045" y="227.821667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="293.103767" y="214.318345" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="297.172327" y="209.866667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="301.240887" y="205.876667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="305.309448" y="202.219167" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="309.430169" y="198.99589" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="313.55089" y="196.203279" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="317.619451" y="184.218529" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="321.688011" y="185.843741" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="325.756572" y="174.05554" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="329.877293" y="166.863333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="333.998014" y="169.996026" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="338.066575" y="159.320288" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="342.135135" y="151.420556" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="346.203696" y="156.508767" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="350.272256" y="144.457027" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="354.392977" y="147.111079" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="358.513699" y="147.1" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="362.582259" y="137.683279" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="366.65082" y="130.612308" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="370.71938" y="130.612308" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="374.840101" y="120.898156" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="378.960823" y="113.22" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="383.029383" y="118.471795" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="387.097944" y="115.592432" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="391.166504" y="109.641439" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="395.235064" y="104.001096" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="399.355786" y="103.023333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="403.476507" y="96.816667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="407.545068" y="101.147692" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="411.613628" y="90.417379" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="415.682188" y="87.352464" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="419.80291" y="93.646069" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="423.923631" y="89.812" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="427.992192" y="82.367619" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="432.060752" y="77.371656" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="436.129312" y="83.233043" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="440.197873" y="82.805" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="444.318594" y="71.508936" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="448.439316" y="71.286879" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="452.507876" y="79.226765" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="456.576436" y="67.24" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="460.644997" y="77.164129" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="464.765718" y="68" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="468.88644" y="70.421791" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#mef0e140f3f" x="472.955" y="68.354667" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m593a170770" x="68.060216" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="72.358285" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="76.426845" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="80.495406" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="84.563966" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="88.684688" y="317.146565" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="92.805409" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="96.873969" y="316.5" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="100.94253" y="316.861745" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="105.01109" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="109.131812" y="315.567324" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="113.252533" y="315.601667" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="117.321093" y="314.912977" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="121.389654" y="316.479467" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="125.458214" y="316.182222" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="129.526775" y="315.888529" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="133.647496" y="315.359695" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="137.768217" y="316.468993" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="141.836778" y="316.343768" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="145.905338" y="315.872593" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="149.973899" y="315.290738" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="154.09462" y="315.027941" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="158.215341" y="313.47461" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="162.283902" y="315.134752" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="166.352462" y="312.756944" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="170.421023" y="314.059048" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="174.489583" y="314.575" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="178.610304" y="310.825205" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="182.731026" y="309.552366" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="186.799586" y="308.661795" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="190.868147" y="310.454074" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="194.936707" y="308.561408" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="199.057428" y="307.636444" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="203.17815" y="307.014493" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="207.24671" y="300.666875" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="211.315271" y="307.0675" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="215.383831" y="304.222778" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="219.452391" y="299.805507" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="223.573113" y="301.808175" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="227.693834" y="297.685217" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="231.762395" y="296.958261" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="235.830955" y="299.23" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="239.899515" y="295.637812" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="244.020237" y="290.6192" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="248.140958" y="295.305612" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="252.209519" y="280.838" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="256.278079" y="286.590476" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="260.346639" y="280.298841" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="264.4152" y="282.45984" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="268.535921" y="278.084966" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="272.656643" y="273.873962" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="276.725203" y="263.76058" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="280.793763" y="269.771679" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="284.862324" y="266.835" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="288.983045" y="270.342192" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="293.103767" y="259.923586" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="297.172327" y="254.504" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="301.240887" y="253.017778" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="305.309448" y="253.668" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="309.378008" y="243.599118" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="313.498729" y="242.673333" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="317.619451" y="238.362769" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="321.688011" y="229.16" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="325.756572" y="233.471463" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="329.825132" y="235.678519" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="333.945853" y="239.058462" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="338.066575" y="227.264882" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="342.135135" y="217.17626" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="346.203696" y="219.778806" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="350.272256" y="218.703529" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="354.340816" y="212.429688" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="358.461538" y="214.743333" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="362.582259" y="209.640537" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="366.65082" y="207.700763" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="370.71938" y="201.88" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="374.78794" y="202.090435" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="378.856501" y="194.864839" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="382.977222" y="188.278261" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="387.097944" y="187.251325" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="391.166504" y="189.776986" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="395.235064" y="184.341022" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="399.303625" y="193.08" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="403.424346" y="184.28" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="407.545068" y="173.483974" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="411.613628" y="177.023056" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="415.682188" y="179.158028" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="419.750749" y="175.641333" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="423.819309" y="187.025075" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="427.940031" y="168.69696" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="432.060752" y="179.276667" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="436.129312" y="165.30695" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="440.197873" y="175.097705" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="444.266433" y="161.486496" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="448.387155" y="162.267338" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="452.507876" y="162.393056" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="456.576436" y="157.816276" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="460.644997" y="147.485" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="464.713557" y="154.867445" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="468.782118" y="160.116164" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#m593a170770" x="472.902839" y="152.370704" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
    <g id="line2d_21">
-    <path d="M 68.081081 88.343521 
-L 72.358285 102.805424 
-L 76.426845 125.229701 
-L 80.547567 133.971773 
-L 84.668288 147.74259 
-L 88.736849 161.129231 
-L 92.805409 175.538667 
-L 96.873969 192.48403 
-L 100.994691 200.804933 
-L 105.115412 212.895869 
-L 109.183973 235.862979 
-L 113.252533 242.19808 
-L 117.321093 252.967568 
-L 121.389654 269.593115 
-L 125.510375 276.86885 
-L 129.631097 281.908333 
-L 133.699657 285.9072 
-L 137.768217 289.888333 
-L 141.836778 297.038049 
-L 145.957499 301.379502 
-L 150.078221 303.307692 
-L 154.146781 302.764559 
-L 158.215341 308.133071 
-L 162.283902 305.660769 
-L 166.352462 304.825806 
-L 170.473184 305.327034 
-L 174.593905 302.65 
-L 178.662465 296.491119 
-L 182.731026 297.154074 
-L 186.799586 291.8656 
-L 190.868147 283.603231 
-L 194.988868 274.404878 
-L 199.109589 273.238974 
-L 203.17815 259.735941 
-L 207.24671 253.871351 
-L 211.315271 245.285405 
-L 215.435992 236.384186 
-L 219.556713 226.983784 
-L 223.625274 212.913 
-L 227.693834 202.565753 
-L 231.762395 187.206 
-L 235.830955 182.4864 
-L 239.951676 167.453503 
-L 244.072398 157.797315 
-L 248.140958 145.869189 
-L 252.209519 135.954388 
-L 256.278079 129.363448 
-L 260.3988 117.371073 
-L 264.519522 103.915096 
-L 268.588082 108.153781 
-L 272.656643 98.291429 
-L 276.725203 85.444203 
-L 280.793763 79.173978 
-L 284.914485 70.649569 
-L 289.035206 70.706341 
-L 293.103767 65.743658 
-L 297.172327 63.521029 
-L 301.240887 54.077447 
-L 305.309448 52.878838 
-L 309.430169 49.043067 
-L 313.55089 46.615 
-L 317.619451 44.487686 
-L 321.688011 46.584088 
-L 325.756572 40.936585 
-L 329.877293 38.976655 
-L 333.998014 38.215493 
-L 338.066575 38.850833 
-L 342.135135 33.766016 
-L 346.203696 34.754602 
-L 350.272256 34.02 
-L 354.392977 33.637354 
-L 358.513699 31.351111 
-L 362.582259 32.311667 
-L 366.65082 31.771672 
-L 370.71938 29.834783 
-L 374.840101 29.251648 
-L 378.960823 29.677655 
-L 383.029383 27.878333 
-L 387.097944 30.555385 
-L 391.166504 29.326937 
-L 395.235064 28.591077 
-L 399.355786 26.233492 
-L 403.476507 29.370448 
-L 407.545068 28.08 
-L 411.613628 27.896947 
-L 415.682188 27.015538 
-L 419.80291 27.412584 
-L 423.923631 27.383469 
-L 427.992192 28.3 
-L 432.060752 26.330038 
-L 436.129312 27.850936 
-L 440.197873 26.282014 
-L 444.318594 26.565385 
-L 448.439316 25.859498 
-L 452.507876 26.924203 
-L 456.576436 26.500145 
-L 460.644997 26.313433 
-L 464.713557 26.680707 
-L 468.834279 26.220267 
-L 472.955 26.267138 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
+    <path d="M 68.055 308.16 
+L 72.358285 286.843676 
+L 76.426845 269.273333 
+L 80.495406 259.745077 
+L 84.563966 246.491019 
+L 88.684688 247.092973 
+L 92.805409 251.831241 
+L 96.873969 246.082074 
+L 100.94253 253.168992 
+L 105.01109 256.496827 
+L 109.079651 265.807273 
+L 113.200372 271.921589 
+L 117.321093 278.471317 
+L 121.389654 281.348889 
+L 125.458214 287.279487 
+L 129.526775 296.304 
+L 133.647496 296.152598 
+L 137.768217 299.410796 
+L 141.836778 306.110923 
+L 145.905338 307.700777 
+L 149.973899 308.6768 
+L 154.09462 309.262 
+L 158.215341 308.830295 
+L 162.283902 309.68 
+L 166.352462 306.986222 
+L 170.421023 306.769481 
+L 174.489583 304.889438 
+L 178.610304 303.98681 
+L 182.731026 302.241825 
+L 186.799586 299.819487 
+L 190.868147 291.945836 
+L 194.936707 283.667658 
+L 199.057428 287.114797 
+L 203.17815 274.465755 
+L 207.24671 266.304928 
+L 211.315271 263.816923 
+L 215.383831 259.927805 
+L 219.452391 245.166038 
+L 223.573113 239.138897 
+L 227.693834 225.002344 
+L 231.762395 215.479175 
+L 235.830955 208.392 
+L 239.899515 207.387746 
+L 244.020237 180.985725 
+L 248.140958 181.059852 
+L 252.209519 171.161739 
+L 256.278079 166.717761 
+L 260.346639 150.964312 
+L 264.467361 140.854444 
+L 268.588082 129.338667 
+L 272.656643 125.578917 
+L 276.725203 118.383529 
+L 280.793763 102.450694 
+L 284.862324 105.444615 
+L 288.983045 103.3248 
+L 293.103767 91.857163 
+L 297.172327 91.249689 
+L 301.240887 81.751698 
+L 305.309448 72.706154 
+L 309.430169 72.337561 
+L 313.55089 65.580072 
+L 317.619451 62.81729 
+L 321.688011 67.921185 
+L 325.756572 58.227801 
+L 329.825132 54.595872 
+L 333.945853 51.0425 
+L 338.066575 55.264865 
+L 342.135135 51.666355 
+L 346.203696 50.390388 
+L 350.272256 45.504 
+L 354.392977 44.946667 
+L 358.513699 43.212741 
+L 362.582259 43.858645 
+L 366.65082 41.195385 
+L 370.71938 39.652 
+L 374.840101 39.713171 
+L 378.960823 38.247407 
+L 383.029383 36.511351 
+L 387.097944 35.269531 
+L 391.166504 37.100812 
+L 395.235064 36.230922 
+L 399.355786 35.921194 
+L 403.476507 34.668961 
+L 407.545068 34.935698 
+L 411.613628 34.295 
+L 415.682188 34.857011 
+L 419.80291 32.779142 
+L 423.923631 33.491409 
+L 427.992192 33.480916 
+L 432.060752 31.623245 
+L 436.129312 30.92625 
+L 440.197873 33.873013 
+L 444.318594 32.948226 
+L 448.439316 32.936364 
+L 452.507876 29.807164 
+L 456.576436 31.203333 
+L 460.644997 31.942222 
+L 464.765718 29.873333 
+L 468.88644 33.309931 
+L 472.955 29.28438 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
-     <path id="m485cd52254" d="M 0 1 
+     <path id="m32f79c2545" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2124,213 +2124,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#m485cd52254" x="68.081081" y="88.343521" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="72.358285" y="102.805424" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="76.426845" y="125.229701" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="80.547567" y="133.971773" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="84.668288" y="147.74259" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="88.736849" y="161.129231" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="92.805409" y="175.538667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="96.873969" y="192.48403" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="100.994691" y="200.804933" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="105.115412" y="212.895869" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="109.183973" y="235.862979" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="113.252533" y="242.19808" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="117.321093" y="252.967568" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="121.389654" y="269.593115" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="125.510375" y="276.86885" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="129.631097" y="281.908333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="133.699657" y="285.9072" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="137.768217" y="289.888333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="141.836778" y="297.038049" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="145.957499" y="301.379502" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="150.078221" y="303.307692" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="154.146781" y="302.764559" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="158.215341" y="308.133071" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="162.283902" y="305.660769" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="166.352462" y="304.825806" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="170.473184" y="305.327034" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="174.593905" y="302.65" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="178.662465" y="296.491119" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="182.731026" y="297.154074" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="186.799586" y="291.8656" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="190.868147" y="283.603231" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="194.988868" y="274.404878" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="199.109589" y="273.238974" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="203.17815" y="259.735941" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="207.24671" y="253.871351" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="211.315271" y="245.285405" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="215.435992" y="236.384186" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="219.556713" y="226.983784" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="223.625274" y="212.913" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="227.693834" y="202.565753" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="231.762395" y="187.206" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="235.830955" y="182.4864" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="239.951676" y="167.453503" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="244.072398" y="157.797315" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="248.140958" y="145.869189" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="252.209519" y="135.954388" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="256.278079" y="129.363448" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="260.3988" y="117.371073" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="264.519522" y="103.915096" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="268.588082" y="108.153781" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="272.656643" y="98.291429" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="276.725203" y="85.444203" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="280.793763" y="79.173978" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="284.914485" y="70.649569" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="289.035206" y="70.706341" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="293.103767" y="65.743658" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="297.172327" y="63.521029" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="301.240887" y="54.077447" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="305.309448" y="52.878838" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="309.430169" y="49.043067" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="313.55089" y="46.615" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="317.619451" y="44.487686" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="321.688011" y="46.584088" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="325.756572" y="40.936585" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="329.877293" y="38.976655" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="333.998014" y="38.215493" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="338.066575" y="38.850833" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="342.135135" y="33.766016" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="346.203696" y="34.754602" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="350.272256" y="34.02" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="354.392977" y="33.637354" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="358.513699" y="31.351111" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="362.582259" y="32.311667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="366.65082" y="31.771672" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="370.71938" y="29.834783" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="374.840101" y="29.251648" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="378.960823" y="29.677655" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="383.029383" y="27.878333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="387.097944" y="30.555385" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="391.166504" y="29.326937" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="395.235064" y="28.591077" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="399.355786" y="26.233492" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="403.476507" y="29.370448" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="407.545068" y="28.08" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="411.613628" y="27.896947" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="415.682188" y="27.015538" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="419.80291" y="27.412584" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="423.923631" y="27.383469" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="427.992192" y="28.3" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="432.060752" y="26.330038" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="436.129312" y="27.850936" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="440.197873" y="26.282014" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="444.318594" y="26.565385" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="448.439316" y="25.859498" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="452.507876" y="26.924203" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="456.576436" y="26.500145" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="460.644997" y="26.313433" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="464.713557" y="26.680707" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="468.834279" y="26.220267" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m485cd52254" x="472.955" y="26.267138" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m32f79c2545" x="68.055" y="308.16" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="72.358285" y="286.843676" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="76.426845" y="269.273333" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="80.495406" y="259.745077" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="84.563966" y="246.491019" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="88.684688" y="247.092973" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="92.805409" y="251.831241" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="96.873969" y="246.082074" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="100.94253" y="253.168992" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="105.01109" y="256.496827" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="109.079651" y="265.807273" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="113.200372" y="271.921589" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="117.321093" y="278.471317" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="121.389654" y="281.348889" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="125.458214" y="287.279487" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="129.526775" y="296.304" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="133.647496" y="296.152598" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="137.768217" y="299.410796" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="141.836778" y="306.110923" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="145.905338" y="307.700777" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="149.973899" y="308.6768" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="154.09462" y="309.262" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="158.215341" y="308.830295" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="162.283902" y="309.68" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="166.352462" y="306.986222" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="170.421023" y="306.769481" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="174.489583" y="304.889438" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="178.610304" y="303.98681" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="182.731026" y="302.241825" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="186.799586" y="299.819487" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="190.868147" y="291.945836" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="194.936707" y="283.667658" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="199.057428" y="287.114797" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="203.17815" y="274.465755" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="207.24671" y="266.304928" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="211.315271" y="263.816923" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="215.383831" y="259.927805" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="219.452391" y="245.166038" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="223.573113" y="239.138897" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="227.693834" y="225.002344" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="231.762395" y="215.479175" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="235.830955" y="208.392" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="239.899515" y="207.387746" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="244.020237" y="180.985725" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="248.140958" y="181.059852" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="252.209519" y="171.161739" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="256.278079" y="166.717761" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="260.346639" y="150.964312" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="264.467361" y="140.854444" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="268.588082" y="129.338667" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="272.656643" y="125.578917" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="276.725203" y="118.383529" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="280.793763" y="102.450694" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="284.862324" y="105.444615" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="288.983045" y="103.3248" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="293.103767" y="91.857163" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="297.172327" y="91.249689" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="301.240887" y="81.751698" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="305.309448" y="72.706154" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="309.430169" y="72.337561" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="313.55089" y="65.580072" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="317.619451" y="62.81729" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="321.688011" y="67.921185" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="325.756572" y="58.227801" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="329.825132" y="54.595872" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="333.945853" y="51.0425" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="338.066575" y="55.264865" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="342.135135" y="51.666355" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="346.203696" y="50.390388" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="350.272256" y="45.504" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="354.392977" y="44.946667" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="358.513699" y="43.212741" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="362.582259" y="43.858645" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="366.65082" y="41.195385" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="370.71938" y="39.652" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="374.840101" y="39.713171" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="378.960823" y="38.247407" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="383.029383" y="36.511351" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="387.097944" y="35.269531" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="391.166504" y="37.100812" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="395.235064" y="36.230922" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="399.355786" y="35.921194" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="403.476507" y="34.668961" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="407.545068" y="34.935698" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="411.613628" y="34.295" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="415.682188" y="34.857011" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="419.80291" y="32.779142" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="423.923631" y="33.491409" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="427.992192" y="33.480916" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="432.060752" y="31.623245" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="436.129312" y="30.92625" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="440.197873" y="33.873013" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="444.318594" y="32.948226" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="448.439316" y="32.936364" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="452.507876" y="29.807164" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="456.576436" y="31.203333" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="460.644997" y="31.942222" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="464.765718" y="29.873333" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="468.88644" y="33.309931" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m32f79c2545" x="472.955" y="29.28438" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_22">
-    <path d="M 68.055 78.376031 
-L 72.358285 104.538462 
-L 76.426845 115.25641 
-L 80.495406 121.219925 
-L 84.563966 141.285714 
-L 88.684688 152.524478 
-L 92.805409 161.510894 
-L 96.873969 180.466667 
-L 100.94253 188.245641 
-L 105.01109 208.7 
-L 109.079651 223.416935 
-L 113.200372 234.598935 
-L 117.321093 250.427251 
-L 121.389654 267 
-L 125.458214 270.504337 
-L 129.526775 275.382564 
-L 133.647496 287.41907 
-L 137.768217 292.843889 
-L 141.836778 298.601538 
-L 145.905338 300.608511 
-L 149.973899 305.984378 
-L 154.042459 310.496406 
-L 158.16318 308.432239 
-L 162.283902 305.830791 
-L 166.352462 307.093813 
-L 170.421023 305.272 
-L 174.489583 305.898921 
-L 178.610304 299.428721 
-L 182.731026 292.081712 
-L 186.799586 288.89751 
-L 190.868147 279.691667 
-L 194.936707 277.076 
-L 199.005267 270.139459 
-L 203.125989 260.875676 
-L 207.24671 248.000315 
-L 211.315271 236.97541 
-L 215.383831 229.806357 
-L 219.452391 217.958857 
-L 223.573113 210.072868 
-L 227.693834 195.928267 
-L 231.762395 184.2525 
-L 235.830955 174.551459 
-L 239.899515 157.368481 
-L 244.020237 144.14605 
-L 248.140958 138.673821 
-L 252.209519 126.148837 
-L 256.278079 116.588058 
-L 260.346639 115.78292 
-L 264.4152 103.876471 
-L 268.535921 98.750769 
-L 272.656643 89.238275 
-L 276.725203 76.114928 
-L 280.793763 76.275556 
-L 284.862324 66.552152 
-L 288.983045 66.113475 
-L 293.103767 60.193257 
-L 297.172327 53.41854 
-L 301.240887 53.336631 
-L 305.309448 46.578403 
-L 309.378008 45.498092 
-L 313.498729 46.483151 
-L 317.619451 39.96163 
-L 321.688011 41.6128 
-L 325.756572 37.572195 
-L 329.825132 36.2928 
-L 333.945853 33.410466 
-L 338.066575 33.429815 
-L 342.135135 33.8 
-L 346.203696 33.549513 
-L 350.272256 30.391692 
-L 354.340816 29.925109 
-L 358.461538 28.907852 
-L 362.582259 30.557719 
-L 366.65082 30.233447 
-L 370.71938 28.050558 
-L 374.78794 28.226667 
-L 378.908662 27.003511 
-L 383.029383 27.369231 
-L 387.097944 28.411719 
-L 391.166504 27.088451 
-L 395.235064 27.36219 
-L 399.303625 26.496318 
-L 403.424346 26.399344 
-L 407.545068 27.74724 
-L 411.613628 27.390667 
-L 415.682188 26.423529 
-L 419.750749 25.665077 
-L 423.87147 25.868718 
-L 427.992192 26.139442 
-L 432.060752 26.285054 
-L 436.129312 26.323321 
-L 440.197873 26.147903 
-L 444.266433 26.556794 
-L 448.387155 26.117838 
-L 452.507876 25.915772 
-L 456.576436 26.105 
-L 460.644997 25.917714 
-L 464.713557 25.66251 
-L 468.834279 25.891892 
-L 472.955 26.361575 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
+    <path d="M 68.055 304.964103 
+L 72.358285 284.211163 
+L 76.426845 259.095942 
+L 80.495406 252.287191 
+L 84.563966 252.595878 
+L 88.684688 249.661792 
+L 92.805409 239.026615 
+L 96.873969 249.166462 
+L 100.94253 256.130811 
+L 105.01109 261.11393 
+L 109.079651 261.463469 
+L 113.200372 269.434545 
+L 117.321093 278.636533 
+L 121.389654 280.471605 
+L 125.458214 286.8 
+L 129.526775 291.418197 
+L 133.647496 297.63089 
+L 137.768217 300.828235 
+L 141.836778 308.837258 
+L 145.905338 309.434118 
+L 149.973899 310.294706 
+L 154.042459 310.991971 
+L 158.16318 311.415094 
+L 162.283902 308.027072 
+L 166.352462 309.561837 
+L 170.421023 307.636444 
+L 174.489583 305.137953 
+L 178.610304 303.011518 
+L 182.731026 301.064733 
+L 186.799586 296.513 
+L 190.868147 288.23206 
+L 194.936707 281.437603 
+L 199.005267 278.593185 
+L 203.125989 270.293556 
+L 207.24671 269.273333 
+L 211.315271 255.159686 
+L 215.383831 246.515556 
+L 219.452391 242.703908 
+L 223.573113 234.753109 
+L 227.693834 222.473065 
+L 231.762395 208.7 
+L 235.830955 199.943682 
+L 239.899515 187.738273 
+L 243.968076 174.852766 
+L 248.088797 167.154478 
+L 252.209519 152.268043 
+L 256.278079 142.866271 
+L 260.346639 144.505692 
+L 264.4152 132.355433 
+L 268.535921 118.654 
+L 272.656643 112.058051 
+L 276.725203 110.065576 
+L 280.793763 102.233043 
+L 284.862324 90.262154 
+L 288.930884 86.556451 
+L 293.051605 82.868209 
+L 297.172327 79.269466 
+L 301.240887 76.590815 
+L 305.309448 68.019068 
+L 309.378008 66.678926 
+L 313.498729 61.709049 
+L 317.619451 57.456377 
+L 321.688011 54.921667 
+L 325.756572 52.990653 
+L 329.825132 51.728281 
+L 333.893692 47.947692 
+L 338.014414 45.25753 
+L 342.135135 49.611304 
+L 346.203696 44.872214 
+L 350.272256 45.510909 
+L 354.340816 41.211348 
+L 358.461538 40.34397 
+L 362.582259 40.998889 
+L 366.65082 36.545985 
+L 370.71938 38.4208 
+L 374.78794 40.885799 
+L 378.856501 35.670769 
+L 382.977222 35.9736 
+L 387.097944 35.436299 
+L 391.166504 37.79 
+L 395.235064 33.91531 
+L 399.303625 32.967469 
+L 403.424346 32.829898 
+L 407.545068 35.9736 
+L 411.613628 32.958194 
+L 415.682188 35.358644 
+L 419.750749 31.442051 
+L 423.819309 32.834224 
+L 427.940031 32.755 
+L 432.060752 31.479431 
+L 436.129312 33.533191 
+L 440.197873 32.337 
+L 444.266433 33.890542 
+L 448.387155 33.325674 
+L 452.507876 33.440781 
+L 456.576436 31.870769 
+L 460.644997 31.351111 
+L 464.713557 31.685217 
+L 468.782118 30.82384 
+L 472.902839 34.02 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
-     <path id="mfa4a2b6300" d="M 0 1 
+     <path id="m5f84e627c7" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2342,213 +2342,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#mfa4a2b6300" x="68.055" y="78.376031" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="72.358285" y="104.538462" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="76.426845" y="115.25641" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="80.495406" y="121.219925" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="84.563966" y="141.285714" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="88.684688" y="152.524478" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="92.805409" y="161.510894" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="96.873969" y="180.466667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="100.94253" y="188.245641" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="105.01109" y="208.7" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="109.079651" y="223.416935" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="113.200372" y="234.598935" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="117.321093" y="250.427251" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="121.389654" y="267" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="125.458214" y="270.504337" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="129.526775" y="275.382564" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="133.647496" y="287.41907" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="137.768217" y="292.843889" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="141.836778" y="298.601538" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="145.905338" y="300.608511" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="149.973899" y="305.984378" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="154.042459" y="310.496406" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="158.16318" y="308.432239" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="162.283902" y="305.830791" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="166.352462" y="307.093813" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="170.421023" y="305.272" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="174.489583" y="305.898921" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="178.610304" y="299.428721" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="182.731026" y="292.081712" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="186.799586" y="288.89751" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="190.868147" y="279.691667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="194.936707" y="277.076" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="199.005267" y="270.139459" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="203.125989" y="260.875676" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="207.24671" y="248.000315" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="211.315271" y="236.97541" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="215.383831" y="229.806357" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="219.452391" y="217.958857" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="223.573113" y="210.072868" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="227.693834" y="195.928267" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="231.762395" y="184.2525" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="235.830955" y="174.551459" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="239.899515" y="157.368481" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="244.020237" y="144.14605" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="248.140958" y="138.673821" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="252.209519" y="126.148837" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="256.278079" y="116.588058" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="260.346639" y="115.78292" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="264.4152" y="103.876471" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="268.535921" y="98.750769" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="272.656643" y="89.238275" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="276.725203" y="76.114928" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="280.793763" y="76.275556" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="284.862324" y="66.552152" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="288.983045" y="66.113475" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="293.103767" y="60.193257" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="297.172327" y="53.41854" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="301.240887" y="53.336631" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="305.309448" y="46.578403" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="309.378008" y="45.498092" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="313.498729" y="46.483151" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="317.619451" y="39.96163" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="321.688011" y="41.6128" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="325.756572" y="37.572195" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="329.825132" y="36.2928" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="333.945853" y="33.410466" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="338.066575" y="33.429815" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="342.135135" y="33.8" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="346.203696" y="33.549513" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="350.272256" y="30.391692" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="354.340816" y="29.925109" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="358.461538" y="28.907852" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="362.582259" y="30.557719" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="366.65082" y="30.233447" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="370.71938" y="28.050558" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="374.78794" y="28.226667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="378.908662" y="27.003511" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="383.029383" y="27.369231" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="387.097944" y="28.411719" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="391.166504" y="27.088451" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="395.235064" y="27.36219" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="399.303625" y="26.496318" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="403.424346" y="26.399344" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="407.545068" y="27.74724" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="411.613628" y="27.390667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="415.682188" y="26.423529" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="419.750749" y="25.665077" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="423.87147" y="25.868718" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="427.992192" y="26.139442" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="432.060752" y="26.285054" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="436.129312" y="26.323321" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="440.197873" y="26.147903" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="444.266433" y="26.556794" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="448.387155" y="26.117838" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="452.507876" y="25.915772" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="456.576436" y="26.105" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="460.644997" y="25.917714" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="464.713557" y="25.66251" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="468.834279" y="25.891892" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#mfa4a2b6300" x="472.955" y="26.361575" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m5f84e627c7" x="68.055" y="304.964103" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="72.358285" y="284.211163" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="76.426845" y="259.095942" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="80.495406" y="252.287191" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="84.563966" y="252.595878" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="88.684688" y="249.661792" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="92.805409" y="239.026615" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="96.873969" y="249.166462" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="100.94253" y="256.130811" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="105.01109" y="261.11393" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="109.079651" y="261.463469" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="113.200372" y="269.434545" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="117.321093" y="278.636533" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="121.389654" y="280.471605" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="125.458214" y="286.8" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="129.526775" y="291.418197" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="133.647496" y="297.63089" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="137.768217" y="300.828235" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="141.836778" y="308.837258" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="145.905338" y="309.434118" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="149.973899" y="310.294706" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="154.042459" y="310.991971" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="158.16318" y="311.415094" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="162.283902" y="308.027072" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="166.352462" y="309.561837" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="170.421023" y="307.636444" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="174.489583" y="305.137953" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="178.610304" y="303.011518" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="182.731026" y="301.064733" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="186.799586" y="296.513" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="190.868147" y="288.23206" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="194.936707" y="281.437603" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="199.005267" y="278.593185" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="203.125989" y="270.293556" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="207.24671" y="269.273333" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="211.315271" y="255.159686" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="215.383831" y="246.515556" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="219.452391" y="242.703908" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="223.573113" y="234.753109" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="227.693834" y="222.473065" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="231.762395" y="208.7" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="235.830955" y="199.943682" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="239.899515" y="187.738273" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="243.968076" y="174.852766" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="248.088797" y="167.154478" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="252.209519" y="152.268043" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="256.278079" y="142.866271" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="260.346639" y="144.505692" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="264.4152" y="132.355433" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="268.535921" y="118.654" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="272.656643" y="112.058051" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="276.725203" y="110.065576" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="280.793763" y="102.233043" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="284.862324" y="90.262154" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="288.930884" y="86.556451" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="293.051605" y="82.868209" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="297.172327" y="79.269466" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="301.240887" y="76.590815" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="305.309448" y="68.019068" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="309.378008" y="66.678926" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="313.498729" y="61.709049" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="317.619451" y="57.456377" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="321.688011" y="54.921667" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="325.756572" y="52.990653" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="329.825132" y="51.728281" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="333.893692" y="47.947692" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="338.014414" y="45.25753" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="342.135135" y="49.611304" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="346.203696" y="44.872214" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="350.272256" y="45.510909" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="354.340816" y="41.211348" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="358.461538" y="40.34397" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="362.582259" y="40.998889" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="366.65082" y="36.545985" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="370.71938" y="38.4208" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="374.78794" y="40.885799" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="378.856501" y="35.670769" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="382.977222" y="35.9736" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="387.097944" y="35.436299" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="391.166504" y="37.79" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="395.235064" y="33.91531" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="399.303625" y="32.967469" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="403.424346" y="32.829898" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="407.545068" y="35.9736" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="411.613628" y="32.958194" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="415.682188" y="35.358644" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="419.750749" y="31.442051" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="423.819309" y="32.834224" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="427.940031" y="32.755" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="432.060752" y="31.479431" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="436.129312" y="33.533191" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="440.197873" y="32.337" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="444.266433" y="33.890542" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="448.387155" y="33.325674" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="452.507876" y="33.440781" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="456.576436" y="31.870769" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="460.644997" y="31.351111" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="464.713557" y="31.685217" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="468.782118" y="30.82384" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#m5f84e627c7" x="472.902839" y="34.02" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_23">
-    <path d="M 68.065432 107.988079 
-L 72.358285 125.38 
-L 76.426845 155.484444 
-L 80.495406 173.412 
-L 84.563966 191.84381 
-L 88.684688 208.721389 
-L 92.805409 216.349508 
-L 96.873969 230.510085 
-L 100.94253 254.2 
-L 105.01109 252.049362 
-L 109.131812 271.864063 
-L 113.252533 271.140993 
-L 117.321093 277.681379 
-L 121.389654 288.78 
-L 125.458214 289.267667 
-L 129.526775 300.484 
-L 133.647496 300.347907 
-L 137.768217 299.332787 
-L 141.836778 306.119259 
-L 145.905338 307.809231 
-L 149.973899 310.34 
-L 154.09462 307.657419 
-L 158.215341 310.608889 
-L 162.283902 307.44189 
-L 166.352462 310.179104 
-L 170.421023 309.749667 
-L 174.489583 302.401034 
-L 178.610304 302.248889 
-L 182.731026 306.416164 
-L 186.799586 303.766829 
-L 190.868147 305.088852 
-L 194.936707 292.358561 
-L 199.057428 291.892766 
-L 203.17815 295.257405 
-L 207.24671 286.603636 
-L 211.315271 282.172903 
-L 215.383831 278.2464 
-L 219.452391 274.382222 
-L 223.573113 271.406875 
-L 227.693834 262.306667 
-L 231.762395 256.529927 
-L 235.830955 251.664966 
-L 239.899515 242.433869 
-L 244.020237 234.503817 
-L 248.140958 230.755932 
-L 252.209519 223.916923 
-L 256.278079 205.533239 
-L 260.346639 209.154426 
-L 264.4152 195.426667 
-L 268.535921 190.145484 
-L 272.656643 189.593559 
-L 276.725203 176.241538 
-L 280.793763 171.059535 
-L 284.862324 166.936119 
-L 288.983045 156.328244 
-L 293.103767 146.081231 
-L 297.172327 138.478632 
-L 301.240887 134.05312 
-L 305.309448 136.97812 
-L 309.378008 122.14678 
-L 313.498729 115.658333 
-L 317.619451 105.324444 
-L 321.688011 101.314207 
-L 325.756572 103.592516 
-L 329.825132 98.59 
-L 333.945853 95.940472 
-L 338.066575 91.894915 
-L 342.135135 83.559178 
-L 346.203696 78.160721 
-L 350.272256 76.590815 
-L 354.340816 77.663544 
-L 358.461538 72.743667 
-L 362.582259 64.941 
-L 366.65082 67.651148 
-L 370.71938 64.622957 
-L 374.78794 66.36 
-L 378.908662 56.217185 
-L 383.029383 53.087244 
-L 387.097944 47.176 
-L 391.166504 49.896119 
-L 395.235064 50.636111 
-L 399.303625 47.708673 
-L 403.424346 47.815294 
-L 407.545068 43.845484 
-L 411.613628 45.520392 
-L 415.682188 42.953285 
-L 419.750749 44.127059 
-L 423.87147 46.680593 
-L 427.992192 42.54 
-L 432.060752 40.513333 
-L 436.129312 44.25 
-L 440.197873 40.288358 
-L 444.266433 42.996 
-L 448.387155 40.188943 
-L 452.507876 41.231111 
-L 456.576436 36.511351 
-L 460.644997 37.98 
-L 464.713557 39.094667 
-L 468.834279 34.821069 
-L 472.955 33.242667 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
+    <path d="M 68.060216 318.04 
+L 72.358285 317.662452 
+L 76.426845 317.539829 
+L 80.495406 314.446667 
+L 84.563966 312.951304 
+L 88.684688 311.052537 
+L 92.805409 311.39 
+L 96.873969 307.093813 
+L 100.94253 305.902519 
+L 105.01109 307.093813 
+L 109.131812 304.535385 
+L 113.252533 309.552366 
+L 117.321093 309.885574 
+L 121.389654 309.61312 
+L 125.458214 312.330732 
+L 129.526775 309.68 
+L 133.647496 314.138667 
+L 137.768217 312.806504 
+L 141.836778 313.243279 
+L 145.905338 311.124 
+L 149.973899 314.626333 
+L 154.09462 311.85831 
+L 158.215341 312.302745 
+L 162.283902 311.88 
+L 166.352462 310.08128 
+L 170.421023 311.585588 
+L 174.489583 309.609153 
+L 178.610304 303.115436 
+L 182.731026 304.884341 
+L 186.799586 303.203944 
+L 190.868147 302.162481 
+L 194.936707 298.033162 
+L 199.057428 298.233231 
+L 203.17815 294.292754 
+L 207.24671 296.402353 
+L 211.315271 289.863704 
+L 215.383831 290.90029 
+L 219.504552 283.945739 
+L 223.625274 279.608955 
+L 227.693834 274.786087 
+L 231.762395 268.808889 
+L 235.830955 260.011765 
+L 239.899515 256.026269 
+L 244.020237 251.497097 
+L 248.140958 255.804444 
+L 252.209519 248.682963 
+L 256.278079 243.969231 
+L 260.346639 245.851095 
+L 264.467361 236.196812 
+L 268.588082 230.849128 
+L 272.656643 216.635115 
+L 276.725203 213.107586 
+L 280.793763 209.016438 
+L 284.862324 208.136585 
+L 288.983045 198.135385 
+L 293.103767 184.411654 
+L 297.172327 194.142188 
+L 301.240887 189.729481 
+L 305.309448 168.814 
+L 309.430169 169.523333 
+L 313.55089 175.694054 
+L 317.619451 159.469677 
+L 321.688011 151.72 
+L 325.756572 149.542759 
+L 329.825132 150.365674 
+L 333.945853 143.41632 
+L 338.066575 136.079375 
+L 342.135135 132.499845 
+L 346.203696 139.015 
+L 350.272256 125.295556 
+L 354.392977 125.411667 
+L 358.513699 122.391045 
+L 362.582259 114.195333 
+L 366.65082 125.295556 
+L 370.71938 103.76 
+L 374.78794 125.698529 
+L 378.908662 117.587164 
+L 383.029383 99.296276 
+L 387.097944 100.99194 
+L 391.166504 106.077795 
+L 395.235064 100.171622 
+L 399.355786 101.112414 
+L 403.476507 98.808358 
+L 407.545068 106.017538 
+L 411.613628 86.210769 
+L 415.682188 97.729412 
+L 419.750749 93.713333 
+L 423.87147 79.845313 
+L 427.992192 91.107481 
+L 432.060752 83.96 
+L 436.129312 81.555068 
+L 440.197873 86.08029 
+L 444.318594 78.296774 
+L 448.439316 84.464483 
+L 452.507876 76.099104 
+L 456.576436 68.674925 
+L 460.644997 70.843448 
+L 464.713557 81.015597 
+L 468.834279 66.943546 
+L 472.955 74.920325 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
     <defs>
-     <path id="m58197e914b" d="M 0 1 
+     <path id="m220b9d30a3" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2560,213 +2560,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #7f7f7f"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#m58197e914b" x="68.065432" y="107.988079" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="72.358285" y="125.38" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="76.426845" y="155.484444" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="80.495406" y="173.412" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="84.563966" y="191.84381" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="88.684688" y="208.721389" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="92.805409" y="216.349508" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="96.873969" y="230.510085" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="100.94253" y="254.2" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="105.01109" y="252.049362" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="109.131812" y="271.864063" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="113.252533" y="271.140993" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="117.321093" y="277.681379" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="121.389654" y="288.78" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="125.458214" y="289.267667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="129.526775" y="300.484" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="133.647496" y="300.347907" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="137.768217" y="299.332787" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="141.836778" y="306.119259" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="145.905338" y="307.809231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="149.973899" y="310.34" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="154.09462" y="307.657419" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="158.215341" y="310.608889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="162.283902" y="307.44189" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="166.352462" y="310.179104" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="170.421023" y="309.749667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="174.489583" y="302.401034" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="178.610304" y="302.248889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="182.731026" y="306.416164" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="186.799586" y="303.766829" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="190.868147" y="305.088852" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="194.936707" y="292.358561" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="199.057428" y="291.892766" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="203.17815" y="295.257405" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="207.24671" y="286.603636" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="211.315271" y="282.172903" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="215.383831" y="278.2464" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="219.452391" y="274.382222" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="223.573113" y="271.406875" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="227.693834" y="262.306667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="231.762395" y="256.529927" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="235.830955" y="251.664966" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="239.899515" y="242.433869" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="244.020237" y="234.503817" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="248.140958" y="230.755932" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="252.209519" y="223.916923" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="256.278079" y="205.533239" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="260.346639" y="209.154426" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="264.4152" y="195.426667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="268.535921" y="190.145484" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="272.656643" y="189.593559" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="276.725203" y="176.241538" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="280.793763" y="171.059535" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="284.862324" y="166.936119" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="288.983045" y="156.328244" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="293.103767" y="146.081231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="297.172327" y="138.478632" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="301.240887" y="134.05312" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="305.309448" y="136.97812" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="309.378008" y="122.14678" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="313.498729" y="115.658333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="317.619451" y="105.324444" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="321.688011" y="101.314207" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="325.756572" y="103.592516" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="329.825132" y="98.59" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="333.945853" y="95.940472" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="338.066575" y="91.894915" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="342.135135" y="83.559178" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="346.203696" y="78.160721" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="350.272256" y="76.590815" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="354.340816" y="77.663544" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="358.461538" y="72.743667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="362.582259" y="64.941" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="366.65082" y="67.651148" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="370.71938" y="64.622957" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="374.78794" y="66.36" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="378.908662" y="56.217185" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="383.029383" y="53.087244" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="387.097944" y="47.176" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="391.166504" y="49.896119" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="395.235064" y="50.636111" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="399.303625" y="47.708673" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="403.424346" y="47.815294" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="407.545068" y="43.845484" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="411.613628" y="45.520392" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="415.682188" y="42.953285" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="419.750749" y="44.127059" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="423.87147" y="46.680593" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="427.992192" y="42.54" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="432.060752" y="40.513333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="436.129312" y="44.25" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="440.197873" y="40.288358" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="444.266433" y="42.996" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="448.387155" y="40.188943" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="452.507876" y="41.231111" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="456.576436" y="36.511351" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="460.644997" y="37.98" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="464.713557" y="39.094667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="468.834279" y="34.821069" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m58197e914b" x="472.955" y="33.242667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m220b9d30a3" x="68.060216" y="318.04" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="72.358285" y="317.662452" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="76.426845" y="317.539829" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="80.495406" y="314.446667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="84.563966" y="312.951304" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="88.684688" y="311.052537" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="92.805409" y="311.39" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="96.873969" y="307.093813" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="100.94253" y="305.902519" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="105.01109" y="307.093813" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="109.131812" y="304.535385" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="113.252533" y="309.552366" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="117.321093" y="309.885574" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="121.389654" y="309.61312" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="125.458214" y="312.330732" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="129.526775" y="309.68" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="133.647496" y="314.138667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="137.768217" y="312.806504" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="141.836778" y="313.243279" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="145.905338" y="311.124" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="149.973899" y="314.626333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="154.09462" y="311.85831" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="158.215341" y="312.302745" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="162.283902" y="311.88" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="166.352462" y="310.08128" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="170.421023" y="311.585588" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="174.489583" y="309.609153" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="178.610304" y="303.115436" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="182.731026" y="304.884341" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="186.799586" y="303.203944" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="190.868147" y="302.162481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="194.936707" y="298.033162" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="199.057428" y="298.233231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="203.17815" y="294.292754" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="207.24671" y="296.402353" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="211.315271" y="289.863704" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="215.383831" y="290.90029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="219.504552" y="283.945739" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="223.625274" y="279.608955" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="227.693834" y="274.786087" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="231.762395" y="268.808889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="235.830955" y="260.011765" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="239.899515" y="256.026269" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="244.020237" y="251.497097" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="248.140958" y="255.804444" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="252.209519" y="248.682963" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="256.278079" y="243.969231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="260.346639" y="245.851095" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="264.467361" y="236.196812" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="268.588082" y="230.849128" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="272.656643" y="216.635115" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="276.725203" y="213.107586" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="280.793763" y="209.016438" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="284.862324" y="208.136585" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="288.983045" y="198.135385" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="293.103767" y="184.411654" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="297.172327" y="194.142188" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="301.240887" y="189.729481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="305.309448" y="168.814" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="309.430169" y="169.523333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="313.55089" y="175.694054" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="317.619451" y="159.469677" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="321.688011" y="151.72" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="325.756572" y="149.542759" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="329.825132" y="150.365674" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="333.945853" y="143.41632" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="338.066575" y="136.079375" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="342.135135" y="132.499845" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="346.203696" y="139.015" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="350.272256" y="125.295556" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="354.392977" y="125.411667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="358.513699" y="122.391045" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="362.582259" y="114.195333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="366.65082" y="125.295556" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="370.71938" y="103.76" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="374.78794" y="125.698529" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="378.908662" y="117.587164" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="383.029383" y="99.296276" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="387.097944" y="100.99194" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="391.166504" y="106.077795" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="395.235064" y="100.171622" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="399.355786" y="101.112414" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="403.476507" y="98.808358" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="407.545068" y="106.017538" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="411.613628" y="86.210769" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="415.682188" y="97.729412" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="419.750749" y="93.713333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="423.87147" y="79.845313" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="427.992192" y="91.107481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="432.060752" y="83.96" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="436.129312" y="81.555068" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="440.197873" y="86.08029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="444.318594" y="78.296774" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="448.439316" y="84.464483" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="452.507876" y="76.099104" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="456.576436" y="68.674925" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="460.644997" y="70.843448" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="464.713557" y="81.015597" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="468.834279" y="66.943546" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m220b9d30a3" x="472.955" y="74.920325" style="fill: #7f7f7f; stroke: #7f7f7f"/>
     </g>
    </g>
    <g id="line2d_24">
-    <path d="M 68.055 84.851168 
-L 72.358285 111.548 
-L 76.426845 124.493333 
-L 80.495406 142.232034 
-L 84.563966 153.68 
-L 88.684688 175.556522 
-L 92.805409 187.639269 
-L 96.873969 196.838578 
-L 100.94253 209.76511 
-L 105.01109 219.58218 
-L 109.079651 237.818833 
-L 113.200372 252.097951 
-L 117.321093 256.684229 
-L 121.389654 266.582759 
-L 125.458214 279.384587 
-L 129.526775 279.850892 
-L 133.647496 288.233084 
-L 137.768217 297.870485 
-L 141.836778 294.81299 
-L 145.905338 301.085607 
-L 149.973899 304.515378 
-L 154.042459 308.772127 
-L 158.16318 307.601297 
-L 162.283902 309.880962 
-L 166.352462 306.201985 
-L 170.421023 306.776736 
-L 174.489583 303.844554 
-L 178.610304 301.676588 
-L 182.731026 300.368119 
-L 186.799586 295.932444 
-L 190.868147 287.959626 
-L 194.936707 287.225121 
-L 199.005267 274.983834 
-L 203.125989 278.340503 
-L 207.24671 264.231356 
-L 211.315271 255.283258 
-L 215.383831 246.093333 
-L 219.452391 235.72 
-L 223.573113 226.656552 
-L 227.693834 210.270495 
-L 231.762395 203.798783 
-L 235.830955 202.068858 
-L 239.899515 183.189565 
-L 243.968076 174.278539 
-L 248.088797 170.242977 
-L 252.209519 157.926904 
-L 256.278079 148.504118 
-L 260.346639 142.198654 
-L 264.4152 124.613274 
-L 268.535921 115.758539 
-L 272.656643 106.872593 
-L 276.725203 100.787639 
-L 280.793763 95.87115 
-L 284.862324 86.088 
-L 288.930884 81.111681 
-L 293.051605 82.704206 
-L 297.172327 73.092 
-L 301.240887 69.577966 
-L 305.309448 68.335728 
-L 309.378008 60.045577 
-L 313.498729 59.304365 
-L 317.619451 52.138065 
-L 321.688011 51.0425 
-L 325.756572 50.007358 
-L 329.825132 49.114 
-L 333.893692 47.708673 
-L 338.014414 44.610345 
-L 342.135135 43.98099 
-L 346.203696 42.845949 
-L 350.272256 37.547586 
-L 354.340816 40.292792 
-L 358.461538 36.277037 
-L 362.582259 38.541493 
-L 366.65082 34.499582 
-L 370.71938 36.865333 
-L 374.78794 35.011028 
-L 378.856501 35.480196 
-L 382.977222 33.477082 
-L 387.097944 34.249462 
-L 391.166504 34.916923 
-L 395.235064 33.8 
-L 399.303625 31.381117 
-L 403.424346 30.92625 
-L 407.545068 33.3402 
-L 411.613628 30.131477 
-L 415.682188 30.271927 
-L 419.750749 31.086667 
-L 423.819309 30.578341 
-L 427.940031 29.797872 
-L 432.060752 29.0975 
-L 436.129312 28.086633 
-L 440.197873 29.663093 
-L 444.266433 28.705064 
-L 448.387155 28.395556 
-L 452.507876 28.16186 
-L 456.576436 28.611034 
-L 460.644997 28.8 
-L 464.713557 28.832464 
-L 468.782118 27.021622 
-L 472.902839 27.390667 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
+    <path d="M 68.055 314.943704 
+L 72.358285 300.874133 
+L 76.426845 288.014031 
+L 80.495406 275.530189 
+L 84.563966 266.373694 
+L 88.684688 267.758252 
+L 92.805409 255.686812 
+L 96.873969 265.994553 
+L 100.94253 266.835 
+L 105.01109 269.753005 
+L 109.079651 274.821101 
+L 113.200372 282.928 
+L 117.321093 284.28893 
+L 121.389654 286.373333 
+L 125.458214 295.939362 
+L 129.526775 295.130043 
+L 133.647496 298.951931 
+L 137.768217 304.418966 
+L 141.836778 308.954703 
+L 145.905338 307.470308 
+L 149.973899 310.255229 
+L 154.042459 312.094118 
+L 158.16318 312.270423 
+L 162.283902 310.76 
+L 166.352462 308.286667 
+L 170.421023 307.59 
+L 174.489583 306.918552 
+L 178.610304 304.385333 
+L 182.731026 303.478685 
+L 186.799586 299.6323 
+L 190.868147 295.785915 
+L 194.936707 290.582749 
+L 199.005267 290.694206 
+L 203.125989 278.484815 
+L 207.24671 275.42835 
+L 211.315271 265.839061 
+L 215.383831 258.988 
+L 219.452391 259.52 
+L 223.573113 246.305806 
+L 227.693834 233.604 
+L 231.762395 218.610185 
+L 235.830955 227.967742 
+L 239.899515 214.032838 
+L 244.020237 197.973103 
+L 248.140958 200.437308 
+L 252.209519 180.1 
+L 256.278079 175.593756 
+L 260.346639 171.882732 
+L 264.4152 159.052035 
+L 268.535921 145.127964 
+L 272.656643 148.84087 
+L 276.725203 140.39 
+L 280.793763 136.88 
+L 284.862324 127.336667 
+L 288.983045 121.458252 
+L 293.103767 109.257708 
+L 297.172327 105.152428 
+L 301.240887 97.407149 
+L 305.309448 106.4275 
+L 309.378008 83.446667 
+L 313.498729 89.729577 
+L 317.619451 85.476062 
+L 321.688011 81.665098 
+L 325.756572 73.842056 
+L 329.825132 72.256 
+L 333.945853 73.53863 
+L 338.066575 69.6226 
+L 342.135135 69.396199 
+L 346.203696 65.353641 
+L 350.272256 66.642857 
+L 354.340816 56.213448 
+L 358.461538 54.562629 
+L 362.582259 56.650667 
+L 366.65082 55.936338 
+L 370.71938 53.902 
+L 374.78794 43.832 
+L 378.908662 45.686256 
+L 383.029383 44.848643 
+L 387.097944 48.4 
+L 391.166504 45.984255 
+L 395.235064 46.595117 
+L 399.303625 44.260503 
+L 403.424346 40.827729 
+L 407.545068 42.083303 
+L 411.613628 42.859907 
+L 415.682188 38.085025 
+L 419.750749 42.741565 
+L 423.87147 41.027103 
+L 427.992192 39.29256 
+L 432.060752 39.7774 
+L 436.129312 38.148889 
+L 440.197873 37.688372 
+L 444.318594 36.525286 
+L 448.439316 40.780194 
+L 452.507876 39.667339 
+L 456.576436 38.137736 
+L 460.644997 42.237407 
+L 464.713557 34.543111 
+L 468.834279 35.716683 
+L 472.955 37.144 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
-     <path id="m9bf7f81920" d="M 0 1 
+     <path id="m80f4c965dc" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2778,213 +2778,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#m9bf7f81920" x="68.055" y="84.851168" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="72.358285" y="111.548" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="76.426845" y="124.493333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="80.495406" y="142.232034" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="84.563966" y="153.68" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="88.684688" y="175.556522" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="92.805409" y="187.639269" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="96.873969" y="196.838578" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="100.94253" y="209.76511" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="105.01109" y="219.58218" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="109.079651" y="237.818833" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="113.200372" y="252.097951" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="117.321093" y="256.684229" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="121.389654" y="266.582759" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="125.458214" y="279.384587" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="129.526775" y="279.850892" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="133.647496" y="288.233084" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="137.768217" y="297.870485" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="141.836778" y="294.81299" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="145.905338" y="301.085607" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="149.973899" y="304.515378" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="154.042459" y="308.772127" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="158.16318" y="307.601297" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="162.283902" y="309.880962" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="166.352462" y="306.201985" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="170.421023" y="306.776736" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="174.489583" y="303.844554" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="178.610304" y="301.676588" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="182.731026" y="300.368119" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="186.799586" y="295.932444" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="190.868147" y="287.959626" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="194.936707" y="287.225121" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="199.005267" y="274.983834" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="203.125989" y="278.340503" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="207.24671" y="264.231356" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="211.315271" y="255.283258" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="215.383831" y="246.093333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="219.452391" y="235.72" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="223.573113" y="226.656552" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="227.693834" y="210.270495" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="231.762395" y="203.798783" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="235.830955" y="202.068858" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="239.899515" y="183.189565" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="243.968076" y="174.278539" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="248.088797" y="170.242977" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="252.209519" y="157.926904" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="256.278079" y="148.504118" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="260.346639" y="142.198654" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="264.4152" y="124.613274" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="268.535921" y="115.758539" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="272.656643" y="106.872593" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="276.725203" y="100.787639" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="280.793763" y="95.87115" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="284.862324" y="86.088" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="288.930884" y="81.111681" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="293.051605" y="82.704206" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="297.172327" y="73.092" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="301.240887" y="69.577966" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="305.309448" y="68.335728" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="309.378008" y="60.045577" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="313.498729" y="59.304365" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="317.619451" y="52.138065" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="321.688011" y="51.0425" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="325.756572" y="50.007358" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="329.825132" y="49.114" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="333.893692" y="47.708673" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="338.014414" y="44.610345" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="342.135135" y="43.98099" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="346.203696" y="42.845949" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="350.272256" y="37.547586" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="354.340816" y="40.292792" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="358.461538" y="36.277037" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="362.582259" y="38.541493" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="366.65082" y="34.499582" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="370.71938" y="36.865333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="374.78794" y="35.011028" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="378.856501" y="35.480196" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="382.977222" y="33.477082" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="387.097944" y="34.249462" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="391.166504" y="34.916923" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="395.235064" y="33.8" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="399.303625" y="31.381117" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="403.424346" y="30.92625" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="407.545068" y="33.3402" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="411.613628" y="30.131477" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="415.682188" y="30.271927" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="419.750749" y="31.086667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="423.819309" y="30.578341" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="427.940031" y="29.797872" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="432.060752" y="29.0975" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="436.129312" y="28.086633" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="440.197873" y="29.663093" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="444.266433" y="28.705064" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="448.387155" y="28.395556" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="452.507876" y="28.16186" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="456.576436" y="28.611034" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="460.644997" y="28.8" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="464.713557" y="28.832464" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="468.782118" y="27.021622" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m9bf7f81920" x="472.902839" y="27.390667" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m80f4c965dc" x="68.055" y="314.943704" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="72.358285" y="300.874133" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="76.426845" y="288.014031" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="80.495406" y="275.530189" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="84.563966" y="266.373694" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="88.684688" y="267.758252" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="92.805409" y="255.686812" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="96.873969" y="265.994553" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="100.94253" y="266.835" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="105.01109" y="269.753005" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="109.079651" y="274.821101" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="113.200372" y="282.928" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="117.321093" y="284.28893" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="121.389654" y="286.373333" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="125.458214" y="295.939362" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="129.526775" y="295.130043" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="133.647496" y="298.951931" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="137.768217" y="304.418966" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="141.836778" y="308.954703" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="145.905338" y="307.470308" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="149.973899" y="310.255229" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="154.042459" y="312.094118" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="158.16318" y="312.270423" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="162.283902" y="310.76" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="166.352462" y="308.286667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="170.421023" y="307.59" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="174.489583" y="306.918552" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="178.610304" y="304.385333" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="182.731026" y="303.478685" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="186.799586" y="299.6323" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="190.868147" y="295.785915" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="194.936707" y="290.582749" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="199.005267" y="290.694206" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="203.125989" y="278.484815" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="207.24671" y="275.42835" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="211.315271" y="265.839061" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="215.383831" y="258.988" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="219.452391" y="259.52" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="223.573113" y="246.305806" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="227.693834" y="233.604" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="231.762395" y="218.610185" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="235.830955" y="227.967742" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="239.899515" y="214.032838" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="244.020237" y="197.973103" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="248.140958" y="200.437308" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="252.209519" y="180.1" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="256.278079" y="175.593756" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="260.346639" y="171.882732" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="264.4152" y="159.052035" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="268.535921" y="145.127964" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="272.656643" y="148.84087" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="276.725203" y="140.39" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="280.793763" y="136.88" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="284.862324" y="127.336667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="288.983045" y="121.458252" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="293.103767" y="109.257708" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="297.172327" y="105.152428" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="301.240887" y="97.407149" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="305.309448" y="106.4275" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="309.378008" y="83.446667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="313.498729" y="89.729577" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="317.619451" y="85.476062" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="321.688011" y="81.665098" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="325.756572" y="73.842056" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="329.825132" y="72.256" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="333.945853" y="73.53863" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="338.066575" y="69.6226" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="342.135135" y="69.396199" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="346.203696" y="65.353641" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="350.272256" y="66.642857" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="354.340816" y="56.213448" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="358.461538" y="54.562629" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="362.582259" y="56.650667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="366.65082" y="55.936338" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="370.71938" y="53.902" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="374.78794" y="43.832" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="378.908662" y="45.686256" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="383.029383" y="44.848643" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="387.097944" y="48.4" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="391.166504" y="45.984255" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="395.235064" y="46.595117" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="399.303625" y="44.260503" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="403.424346" y="40.827729" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="407.545068" y="42.083303" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="411.613628" y="42.859907" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="415.682188" y="38.085025" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="419.750749" y="42.741565" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="423.87147" y="41.027103" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="427.992192" y="39.29256" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="432.060752" y="39.7774" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="436.129312" y="38.148889" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="440.197873" y="37.688372" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="444.318594" y="36.525286" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="448.439316" y="40.780194" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="452.507876" y="39.667339" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="456.576436" y="38.137736" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="460.644997" y="42.237407" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="464.713557" y="34.543111" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="468.834279" y="35.716683" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m80f4c965dc" x="472.955" y="37.144" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_25">
-    <path d="M 68.060216 85.361677 
-L 72.358285 102.429767 
-L 76.426845 121.153469 
-L 80.495406 137.964568 
-L 84.563966 152.480253 
-L 88.684688 166.300641 
-L 92.805409 174.535541 
-L 96.873969 188.8725 
-L 100.94253 203.906623 
-L 105.01109 210.960851 
-L 109.131812 234.342791 
-L 113.252533 241.346087 
-L 117.321093 248.794469 
-L 121.389654 262.839045 
-L 125.458214 272.095931 
-L 129.526775 278.908085 
-L 133.647496 285.25355 
-L 137.768217 294.904186 
-L 141.836778 296.413043 
-L 145.905338 304.139355 
-L 149.973899 304.854938 
-L 154.09462 302.578194 
-L 158.215341 308.253379 
-L 162.283902 308.223742 
-L 166.352462 306.830535 
-L 170.421023 306.45 
-L 174.489583 305.5 
-L 178.610304 302.018674 
-L 182.731026 297.071922 
-L 186.799586 293.428785 
-L 190.868147 292.96 
-L 194.936707 285.631772 
-L 199.057428 276.544 
-L 203.17815 273.321887 
-L 207.24671 262.760521 
-L 211.315271 253.632317 
-L 215.383831 241.818221 
-L 219.452391 237.068931 
-L 223.573113 226.686997 
-L 227.693834 212.113591 
-L 231.762395 194.497778 
-L 235.830955 194.518958 
-L 239.899515 178.204419 
-L 244.020237 174.666 
-L 248.140958 161.388969 
-L 252.209519 149.142277 
-L 256.278079 141.520656 
-L 260.346639 126.26586 
-L 264.4152 121.665306 
-L 268.535921 106.943686 
-L 272.656643 106.810667 
-L 276.725203 102.115789 
-L 280.793763 89.776747 
-L 284.862324 84.322353 
-L 288.983045 79.905904 
-L 293.103767 78.516279 
-L 297.172327 75.066383 
-L 301.240887 65.34 
-L 305.309448 65.842353 
-L 309.378008 61.536449 
-L 313.498729 57.343427 
-L 317.619451 58.571323 
-L 321.688011 51.246957 
-L 325.756572 50.338261 
-L 329.825132 49.414323 
-L 333.945853 44.946667 
-L 338.066575 43.446154 
-L 342.135135 44.038137 
-L 346.203696 38.146177 
-L 350.272256 40.611852 
-L 354.340816 37.607525 
-L 358.461538 37.401635 
-L 362.582259 36.210552 
-L 366.65082 33.468659 
-L 370.71938 33.721132 
-L 374.78794 34.378213 
-L 378.908662 33.064756 
-L 383.029383 30.576552 
-L 387.097944 36.46 
-L 391.166504 31.724027 
-L 395.235064 33.553392 
-L 399.303625 30.107239 
-L 403.424346 31.1875 
-L 407.545068 31.153491 
-L 411.613628 33.019398 
-L 415.682188 28.739347 
-L 419.750749 30.710435 
-L 423.87147 29.916034 
-L 427.992192 29.595266 
-L 432.060752 28.603243 
-L 436.129312 29.748221 
-L 440.197873 30.38 
-L 444.266433 29.022857 
-L 448.387155 30.224654 
-L 452.507876 30.879359 
-L 456.576436 29.721951 
-L 460.644997 30.044852 
-L 464.713557 28.091392 
-L 468.834279 29.232963 
-L 472.955 28.745116 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
+    <path d="M 68.060216 307.195385 
+L 72.358285 298.846945 
+L 76.426845 284.29227 
+L 80.495406 269.373883 
+L 84.563966 265.511809 
+L 88.684688 262.096352 
+L 92.805409 262.582093 
+L 96.873969 258.20283 
+L 100.94253 266.93 
+L 105.01109 270.737891 
+L 109.131812 277.828889 
+L 113.252533 277.842556 
+L 117.321093 284.679873 
+L 121.389654 283.605976 
+L 125.458214 291.361765 
+L 129.526775 296.828867 
+L 133.647496 300.019556 
+L 137.768217 307.144384 
+L 141.836778 306.819351 
+L 145.905338 307.766897 
+L 149.973899 308.039747 
+L 154.09462 310.80908 
+L 158.215341 312.100657 
+L 162.283902 310.557115 
+L 166.352462 309.036923 
+L 170.421023 309.142222 
+L 174.541744 306.228624 
+L 178.662465 305.39679 
+L 182.731026 302.84 
+L 186.799586 302.407945 
+L 190.868147 290.855177 
+L 194.936707 289.908724 
+L 199.057428 282.379375 
+L 203.17815 273.915294 
+L 207.24671 273.884 
+L 211.315271 263.7 
+L 215.383831 256.603721 
+L 219.504552 251.417231 
+L 223.625274 239.096913 
+L 227.693834 229.972197 
+L 231.762395 226.002353 
+L 235.830955 212.225535 
+L 239.899515 199.48 
+L 244.020237 195.006988 
+L 248.140958 181.61758 
+L 252.209519 179.951935 
+L 256.278079 162.797033 
+L 260.346639 158.56858 
+L 264.467361 141.7485 
+L 268.588082 141.736889 
+L 272.656643 127.322361 
+L 276.725203 131.76012 
+L 280.793763 115.830892 
+L 284.862324 113.892644 
+L 288.983045 105.19292 
+L 293.103767 99.553103 
+L 297.172327 94.843293 
+L 301.240887 91.40424 
+L 305.309448 89.862594 
+L 309.430169 80.596782 
+L 313.55089 81.291915 
+L 317.619451 76.168385 
+L 321.688011 69.80472 
+L 325.756572 73.224317 
+L 329.825132 63.346985 
+L 333.945853 64.891685 
+L 338.066575 65.422609 
+L 342.135135 57.990638 
+L 346.203696 55.262692 
+L 350.272256 54.518261 
+L 354.392977 56.950769 
+L 358.513699 52.394667 
+L 362.582259 48.70908 
+L 366.65082 46.176817 
+L 370.71938 45.07131 
+L 374.840101 43.310201 
+L 378.960823 44.506194 
+L 383.029383 45.066708 
+L 387.097944 40.488 
+L 391.166504 41.297032 
+L 395.235064 37.721975 
+L 399.355786 39.176206 
+L 403.476507 41.570513 
+L 407.545068 41.748852 
+L 411.613628 40.07 
+L 415.682188 39.938985 
+L 419.80291 39.128889 
+L 423.923631 35.033443 
+L 427.992192 37.80858 
+L 432.060752 40.020068 
+L 436.129312 34.572102 
+L 440.197873 37.105752 
+L 444.318594 35.392381 
+L 448.439316 34.296142 
+L 452.507876 36.742928 
+L 456.576436 34.630641 
+L 460.644997 36.4752 
+L 464.765718 35.308757 
+L 468.88644 35.672025 
+L 472.955 33.267516 
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
     <defs>
-     <path id="m7af6fe7da2" d="M 0 1 
+     <path id="m4a97e00387" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2996,118 +2996,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p1668bcb034)">
-     <use xlink:href="#m7af6fe7da2" x="68.060216" y="85.361677" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="72.358285" y="102.429767" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="76.426845" y="121.153469" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="80.495406" y="137.964568" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="84.563966" y="152.480253" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="88.684688" y="166.300641" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="92.805409" y="174.535541" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="96.873969" y="188.8725" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="100.94253" y="203.906623" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="105.01109" y="210.960851" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="109.131812" y="234.342791" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="113.252533" y="241.346087" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="117.321093" y="248.794469" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="121.389654" y="262.839045" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="125.458214" y="272.095931" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="129.526775" y="278.908085" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="133.647496" y="285.25355" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="137.768217" y="294.904186" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="141.836778" y="296.413043" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="145.905338" y="304.139355" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="149.973899" y="304.854938" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="154.09462" y="302.578194" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="158.215341" y="308.253379" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="162.283902" y="308.223742" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="166.352462" y="306.830535" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="170.421023" y="306.45" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="174.489583" y="305.5" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="178.610304" y="302.018674" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="182.731026" y="297.071922" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="186.799586" y="293.428785" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="190.868147" y="292.96" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="194.936707" y="285.631772" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="199.057428" y="276.544" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="203.17815" y="273.321887" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="207.24671" y="262.760521" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="211.315271" y="253.632317" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="215.383831" y="241.818221" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="219.452391" y="237.068931" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="223.573113" y="226.686997" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="227.693834" y="212.113591" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="231.762395" y="194.497778" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="235.830955" y="194.518958" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="239.899515" y="178.204419" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="244.020237" y="174.666" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="248.140958" y="161.388969" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="252.209519" y="149.142277" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="256.278079" y="141.520656" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="260.346639" y="126.26586" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="264.4152" y="121.665306" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="268.535921" y="106.943686" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="272.656643" y="106.810667" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="276.725203" y="102.115789" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="280.793763" y="89.776747" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="284.862324" y="84.322353" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="288.983045" y="79.905904" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="293.103767" y="78.516279" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="297.172327" y="75.066383" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="301.240887" y="65.34" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="305.309448" y="65.842353" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="309.378008" y="61.536449" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="313.498729" y="57.343427" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="317.619451" y="58.571323" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="321.688011" y="51.246957" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="325.756572" y="50.338261" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="329.825132" y="49.414323" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="333.945853" y="44.946667" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="338.066575" y="43.446154" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="342.135135" y="44.038137" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="346.203696" y="38.146177" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="350.272256" y="40.611852" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="354.340816" y="37.607525" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="358.461538" y="37.401635" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="362.582259" y="36.210552" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="366.65082" y="33.468659" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="370.71938" y="33.721132" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="374.78794" y="34.378213" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="378.908662" y="33.064756" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="383.029383" y="30.576552" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="387.097944" y="36.46" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="391.166504" y="31.724027" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="395.235064" y="33.553392" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="399.303625" y="30.107239" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="403.424346" y="31.1875" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="407.545068" y="31.153491" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="411.613628" y="33.019398" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="415.682188" y="28.739347" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="419.750749" y="30.710435" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="423.87147" y="29.916034" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="427.992192" y="29.595266" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="432.060752" y="28.603243" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="436.129312" y="29.748221" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="440.197873" y="30.38" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="444.266433" y="29.022857" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="448.387155" y="30.224654" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="452.507876" y="30.879359" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="456.576436" y="29.721951" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="460.644997" y="30.044852" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="464.713557" y="28.091392" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="468.834279" y="29.232963" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m7af6fe7da2" x="472.955" y="28.745116" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pb06ad7982b)">
+     <use xlink:href="#m4a97e00387" x="68.060216" y="307.195385" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="72.358285" y="298.846945" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="76.426845" y="284.29227" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="80.495406" y="269.373883" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="84.563966" y="265.511809" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="88.684688" y="262.096352" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="92.805409" y="262.582093" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="96.873969" y="258.20283" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="100.94253" y="266.93" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="105.01109" y="270.737891" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="109.131812" y="277.828889" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="113.252533" y="277.842556" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="117.321093" y="284.679873" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="121.389654" y="283.605976" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="125.458214" y="291.361765" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="129.526775" y="296.828867" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="133.647496" y="300.019556" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="137.768217" y="307.144384" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="141.836778" y="306.819351" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="145.905338" y="307.766897" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="149.973899" y="308.039747" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="154.09462" y="310.80908" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="158.215341" y="312.100657" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="162.283902" y="310.557115" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="166.352462" y="309.036923" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="170.421023" y="309.142222" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="174.541744" y="306.228624" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="178.662465" y="305.39679" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="182.731026" y="302.84" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="186.799586" y="302.407945" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="190.868147" y="290.855177" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="194.936707" y="289.908724" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="199.057428" y="282.379375" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="203.17815" y="273.915294" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="207.24671" y="273.884" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="211.315271" y="263.7" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="215.383831" y="256.603721" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="219.504552" y="251.417231" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="223.625274" y="239.096913" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="227.693834" y="229.972197" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="231.762395" y="226.002353" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="235.830955" y="212.225535" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="239.899515" y="199.48" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="244.020237" y="195.006988" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="248.140958" y="181.61758" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="252.209519" y="179.951935" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="256.278079" y="162.797033" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="260.346639" y="158.56858" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="264.467361" y="141.7485" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="268.588082" y="141.736889" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="272.656643" y="127.322361" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="276.725203" y="131.76012" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="280.793763" y="115.830892" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="284.862324" y="113.892644" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="288.983045" y="105.19292" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="293.103767" y="99.553103" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="297.172327" y="94.843293" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="301.240887" y="91.40424" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="305.309448" y="89.862594" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="309.430169" y="80.596782" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="313.55089" y="81.291915" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="317.619451" y="76.168385" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="321.688011" y="69.80472" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="325.756572" y="73.224317" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="329.825132" y="63.346985" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="333.945853" y="64.891685" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="338.066575" y="65.422609" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="342.135135" y="57.990638" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="346.203696" y="55.262692" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="350.272256" y="54.518261" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="354.392977" y="56.950769" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="358.513699" y="52.394667" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="362.582259" y="48.70908" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="366.65082" y="46.176817" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="370.71938" y="45.07131" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="374.840101" y="43.310201" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="378.960823" y="44.506194" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="383.029383" y="45.066708" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="387.097944" y="40.488" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="391.166504" y="41.297032" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="395.235064" y="37.721975" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="399.355786" y="39.176206" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="403.476507" y="41.570513" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="407.545068" y="41.748852" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="411.613628" y="40.07" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="415.682188" y="39.938985" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="419.80291" y="39.128889" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="423.923631" y="35.033443" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="427.992192" y="37.80858" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="432.060752" y="40.020068" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="436.129312" y="34.572102" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="440.197873" y="37.105752" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="444.318594" y="35.392381" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="448.439316" y="34.296142" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="452.507876" y="36.742928" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="456.576436" y="34.630641" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="460.644997" y="36.4752" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="464.765718" y="35.308757" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="468.88644" y="35.672025" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m4a97e00387" x="472.955" y="33.267516" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_26">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_27">
     <path d="M 162.023097 318.04 
 L 162.023097 25.44 
-" clip-path="url(#p1668bcb034)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#pb06ad7982b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -3330,21 +3330,21 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 369.12875 314.04 
-L 487.6 314.04 
-Q 489.2 314.04 489.2 312.44 
-L 489.2 182.136875 
-Q 489.2 180.536875 487.6 180.536875 
-L 369.12875 180.536875 
-Q 367.52875 180.536875 367.52875 182.136875 
-L 367.52875 312.44 
-Q 367.52875 314.04 369.12875 314.04 
+     <path d="M 53.41 238.491563 
+L 171.88125 238.491563 
+Q 173.48125 238.491563 173.48125 236.891563 
+L 173.48125 106.588437 
+Q 173.48125 104.988438 171.88125 104.988438 
+L 53.41 104.988438 
+Q 51.81 104.988438 51.81 106.588437 
+L 51.81 236.891563 
+Q 51.81 238.491563 53.41 238.491563 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="text_19">
      <!-- Cell type -->
-     <g transform="translate(406.258906 191.335313) scale(0.1 -0.1)">
+     <g transform="translate(90.540156 115.786875) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-43"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
       <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
@@ -3357,17 +3357,17 @@ z
      </g>
     </g>
     <g id="line2d_28">
-     <path d="M 370.72875 200.69375 
-L 378.72875 200.69375 
-L 386.72875 200.69375 
+     <path d="M 55.01 125.145313 
+L 63.01 125.145313 
+L 71.01 125.145313 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcab563d38d" x="378.72875" y="200.69375" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#mf4c2f13220" x="63.01" y="125.145313" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
      <!-- Cardiomyocytes -->
-     <g transform="translate(393.12875 203.49375) scale(0.08 -0.08)">
+     <g transform="translate(77.41 127.945312) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -3418,17 +3418,17 @@ z
      </g>
     </g>
     <g id="line2d_29">
-     <path d="M 370.72875 212.43625 
-L 378.72875 212.43625 
-L 386.72875 212.43625 
+     <path d="M 55.01 136.887812 
+L 63.01 136.887812 
+L 71.01 136.887812 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#macc6760856" x="378.72875" y="212.43625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m942f1f9cbb" x="63.01" y="136.887812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
      <!-- EpiblastPrimitiveStreak -->
-     <g transform="translate(393.12875 215.23625) scale(0.08 -0.08)">
+     <g transform="translate(77.41 139.687813) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-45" d="M 628 4666 
 L 3578 4666 
@@ -3512,17 +3512,17 @@ z
      </g>
     </g>
     <g id="line2d_30">
-     <path d="M 370.72875 224.17875 
-L 378.72875 224.17875 
-L 386.72875 224.17875 
+     <path d="M 55.01 148.630313 
+L 63.01 148.630313 
+L 71.01 148.630313 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m822c9ce222" x="378.72875" y="224.17875" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#m4d42af8b23" x="63.01" y="148.630313" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_22">
      <!-- ExEndodermParietal -->
-     <g transform="translate(393.12875 226.97875) scale(0.08 -0.08)">
+     <g transform="translate(77.41 151.430313) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -3561,17 +3561,17 @@ z
      </g>
     </g>
     <g id="line2d_31">
-     <path d="M 370.72875 235.92125 
-L 378.72875 235.92125 
-L 386.72875 235.92125 
+     <path d="M 55.01 160.372813 
+L 63.01 160.372813 
+L 71.01 160.372813 
 " style="fill: none; stroke: #d62728; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbb0db5921f" x="378.72875" y="235.92125" style="fill: #d62728; stroke: #d62728"/>
+      <use xlink:href="#m75121de8ea" x="63.01" y="160.372813" style="fill: #d62728; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_23">
      <!-- ExEndodermVisceral -->
-     <g transform="translate(393.12875 238.72125) scale(0.08 -0.08)">
+     <g transform="translate(77.41 163.172813) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-56" d="M 1831 0 
 L 50 4666 
@@ -3605,17 +3605,17 @@ z
      </g>
     </g>
     <g id="line2d_32">
-     <path d="M 370.72875 247.66375 
-L 378.72875 247.66375 
-L 386.72875 247.66375 
+     <path d="M 55.01 172.115312 
+L 63.01 172.115312 
+L 71.01 172.115312 
 " style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mef0e140f3f" x="378.72875" y="247.66375" style="fill: #9467bd; stroke: #9467bd"/>
+      <use xlink:href="#m593a170770" x="63.01" y="172.115312" style="fill: #9467bd; stroke: #9467bd"/>
      </g>
     </g>
     <g id="text_24">
      <!-- Haematoendothelial -->
-     <g transform="translate(393.12875 250.46375) scale(0.08 -0.08)">
+     <g transform="translate(77.41 174.915312) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-48" d="M 628 4666 
 L 1259 4666 
@@ -3654,17 +3654,17 @@ z
      </g>
     </g>
     <g id="line2d_33">
-     <path d="M 370.72875 259.40625 
-L 378.72875 259.40625 
-L 386.72875 259.40625 
+     <path d="M 55.01 183.857812 
+L 63.01 183.857812 
+L 71.01 183.857812 
 " style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m485cd52254" x="378.72875" y="259.40625" style="fill: #8c564b; stroke: #8c564b"/>
+      <use xlink:href="#m32f79c2545" x="63.01" y="183.857812" style="fill: #8c564b; stroke: #8c564b"/>
      </g>
     </g>
     <g id="text_25">
      <!-- Mesoderm -->
-     <g transform="translate(393.12875 262.20625) scale(0.08 -0.08)">
+     <g transform="translate(77.41 186.657813) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-4d" d="M 628 4666 
 L 1569 4666 
@@ -3694,17 +3694,17 @@ z
      </g>
     </g>
     <g id="line2d_34">
-     <path d="M 370.72875 271.14875 
-L 378.72875 271.14875 
-L 386.72875 271.14875 
+     <path d="M 55.01 195.600312 
+L 63.01 195.600312 
+L 71.01 195.600312 
 " style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mfa4a2b6300" x="378.72875" y="271.14875" style="fill: #e377c2; stroke: #e377c2"/>
+      <use xlink:href="#m5f84e627c7" x="63.01" y="195.600312" style="fill: #e377c2; stroke: #e377c2"/>
      </g>
     </g>
     <g id="text_26">
      <!-- NeuroectodermBrain -->
-     <g transform="translate(393.12875 273.94875) scale(0.08 -0.08)">
+     <g transform="translate(77.41 198.400312) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-4e" d="M 628 4666 
 L 1478 4666 
@@ -3773,17 +3773,17 @@ z
      </g>
     </g>
     <g id="line2d_35">
-     <path d="M 370.72875 282.89125 
-L 378.72875 282.89125 
-L 386.72875 282.89125 
+     <path d="M 55.01 207.342812 
+L 63.01 207.342812 
+L 71.01 207.342812 
 " style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m58197e914b" x="378.72875" y="282.89125" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+      <use xlink:href="#m220b9d30a3" x="63.01" y="207.342812" style="fill: #7f7f7f; stroke: #7f7f7f"/>
      </g>
     </g>
     <g id="text_27">
      <!-- NeuroectodermRostral -->
-     <g transform="translate(393.12875 285.69125) scale(0.08 -0.08)">
+     <g transform="translate(77.41 210.142812) scale(0.08 -0.08)">
       <use xlink:href="#DejaVuSans-4e"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(74.804688 0)"/>
       <use xlink:href="#DejaVuSans-75" transform="translate(136.328125 0)"/>
@@ -3807,17 +3807,17 @@ L 386.72875 282.89125
      </g>
     </g>
     <g id="line2d_36">
-     <path d="M 370.72875 294.63375 
-L 378.72875 294.63375 
-L 386.72875 294.63375 
+     <path d="M 55.01 219.085312 
+L 63.01 219.085312 
+L 71.01 219.085312 
 " style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9bf7f81920" x="378.72875" y="294.63375" style="fill: #bcbd22; stroke: #bcbd22"/>
+      <use xlink:href="#m80f4c965dc" x="63.01" y="219.085312" style="fill: #bcbd22; stroke: #bcbd22"/>
      </g>
     </g>
     <g id="text_28">
      <!-- SurfaceEctoderm -->
-     <g transform="translate(393.12875 297.43375) scale(0.08 -0.08)">
+     <g transform="translate(77.41 221.885312) scale(0.08 -0.08)">
       <use xlink:href="#DejaVuSans-53"/>
       <use xlink:href="#DejaVuSans-75" transform="translate(63.476562 0)"/>
       <use xlink:href="#DejaVuSans-72" transform="translate(126.855469 0)"/>
@@ -3836,17 +3836,17 @@ L 386.72875 294.63375
      </g>
     </g>
     <g id="line2d_37">
-     <path d="M 370.72875 306.37625 
-L 378.72875 306.37625 
-L 386.72875 306.37625 
+     <path d="M 55.01 230.827812 
+L 63.01 230.827812 
+L 71.01 230.827812 
 " style="fill: none; stroke: #17becf; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7af6fe7da2" x="378.72875" y="306.37625" style="fill: #17becf; stroke: #17becf"/>
+      <use xlink:href="#m4a97e00387" x="63.01" y="230.827812" style="fill: #17becf; stroke: #17becf"/>
      </g>
     </g>
     <g id="text_29">
      <!-- Pluripotent -->
-     <g transform="translate(393.12875 309.17625) scale(0.08 -0.08)">
+     <g transform="translate(77.41 233.627813) scale(0.08 -0.08)">
       <use xlink:href="#DejaVuSans-50"/>
       <use xlink:href="#DejaVuSans-6c" transform="translate(60.302734 0)"/>
       <use xlink:href="#DejaVuSans-75" transform="translate(88.085938 0)"/>
@@ -3864,7 +3864,7 @@ L 386.72875 306.37625
   </g>
  </g>
  <defs>
-  <clipPath id="p1668bcb034">
+  <clipPath id="pb06ad7982b">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:39.881810</dc:date>
+    <dc:date>2026-08-16T17:12:23.020178</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m09207e4bde" d="M 0 0 
+       <path id="m9ec1b69fa3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09207e4bde" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -91,7 +91,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m09207e4bde" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -133,7 +133,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m09207e4bde" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -164,7 +164,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m09207e4bde" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -179,7 +179,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m09207e4bde" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -220,7 +220,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m09207e4bde" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -235,7 +235,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m09207e4bde" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -284,7 +284,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m09207e4bde" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -299,7 +299,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m09207e4bde" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ec1b69fa3" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,12 +617,12 @@ z
     <g id="ytick_1">
      <g id="line2d_10">
       <defs>
-       <path id="mcbd001b34e" d="M 0 0 
+       <path id="m494d02eb14" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -637,7 +637,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -652,7 +652,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -667,7 +667,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -714,7 +714,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -770,7 +770,7 @@ z
     <g id="ytick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mcbd001b34e" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494d02eb14" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -920,109 +920,109 @@ z
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 68.195835 27.186866 
-L 72.462607 26.368889 
-L 76.583329 27.161176 
-L 80.70405 31.546435 
-L 84.77261 27.607407 
-L 88.841171 32.701606 
-L 92.909731 40.282029 
-L 96.978291 42.355938 
-L 101.099013 57.36 
-L 105.219734 64.773115 
-L 109.288295 89.623226 
-L 113.356855 114.562202 
-L 117.425415 130.519708 
-L 121.493976 157 
-L 125.614697 193.823019 
-L 129.735419 212.798387 
-L 133.803979 230.014118 
-L 137.872539 252.787611 
-L 141.9411 270.035313 
-L 146.00966 279.502439 
-L 150.130382 295.257405 
-L 154.251103 293.77561 
-L 158.319663 305.28 
-L 162.388224 305.035556 
-L 166.456784 302.612 
-L 170.577506 299.77844 
-L 174.698227 299.805507 
-L 178.766787 289.021818 
-L 182.835348 279.34129 
-L 186.903908 268.371765 
-L 190.972469 254.968444 
-L 195.09319 234.88 
-L 199.213911 230.26 
-L 203.282472 211.813478 
-L 207.351032 193.261818 
-L 211.419593 170.226552 
-L 215.488153 140.352 
-L 219.608874 132.726667 
-L 223.729596 115.786667 
-L 227.798156 117.334688 
-L 231.866717 100.85662 
-L 235.935277 96.816667 
-L 240.003837 88.42339 
-L 244.124559 72.348889 
-L 248.24528 66.984733 
-L 252.313841 55.241852 
-L 256.382401 50.815929 
-L 260.450961 52.261667 
-L 264.519522 48.018583 
-L 268.640243 48.061176 
-L 272.760965 41.771163 
-L 276.829525 39.93578 
-L 280.898085 37.649209 
-L 284.966646 32.549907 
-L 289.035206 31.136637 
-L 293.155928 31.990746 
-L 297.276649 31.6 
-L 301.345209 31.149268 
-L 305.41377 28.271613 
-L 309.48233 29.164 
-L 313.55089 27.858182 
-L 317.671612 28.575 
-L 321.792333 27.7808 
-L 325.860894 26.565385 
-L 329.929454 27.812432 
-L 333.998014 26.855806 
-L 338.066575 29.510957 
-L 342.187296 26.457739 
-L 346.308018 26.457739 
-L 350.376578 25.900787 
-L 354.445138 27.838361 
-L 358.513699 25.44 
-L 362.582259 25.855035 
-L 366.702981 26.440342 
-L 370.823702 25.981852 
-L 374.892262 26.383871 
-L 378.960823 25.904444 
-L 383.029383 25.923636 
-L 387.097944 25.44 
-L 391.218665 25.44 
-L 395.339386 25.897188 
-L 399.407947 26.333435 
-L 403.476507 25.44 
-L 407.545068 25.953333 
-L 411.613628 26.466667 
-L 415.734349 25.90816 
-L 419.855071 26.276 
-L 423.923631 25.44 
-L 427.992192 25.940171 
-L 432.060752 25.44 
-L 436.129312 25.867153 
-L 440.250034 25.44 
-L 444.370755 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.911935 
-L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+    <path d="M 68.060216 26.822362 
+L 72.358285 25.976881 
+L 76.426845 27.656667 
+L 80.495406 29.002087 
+L 84.563966 31.508741 
+L 88.684688 35.410074 
+L 92.805409 38.8996 
+L 96.873969 46.373984 
+L 100.94253 62.3076 
+L 105.01109 71.074862 
+L 109.079651 93.713333 
+L 113.200372 114.530149 
+L 117.321093 139.206154 
+L 121.389654 179.842769 
+L 125.458214 178.347097 
+L 129.526775 220.345455 
+L 133.595335 238.836207 
+L 137.716056 258.519658 
+L 141.836778 270.001194 
+L 145.905338 290.130462 
+L 149.973899 296.347241 
+L 154.042459 306.981102 
+L 158.16318 306.336 
+L 162.283902 308.218462 
+L 166.352462 309.206792 
+L 170.421023 302.8875 
+L 174.489583 299.046667 
+L 178.558143 288.266667 
+L 182.678865 279.186557 
+L 186.799586 268.490219 
+L 190.868147 255.372913 
+L 194.936707 236.53 
+L 199.005267 215.142333 
+L 203.073828 221.829153 
+L 207.194549 204.385455 
+L 211.315271 183.169688 
+L 215.383831 172.654375 
+L 219.452391 158.085333 
+L 223.520952 135.662136 
+L 227.589512 125.552727 
+L 231.710233 108.175172 
+L 235.830955 101.828702 
+L 239.899515 93.434667 
+L 243.968076 85.36448 
+L 248.036636 74.869515 
+L 252.157357 72.153333 
+L 256.278079 61.229091 
+L 260.346639 64.642718 
+L 264.4152 53.237 
+L 268.48376 44.127059 
+L 272.55232 45.446838 
+L 276.673042 41.4 
+L 280.793763 37.944274 
+L 284.862324 40.42112 
+L 288.930884 38.391148 
+L 292.999444 34.76177 
+L 297.068005 34.68 
+L 301.188726 36.22 
+L 305.309448 31.998276 
+L 309.378008 32.809185 
+L 313.446568 30.1425 
+L 317.515129 30.72 
+L 321.583689 29.13045 
+L 325.704411 28.825455 
+L 329.825132 29.491385 
+L 333.893692 29.441368 
+L 337.962253 27.240615 
+L 342.030813 27.818862 
+L 346.151535 27.838361 
+L 350.272256 26.703022 
+L 354.340816 25.931765 
+L 358.409377 26.383871 
+L 362.477937 28.271613 
+L 366.546498 27.7808 
+L 370.667219 26.80093 
+L 374.78794 26.879016 
+L 378.856501 26.347287 
+L 382.925061 27.161176 
+L 386.993622 26.903 
+L 391.062182 27.53 
+L 395.182903 26.333435 
+L 399.303625 25.44 
+L 403.372185 26.354375 
+L 407.440746 25.919672 
+L 411.509306 25.883333 
+L 415.577866 26.554667 
+L 419.698588 25.44 
+L 423.819309 25.44 
+L 427.88787 25.88 
+L 431.95643 26.340308 
+L 436.02499 25.44 
+L 440.145712 25.44 
+L 444.266433 25.953333 
+L 448.334994 25.904444 
+L 452.403554 25.972 
+L 456.472114 25.44 
+L 460.540675 25.953333 
+L 464.661396 25.44 
+L 468.782118 25.944483 
+L 472.850678 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="m1a09366b54" d="M 0 1 
+     <path id="me3d1f519f4" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1034,213 +1034,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m1a09366b54" x="68.195835" y="27.186866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="72.462607" y="26.368889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="76.583329" y="27.161176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="80.70405" y="31.546435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="84.77261" y="27.607407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="88.841171" y="32.701606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="92.909731" y="40.282029" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="96.978291" y="42.355938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="101.099013" y="57.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="105.219734" y="64.773115" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="109.288295" y="89.623226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="113.356855" y="114.562202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="117.425415" y="130.519708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="121.493976" y="157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="125.614697" y="193.823019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="129.735419" y="212.798387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="133.803979" y="230.014118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="137.872539" y="252.787611" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="141.9411" y="270.035313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="146.00966" y="279.502439" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="150.130382" y="295.257405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="154.251103" y="293.77561" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="158.319663" y="305.28" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="162.388224" y="305.035556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="166.456784" y="302.612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="170.577506" y="299.77844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="174.698227" y="299.805507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="178.766787" y="289.021818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="182.835348" y="279.34129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="186.903908" y="268.371765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="190.972469" y="254.968444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="195.09319" y="234.88" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="199.213911" y="230.26" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="203.282472" y="211.813478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="207.351032" y="193.261818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="211.419593" y="170.226552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="215.488153" y="140.352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="219.608874" y="132.726667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="223.729596" y="115.786667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="227.798156" y="117.334688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="231.866717" y="100.85662" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="235.935277" y="96.816667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="240.003837" y="88.42339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="244.124559" y="72.348889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="248.24528" y="66.984733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="252.313841" y="55.241852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="256.382401" y="50.815929" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="260.450961" y="52.261667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="264.519522" y="48.018583" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="268.640243" y="48.061176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="272.760965" y="41.771163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="276.829525" y="39.93578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="280.898085" y="37.649209" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="284.966646" y="32.549907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="289.035206" y="31.136637" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="293.155928" y="31.990746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="297.276649" y="31.6" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="301.345209" y="31.149268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="305.41377" y="28.271613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="309.48233" y="29.164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="313.55089" y="27.858182" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="317.671612" y="28.575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="321.792333" y="27.7808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="325.860894" y="26.565385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="329.929454" y="27.812432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="333.998014" y="26.855806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="338.066575" y="29.510957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="342.187296" y="26.457739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="346.308018" y="26.457739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="350.376578" y="25.900787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="354.445138" y="27.838361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="358.513699" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="362.582259" y="25.855035" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="366.702981" y="26.440342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="370.823702" y="25.981852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="374.892262" y="26.383871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="378.960823" y="25.904444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="383.029383" y="25.923636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="387.097944" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="391.218665" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="395.339386" y="25.897188" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="399.407947" y="26.333435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="403.476507" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="407.545068" y="25.953333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="411.613628" y="26.466667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="415.734349" y="25.90816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="419.855071" y="26.276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="423.923631" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="427.992192" y="25.940171" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="432.060752" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="436.129312" y="25.867153" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="440.250034" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="444.370755" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="448.439316" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="452.507876" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="456.576436" y="25.911935" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="460.644997" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="464.765718" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="468.88644" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m1a09366b54" x="472.955" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#me3d1f519f4" x="68.060216" y="26.822362" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="72.358285" y="25.976881" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="76.426845" y="27.656667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="80.495406" y="29.002087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="84.563966" y="31.508741" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="88.684688" y="35.410074" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="92.805409" y="38.8996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="96.873969" y="46.373984" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="100.94253" y="62.3076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="105.01109" y="71.074862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="109.079651" y="93.713333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="113.200372" y="114.530149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="117.321093" y="139.206154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="121.389654" y="179.842769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="125.458214" y="178.347097" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="129.526775" y="220.345455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="133.595335" y="238.836207" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="137.716056" y="258.519658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="141.836778" y="270.001194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="145.905338" y="290.130462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="149.973899" y="296.347241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="154.042459" y="306.981102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="158.16318" y="306.336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="162.283902" y="308.218462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="166.352462" y="309.206792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="170.421023" y="302.8875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="174.489583" y="299.046667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="178.558143" y="288.266667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="182.678865" y="279.186557" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="186.799586" y="268.490219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="190.868147" y="255.372913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="194.936707" y="236.53" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="199.005267" y="215.142333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="203.073828" y="221.829153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="207.194549" y="204.385455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="211.315271" y="183.169688" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="215.383831" y="172.654375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="219.452391" y="158.085333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="223.520952" y="135.662136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="227.589512" y="125.552727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="231.710233" y="108.175172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="235.830955" y="101.828702" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="239.899515" y="93.434667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="243.968076" y="85.36448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="248.036636" y="74.869515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="252.157357" y="72.153333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="256.278079" y="61.229091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="260.346639" y="64.642718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="264.4152" y="53.237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="268.48376" y="44.127059" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="272.55232" y="45.446838" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="276.673042" y="41.4" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="280.793763" y="37.944274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="284.862324" y="40.42112" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="288.930884" y="38.391148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="292.999444" y="34.76177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="297.068005" y="34.68" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="301.188726" y="36.22" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="305.309448" y="31.998276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="309.378008" y="32.809185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="313.446568" y="30.1425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="317.515129" y="30.72" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="321.583689" y="29.13045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="325.704411" y="28.825455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="329.825132" y="29.491385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="333.893692" y="29.441368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="337.962253" y="27.240615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="342.030813" y="27.818862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="346.151535" y="27.838361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="350.272256" y="26.703022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="354.340816" y="25.931765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="358.409377" y="26.383871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="362.477937" y="28.271613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="366.546498" y="27.7808" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="370.667219" y="26.80093" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="374.78794" y="26.879016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="378.856501" y="26.347287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="382.925061" y="27.161176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="386.993622" y="26.903" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="391.062182" y="27.53" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="395.182903" y="26.333435" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="399.303625" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="403.372185" y="26.354375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="407.440746" y="25.919672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="411.509306" y="25.883333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="415.577866" y="26.554667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="419.698588" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="423.819309" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="427.88787" y="25.88" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="431.95643" y="26.340308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="436.02499" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="440.145712" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="444.266433" y="25.953333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="448.334994" y="25.904444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="452.403554" y="25.972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="456.472114" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="460.540675" y="25.953333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="464.661396" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="468.782118" y="25.944483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me3d1f519f4" x="472.850678" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_17">
     <path d="M 68.065432 25.44 
 L 72.358285 25.44 
 L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.616127 25.646056 
-L 88.736849 25.44 
-L 92.805409 26.2912 
-L 96.873969 27.148613 
-L 100.94253 29.736923 
-L 105.01109 33.400441 
-L 109.131812 37.226714 
-L 113.252533 41.158964 
-L 117.321093 54.906056 
-L 121.389654 69.111642 
-L 125.458214 97.132399 
-L 129.578936 132.16613 
-L 133.699657 158.769072 
-L 137.768217 197.268859 
-L 141.836778 231.778685 
-L 145.905338 258.710035 
-L 149.973899 283.558519 
-L 154.09462 296.60198 
-L 158.215341 303.361716 
-L 162.283902 304.065075 
-L 166.352462 300.883534 
-L 170.421023 295.82 
-L 174.541744 277.980568 
-L 178.662465 265.500146 
-L 182.731026 242.771172 
-L 186.799586 215.724387 
-L 190.868147 178.419936 
-L 194.936707 163.146914 
-L 199.057428 141.727331 
-L 203.17815 106.816296 
-L 207.24671 95.246 
-L 211.315271 81.213574 
-L 215.383831 60.682528 
-L 219.504552 56.608261 
-L 223.625274 45.224342 
-L 227.693834 42.562519 
-L 231.762395 36.495896 
-L 235.830955 33.371282 
-L 239.951676 32.0368 
-L 244.072398 30.798974 
-L 248.140958 30.090596 
-L 252.209519 28.561067 
-L 256.278079 28.16186 
-L 260.346639 27.536808 
-L 264.467361 26.990199 
-L 268.588082 25.852113 
-L 272.656643 26.470282 
-L 276.725203 25.846389 
-L 280.793763 27.167528 
-L 284.914485 26.330038 
-L 289.035206 26.069247 
-L 293.103767 25.846389 
-L 297.172327 26.267138 
-L 301.240887 25.44 
-L 305.309448 25.826271 
-L 309.430169 25.852113 
-L 313.55089 25.44 
-L 317.619451 25.650504 
-L 321.688011 25.44 
+L 80.495406 25.620617 
+L 84.563966 25.44 
+L 88.684688 26.095075 
+L 92.805409 27.052756 
+L 96.873969 26.838089 
+L 100.94253 29.468551 
+L 105.01109 33.256751 
+L 109.131812 35.94359 
+L 113.252533 43.888678 
+L 117.321093 53.90381 
+L 121.389654 74.307216 
+L 125.458214 103.393057 
+L 129.526775 130.691799 
+L 133.647496 167.262491 
+L 137.768217 202.500513 
+L 141.836778 235.119435 
+L 145.905338 264.541518 
+L 149.973899 284.03 
+L 154.09462 293.159048 
+L 158.215341 303.659659 
+L 162.283902 303.613194 
+L 166.352462 301.804268 
+L 170.421023 296.845256 
+L 174.489583 286.738605 
+L 178.610304 272.636552 
+L 182.731026 247.175938 
+L 186.799586 223.448656 
+L 190.868147 200.20381 
+L 194.936707 174.253746 
+L 199.057428 142.691264 
+L 203.17815 125.180292 
+L 207.24671 99.463433 
+L 211.315271 89.022284 
+L 215.383831 72.09512 
+L 219.452391 57.557037 
+L 223.573113 58.344484 
+L 227.693834 46.323608 
+L 231.762395 44.729926 
+L 235.830955 38.24125 
+L 239.899515 33.653333 
+L 243.968076 31.760976 
+L 248.088797 30.412288 
+L 252.209519 30.300465 
+L 256.278079 29.110244 
+L 260.346639 28.072388 
+L 264.4152 27.358689 
+L 268.535921 28.109333 
+L 272.656643 27.464277 
+L 276.725203 26.445498 
+L 280.793763 26.703022 
+L 284.862324 25.79792 
+L 288.930884 25.631869 
+L 293.051605 25.44 
+L 297.172327 25.44 
+L 301.240887 25.639727 
+L 305.309448 25.626369 
+L 309.378008 25.858 
+L 313.498729 25.44 
+L 317.619451 25.44 
+L 321.688011 25.640411 
 L 325.756572 25.44 
-L 329.877293 25.44 
-L 333.998014 25.44 
-L 338.066575 25.44 
-L 342.135135 25.81877 
+L 329.825132 25.44 
+L 333.893692 25.643902 
+L 338.014414 25.44 
+L 342.135135 25.44 
 L 346.203696 25.44 
 L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
+L 354.340816 25.44 
+L 358.461538 25.44 
 L 362.582259 25.44 
 L 366.65082 25.44 
 L 370.71938 25.44 
-L 374.840101 25.44 
-L 378.960823 25.44 
-L 383.029383 25.44 
+L 374.78794 25.634419 
+L 378.856501 25.44 
+L 382.977222 25.44 
 L 387.097944 25.44 
 L 391.166504 25.44 
 L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
+L 399.303625 25.44 
+L 403.424346 25.44 
 L 407.545068 25.44 
 L 411.613628 25.44 
 L 415.682188 25.44 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
+L 419.750749 25.44 
+L 423.819309 25.44 
+L 427.940031 25.44 
 L 432.060752 25.44 
 L 436.129312 25.44 
 L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
+L 444.266433 25.44 
+L 448.334994 25.44 
+L 452.455715 25.44 
 L 456.576436 25.44 
 L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+L 464.713557 25.44 
+L 468.782118 25.44 
+L 472.902839 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="m087ed5a55f" d="M 0 1 
+     <path id="m305b67a360" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1252,168 +1252,168 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m087ed5a55f" x="68.065432" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="72.358285" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="76.426845" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="80.495406" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="84.616127" y="25.646056" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="88.736849" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="92.805409" y="26.2912" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="96.873969" y="27.148613" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="100.94253" y="29.736923" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="105.01109" y="33.400441" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="109.131812" y="37.226714" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="113.252533" y="41.158964" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="117.321093" y="54.906056" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="121.389654" y="69.111642" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="125.458214" y="97.132399" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="129.578936" y="132.16613" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="133.699657" y="158.769072" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="137.768217" y="197.268859" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="141.836778" y="231.778685" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="145.905338" y="258.710035" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="149.973899" y="283.558519" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="154.09462" y="296.60198" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="158.215341" y="303.361716" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="162.283902" y="304.065075" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="166.352462" y="300.883534" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="170.421023" y="295.82" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="174.541744" y="277.980568" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="178.662465" y="265.500146" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="182.731026" y="242.771172" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="186.799586" y="215.724387" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="190.868147" y="178.419936" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="194.936707" y="163.146914" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="199.057428" y="141.727331" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="203.17815" y="106.816296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="207.24671" y="95.246" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="211.315271" y="81.213574" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="215.383831" y="60.682528" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="219.504552" y="56.608261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="223.625274" y="45.224342" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="227.693834" y="42.562519" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="231.762395" y="36.495896" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="235.830955" y="33.371282" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="239.951676" y="32.0368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="244.072398" y="30.798974" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="248.140958" y="30.090596" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="252.209519" y="28.561067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="256.278079" y="28.16186" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="260.346639" y="27.536808" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="264.467361" y="26.990199" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="268.588082" y="25.852113" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="272.656643" y="26.470282" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="276.725203" y="25.846389" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="280.793763" y="27.167528" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="284.914485" y="26.330038" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="289.035206" y="26.069247" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="293.103767" y="25.846389" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="297.172327" y="26.267138" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="301.240887" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="305.309448" y="25.826271" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="309.430169" y="25.852113" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="313.55089" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="317.619451" y="25.650504" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="321.688011" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="325.756572" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="329.877293" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="333.998014" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="338.066575" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="342.135135" y="25.81877" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="346.203696" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="350.272256" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="354.392977" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="358.513699" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="362.582259" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="366.65082" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="370.71938" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="374.840101" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="378.960823" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="383.029383" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="387.097944" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="391.166504" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="395.235064" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="399.355786" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="403.476507" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="407.545068" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="411.613628" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="415.682188" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="419.80291" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="423.923631" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="427.992192" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="432.060752" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="436.129312" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="440.197873" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="444.318594" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="448.439316" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="452.507876" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="456.576436" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="460.644997" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="464.765718" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="468.88644" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m087ed5a55f" x="472.955" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#m305b67a360" x="68.065432" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="72.358285" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="76.426845" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="80.495406" y="25.620617" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="84.563966" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="88.684688" y="26.095075" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="92.805409" y="27.052756" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="96.873969" y="26.838089" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="100.94253" y="29.468551" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="105.01109" y="33.256751" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="109.131812" y="35.94359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="113.252533" y="43.888678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="117.321093" y="53.90381" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="121.389654" y="74.307216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="125.458214" y="103.393057" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="129.526775" y="130.691799" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="133.647496" y="167.262491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="137.768217" y="202.500513" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="141.836778" y="235.119435" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="145.905338" y="264.541518" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="149.973899" y="284.03" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="154.09462" y="293.159048" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="158.215341" y="303.659659" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="162.283902" y="303.613194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="166.352462" y="301.804268" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="170.421023" y="296.845256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="174.489583" y="286.738605" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="178.610304" y="272.636552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="182.731026" y="247.175938" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="186.799586" y="223.448656" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="190.868147" y="200.20381" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="194.936707" y="174.253746" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="199.057428" y="142.691264" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="203.17815" y="125.180292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="207.24671" y="99.463433" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="211.315271" y="89.022284" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="215.383831" y="72.09512" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="219.452391" y="57.557037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="223.573113" y="58.344484" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="227.693834" y="46.323608" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="231.762395" y="44.729926" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="235.830955" y="38.24125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="239.899515" y="33.653333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="243.968076" y="31.760976" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="248.088797" y="30.412288" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="252.209519" y="30.300465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="256.278079" y="29.110244" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="260.346639" y="28.072388" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="264.4152" y="27.358689" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="268.535921" y="28.109333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="272.656643" y="27.464277" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="276.725203" y="26.445498" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="280.793763" y="26.703022" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="284.862324" y="25.79792" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="288.930884" y="25.631869" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="293.051605" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="297.172327" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="301.240887" y="25.639727" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="305.309448" y="25.626369" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="309.378008" y="25.858" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="313.498729" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="317.619451" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="321.688011" y="25.640411" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="325.756572" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="329.825132" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="333.893692" y="25.643902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="338.014414" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="342.135135" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="346.203696" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="350.272256" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="354.340816" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="358.461538" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="362.582259" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="366.65082" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="370.71938" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="374.78794" y="25.634419" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="378.856501" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="382.977222" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="387.097944" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="391.166504" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="395.235064" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="399.303625" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="403.424346" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="407.545068" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="411.613628" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="415.682188" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="419.750749" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="423.819309" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="427.940031" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="432.060752" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="436.129312" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="440.197873" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="444.266433" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="448.334994" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="452.455715" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="456.576436" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="460.644997" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="464.713557" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="468.782118" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m305b67a360" x="472.902839" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_18">
-    <path d="M 68.060216 25.44 
+    <path d="M 68.070648 25.44 
 L 72.358285 25.44 
 L 76.426845 25.44 
 L 80.495406 25.44 
-L 84.563966 25.6528 
-L 88.684688 25.88 
-L 92.805409 25.671304 
-L 96.873969 26.544151 
-L 100.94253 26.425185 
-L 105.01109 28.067429 
-L 109.131812 28.974765 
-L 113.252533 34.528333 
-L 117.321093 37.187509 
-L 121.389654 46.615 
-L 125.458214 63.907692 
-L 129.526775 83.744059 
-L 133.647496 115.302172 
-L 137.768217 153.733846 
-L 141.836778 193.995676 
-L 145.905338 238.512821 
-L 149.973899 264.84 
-L 154.09462 288.129778 
-L 158.215341 301.32 
-L 162.283902 306.336 
-L 166.352462 304.270588 
-L 170.421023 293.656667 
-L 174.541744 267.405674 
-L 178.662465 249.101667 
-L 182.731026 210.616923 
-L 186.799586 181.203271 
-L 190.868147 142.915093 
-L 194.936707 121.8 
-L 199.057428 94.788504 
-L 203.17815 78.127442 
-L 207.24671 64.453333 
-L 211.315271 51.917902 
-L 215.383831 41.418865 
-L 219.504552 37.015385 
-L 223.625274 33.228633 
-L 227.693834 34.50952 
-L 231.762395 29.247808 
-L 235.830955 28.430073 
-L 239.899515 27.384186 
-L 244.020237 27.515177 
-L 248.140958 26.027157 
-L 252.209519 25.871882 
-L 256.278079 25.652029 
-L 260.346639 26.258462 
-L 264.467361 26.258462 
-L 268.588082 25.44 
-L 272.656643 25.821238 
+L 84.616127 25.44 
+L 88.736849 25.834074 
+L 92.805409 26.112644 
+L 96.873969 25.875093 
+L 100.94253 26.288116 
+L 105.063251 26.735646 
+L 109.183973 29.070803 
+L 113.252533 34.443077 
+L 117.321093 37.5675 
+L 121.389654 46.12 
+L 125.458214 66.538015 
+L 129.578936 88.333381 
+L 133.699657 120.25 
+L 137.768217 160.502464 
+L 141.836778 204.08 
+L 145.905338 244.263 
+L 150.02606 265.566347 
+L 154.146781 290.8016 
+L 158.215341 299.16942 
+L 162.283902 301.064733 
+L 166.352462 299.602192 
+L 170.421023 292.2 
+L 174.541744 272.615385 
+L 178.662465 248.222703 
+L 182.731026 222.76944 
+L 186.799586 194.571667 
+L 190.868147 162.320685 
+L 194.988868 130.245854 
+L 199.109589 106.791667 
+L 203.17815 84.417187 
+L 207.24671 64.930769 
+L 211.315271 55.566963 
+L 215.383831 47.534286 
+L 219.504552 41.671825 
+L 223.625274 35.568462 
+L 227.693834 34.306667 
+L 231.762395 31.636235 
+L 235.830955 30.335209 
+L 239.951676 28.640312 
+L 244.072398 26.72146 
+L 248.140958 26.14224 
+L 252.209519 26.75717 
+L 256.278079 26.285054 
+L 260.346639 26.326667 
+L 264.467361 25.44 
+L 268.588082 25.653577 
+L 272.656643 25.629385 
 L 276.725203 25.44 
-L 280.793763 25.44 
-L 284.862324 25.642491 
-L 288.983045 25.633775 
+L 280.793763 25.913846 
+L 284.914485 25.44 
+L 289.035206 25.44 
 L 293.103767 25.44 
-L 297.172327 25.44 
-L 301.240887 25.684854 
+L 297.172327 25.641793 
+L 301.240887 25.44 
 L 305.309448 25.44 
 L 309.430169 25.44 
 L 313.55089 25.44 
@@ -1422,7 +1422,7 @@ L 321.688011 25.44
 L 325.756572 25.44 
 L 329.877293 25.44 
 L 333.998014 25.44 
-L 338.066575 25.643902 
+L 338.066575 25.44 
 L 342.135135 25.44 
 L 346.203696 25.44 
 L 350.272256 25.44 
@@ -1436,7 +1436,7 @@ L 378.960823 25.44
 L 383.029383 25.44 
 L 387.097944 25.44 
 L 391.166504 25.44 
-L 395.235064 25.834074 
+L 395.235064 25.44 
 L 399.355786 25.44 
 L 403.476507 25.44 
 L 407.545068 25.44 
@@ -1456,9 +1456,9 @@ L 460.644997 25.44
 L 464.765718 25.44 
 L 468.88644 25.44 
 L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m50c4c5b6d6" d="M 0 1 
+     <path id="mda5000919b" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1470,107 +1470,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m50c4c5b6d6" x="68.060216" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="72.358285" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="76.426845" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="80.495406" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="84.563966" y="25.6528" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="88.684688" y="25.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="92.805409" y="25.671304" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="96.873969" y="26.544151" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="100.94253" y="26.425185" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="105.01109" y="28.067429" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="109.131812" y="28.974765" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="113.252533" y="34.528333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="117.321093" y="37.187509" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="121.389654" y="46.615" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="125.458214" y="63.907692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="129.526775" y="83.744059" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="133.647496" y="115.302172" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="137.768217" y="153.733846" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="141.836778" y="193.995676" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="145.905338" y="238.512821" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="149.973899" y="264.84" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="154.09462" y="288.129778" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="158.215341" y="301.32" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="162.283902" y="306.336" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="166.352462" y="304.270588" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="170.421023" y="293.656667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="174.541744" y="267.405674" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="178.662465" y="249.101667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="182.731026" y="210.616923" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="186.799586" y="181.203271" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="190.868147" y="142.915093" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="194.936707" y="121.8" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="199.057428" y="94.788504" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="203.17815" y="78.127442" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="207.24671" y="64.453333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="211.315271" y="51.917902" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="215.383831" y="41.418865" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="219.504552" y="37.015385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="223.625274" y="33.228633" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="227.693834" y="34.50952" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="231.762395" y="29.247808" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="235.830955" y="28.430073" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="239.899515" y="27.384186" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="244.020237" y="27.515177" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="248.140958" y="26.027157" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="252.209519" y="25.871882" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="256.278079" y="25.652029" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="260.346639" y="26.258462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="264.467361" y="26.258462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="268.588082" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="272.656643" y="25.821238" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="276.725203" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="280.793763" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="284.862324" y="25.642491" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="288.983045" y="25.633775" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="293.103767" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="297.172327" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="301.240887" y="25.684854" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="305.309448" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="309.430169" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="313.55089" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="317.619451" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="321.688011" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="325.756572" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="329.877293" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="333.998014" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="338.066575" y="25.643902" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="342.135135" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="346.203696" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="350.272256" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="354.392977" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="358.513699" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="362.582259" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="366.65082" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="370.71938" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="374.840101" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="378.960823" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="383.029383" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="387.097944" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="391.166504" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="395.235064" y="25.834074" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="399.355786" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="403.476507" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="407.545068" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="411.613628" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="415.682188" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="419.80291" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="423.923631" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="427.992192" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="432.060752" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="436.129312" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="440.197873" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="444.318594" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="448.439316" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="452.507876" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="456.576436" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="460.644997" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="464.765718" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="468.88644" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m50c4c5b6d6" x="472.955" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#mda5000919b" x="68.070648" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="72.358285" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="76.426845" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="80.495406" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="84.616127" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="88.736849" y="25.834074" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="92.805409" y="26.112644" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="96.873969" y="25.875093" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="100.94253" y="26.288116" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="105.063251" y="26.735646" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="109.183973" y="29.070803" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="113.252533" y="34.443077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="117.321093" y="37.5675" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="121.389654" y="46.12" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="125.458214" y="66.538015" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="129.578936" y="88.333381" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="133.699657" y="120.25" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="137.768217" y="160.502464" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="141.836778" y="204.08" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="145.905338" y="244.263" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="150.02606" y="265.566347" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="154.146781" y="290.8016" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="158.215341" y="299.16942" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="162.283902" y="301.064733" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="166.352462" y="299.602192" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="170.421023" y="292.2" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="174.541744" y="272.615385" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="178.662465" y="248.222703" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="182.731026" y="222.76944" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="186.799586" y="194.571667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="190.868147" y="162.320685" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="194.988868" y="130.245854" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="199.109589" y="106.791667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="203.17815" y="84.417187" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="207.24671" y="64.930769" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="211.315271" y="55.566963" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="215.383831" y="47.534286" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="219.504552" y="41.671825" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="223.625274" y="35.568462" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="227.693834" y="34.306667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="231.762395" y="31.636235" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="235.830955" y="30.335209" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="239.951676" y="28.640312" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="244.072398" y="26.72146" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="248.140958" y="26.14224" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="252.209519" y="26.75717" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="256.278079" y="26.285054" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="260.346639" y="26.326667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="264.467361" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="268.588082" y="25.653577" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="272.656643" y="25.629385" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="276.725203" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="280.793763" y="25.913846" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="284.914485" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="289.035206" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="293.103767" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="297.172327" y="25.641793" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="301.240887" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="305.309448" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="309.430169" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="313.55089" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="317.619451" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="321.688011" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="325.756572" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="329.877293" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="333.998014" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="338.066575" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="342.135135" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="346.203696" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="350.272256" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="354.392977" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="358.513699" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="362.582259" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="366.65082" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="370.71938" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="374.840101" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="378.960823" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="383.029383" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="387.097944" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="391.166504" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="395.235064" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="399.355786" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="403.476507" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="407.545068" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="411.613628" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="415.682188" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="419.80291" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="423.923631" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="427.992192" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="432.060752" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="436.129312" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="440.197873" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="444.318594" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="448.439316" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="452.507876" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="456.576436" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="460.644997" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="464.765718" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="468.88644" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mda5000919b" x="472.955" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_19">
@@ -1578,105 +1578,105 @@ z
 L 72.358285 25.44 
 L 76.426845 25.44 
 L 80.495406 25.44 
-L 84.563966 26.712174 
-L 88.684688 25.678857 
-L 92.805409 26.940513 
-L 96.873969 27.276951 
-L 100.94253 28.806195 
-L 105.01109 29.397874 
-L 109.131812 32.525381 
-L 113.252533 36.212338 
-L 117.321093 50.678483 
-L 121.389654 52.732941 
-L 125.458214 80.388357 
-L 129.526775 102.329507 
-L 133.647496 139.902026 
-L 137.768217 174.49094 
-L 141.836778 217.365763 
-L 145.905338 252.145528 
-L 149.973899 273.409961 
-L 154.09462 293.884936 
-L 158.215341 300.207725 
-L 162.283902 303.108971 
-L 166.352462 298.533333 
-L 170.421023 284.878667 
-L 174.541744 276.390631 
-L 178.662465 252.448833 
-L 182.731026 223.4675 
-L 186.799586 202.905302 
-L 190.868147 162.696 
-L 194.936707 148.482051 
-L 199.057428 118.729205 
-L 203.17815 95.414979 
-L 207.24671 83.703333 
-L 211.315271 58.88 
-L 215.383831 54.821411 
-L 219.504552 49.687331 
-L 223.625274 42.340172 
-L 227.693834 35.502262 
-L 231.762395 33.396667 
-L 235.830955 35.098641 
-L 239.899515 31.541611 
-L 244.020237 27.466667 
-L 248.140958 28.533568 
-L 252.209519 27.652941 
-L 256.278079 27.046431 
-L 260.346639 26.383871 
-L 264.467361 26.193476 
-L 268.588082 26.73469 
-L 272.656643 25.974429 
-L 276.725203 26.763982 
-L 280.793763 25.710926 
-L 284.862324 25.44 
-L 288.983045 25.935932 
-L 293.103767 25.964843 
-L 297.172327 25.940171 
-L 301.240887 25.44 
-L 305.309448 26 
-L 309.430169 25.676923 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 25.692241 
+L 84.563966 25.66251 
+L 88.684688 25.44 
+L 92.805409 26.927797 
+L 96.873969 26.63918 
+L 100.94253 28.200377 
+L 105.01109 31.501833 
+L 109.131812 33.348108 
+L 113.252533 38.444444 
+L 117.321093 46.061333 
+L 121.389654 63.06 
+L 125.458214 81.674062 
+L 129.526775 111.75032 
+L 133.647496 144.125141 
+L 137.768217 180.743077 
+L 141.836778 225.383333 
+L 145.905338 247.761308 
+L 149.973899 280.888299 
+L 154.042459 294.792329 
+L 158.16318 302.05537 
+L 162.283902 306.816986 
+L 166.352462 304.337756 
+L 170.421023 293.424444 
+L 174.489583 280.778286 
+L 178.610304 256.692947 
+L 182.731026 242.058387 
+L 186.799586 203.840777 
+L 190.868147 185.288405 
+L 194.936707 151.502907 
+L 199.005267 129.722085 
+L 203.125989 111.990588 
+L 207.24671 94.125446 
+L 211.315271 75.169442 
+L 215.383831 55.610311 
+L 219.452391 54.084 
+L 223.520952 46.39476 
+L 227.641673 40.772751 
+L 231.762395 37.577481 
+L 235.830955 32.431327 
+L 239.899515 32.547692 
+L 243.968076 32.113333 
+L 248.088797 28.776667 
+L 252.209519 29.865882 
+L 256.278079 28.288319 
+L 260.346639 27.009502 
+L 264.4152 28.733333 
+L 268.48376 27.118852 
+L 272.604481 27.236667 
+L 276.725203 26.444635 
+L 280.793763 26.726154 
+L 284.862324 25.94887 
+L 288.930884 26.884938 
+L 293.051605 26.669412 
+L 297.172327 26.511795 
+L 301.240887 26.82673 
+L 305.309448 26.549384 
+L 309.378008 26.28 
+L 313.446568 25.953333 
+L 317.56729 25.44 
+L 321.688011 26.669412 
 L 325.756572 25.44 
 L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.70125 
+L 333.893692 26 
+L 337.962253 25.44 
+L 342.082974 25.693333 
+L 346.203696 25.67502 
 L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
-L 362.582259 25.44 
+L 354.340816 25.44 
+L 358.409377 25.44 
+L 362.530098 25.44 
 L 366.65082 25.44 
 L 370.71938 25.44 
-L 374.840101 25.44 
-L 378.960823 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
+L 374.78794 25.44 
+L 378.856501 25.44 
+L 382.925061 25.44 
+L 387.045783 25.44 
 L 391.166504 25.44 
 L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
+L 399.303625 25.44 
+L 403.372185 25.44 
+L 407.492907 25.44 
 L 411.613628 25.44 
 L 415.682188 25.44 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.691159 
+L 419.750749 25.44 
+L 423.819309 25.687966 
+L 427.88787 25.44 
+L 432.008591 25.44 
+L 436.129312 25.44 
 L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
+L 444.266433 25.44 
+L 448.334994 25.44 
+L 452.403554 25.44 
+L 456.524275 25.44 
 L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
+L 464.713557 25.44 
+L 468.782118 25.44 
+L 472.850678 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
     <defs>
-     <path id="m3c58dab356" d="M 0 1 
+     <path id="mbfc1946f7d" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1688,213 +1688,213 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m3c58dab356" x="68.060216" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="72.358285" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="76.426845" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="80.495406" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="84.563966" y="26.712174" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="88.684688" y="25.678857" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="92.805409" y="26.940513" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="96.873969" y="27.276951" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="100.94253" y="28.806195" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="105.01109" y="29.397874" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="109.131812" y="32.525381" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="113.252533" y="36.212338" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="117.321093" y="50.678483" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="121.389654" y="52.732941" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="125.458214" y="80.388357" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="129.526775" y="102.329507" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="133.647496" y="139.902026" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="137.768217" y="174.49094" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="141.836778" y="217.365763" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="145.905338" y="252.145528" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="149.973899" y="273.409961" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="154.09462" y="293.884936" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="158.215341" y="300.207725" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="162.283902" y="303.108971" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="166.352462" y="298.533333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="170.421023" y="284.878667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="174.541744" y="276.390631" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="178.662465" y="252.448833" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="182.731026" y="223.4675" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="186.799586" y="202.905302" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="190.868147" y="162.696" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="194.936707" y="148.482051" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="199.057428" y="118.729205" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="203.17815" y="95.414979" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="207.24671" y="83.703333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="211.315271" y="58.88" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="215.383831" y="54.821411" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="219.504552" y="49.687331" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="223.625274" y="42.340172" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="227.693834" y="35.502262" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="231.762395" y="33.396667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="235.830955" y="35.098641" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="239.899515" y="31.541611" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="244.020237" y="27.466667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="248.140958" y="28.533568" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="252.209519" y="27.652941" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="256.278079" y="27.046431" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="260.346639" y="26.383871" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="264.467361" y="26.193476" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="268.588082" y="26.73469" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="272.656643" y="25.974429" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="276.725203" y="26.763982" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="280.793763" y="25.710926" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="284.862324" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="288.983045" y="25.935932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="293.103767" y="25.964843" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="297.172327" y="25.940171" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="301.240887" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="305.309448" y="26" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="309.430169" y="25.676923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="313.55089" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="317.619451" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="321.688011" y="25.692241" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="325.756572" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="329.825132" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="333.945853" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="338.066575" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="342.135135" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="346.203696" y="25.70125" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="350.272256" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="354.392977" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="358.513699" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="362.582259" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="366.65082" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="370.71938" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="374.840101" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="378.960823" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="383.029383" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="387.097944" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="391.166504" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="395.235064" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="399.355786" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="403.476507" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="407.545068" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="411.613628" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="415.682188" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="419.80291" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="423.923631" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="427.992192" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="432.060752" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="436.129312" y="25.691159" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="440.197873" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="444.318594" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="448.439316" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="452.507876" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="456.576436" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="460.644997" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="464.765718" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="468.88644" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m3c58dab356" x="472.955" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#mbfc1946f7d" x="68.060216" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="72.358285" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="76.426845" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="80.495406" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="84.563966" y="25.66251" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="88.684688" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="92.805409" y="26.927797" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="96.873969" y="26.63918" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="100.94253" y="28.200377" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="105.01109" y="31.501833" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="109.131812" y="33.348108" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="113.252533" y="38.444444" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="117.321093" y="46.061333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="121.389654" y="63.06" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="125.458214" y="81.674062" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="129.526775" y="111.75032" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="133.647496" y="144.125141" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="137.768217" y="180.743077" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="141.836778" y="225.383333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="145.905338" y="247.761308" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="149.973899" y="280.888299" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="154.042459" y="294.792329" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="158.16318" y="302.05537" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="162.283902" y="306.816986" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="166.352462" y="304.337756" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="170.421023" y="293.424444" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="174.489583" y="280.778286" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="178.610304" y="256.692947" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="182.731026" y="242.058387" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="186.799586" y="203.840777" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="190.868147" y="185.288405" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="194.936707" y="151.502907" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="199.005267" y="129.722085" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="203.125989" y="111.990588" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="207.24671" y="94.125446" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="211.315271" y="75.169442" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="215.383831" y="55.610311" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="219.452391" y="54.084" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="223.520952" y="46.39476" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="227.641673" y="40.772751" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="231.762395" y="37.577481" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="235.830955" y="32.431327" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="239.899515" y="32.547692" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="243.968076" y="32.113333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="248.088797" y="28.776667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="252.209519" y="29.865882" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="256.278079" y="28.288319" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="260.346639" y="27.009502" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="264.4152" y="28.733333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="268.48376" y="27.118852" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="272.604481" y="27.236667" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="276.725203" y="26.444635" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="280.793763" y="26.726154" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="284.862324" y="25.94887" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="288.930884" y="26.884938" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="293.051605" y="26.669412" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="297.172327" y="26.511795" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="301.240887" y="26.82673" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="305.309448" y="26.549384" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="309.378008" y="26.28" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="313.446568" y="25.953333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="317.56729" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="321.688011" y="26.669412" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="325.756572" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="329.825132" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="333.893692" y="26" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="337.962253" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="342.082974" y="25.693333" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="346.203696" y="25.67502" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="350.272256" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="354.340816" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="358.409377" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="362.530098" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="366.65082" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="370.71938" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="374.78794" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="378.856501" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="382.925061" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="387.045783" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="391.166504" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="395.235064" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="399.303625" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="403.372185" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="407.492907" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="411.613628" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="415.682188" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="419.750749" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="423.819309" y="25.687966" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="427.88787" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="432.008591" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="436.129312" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="440.197873" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="444.266433" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="448.334994" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="452.403554" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="456.524275" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="460.644997" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="464.713557" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="468.782118" y="25.44" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#mbfc1946f7d" x="472.850678" y="25.44" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_20">
     <path d="M 68.060216 25.44 
-L 72.358285 25.82755 
-L 76.426845 26.440342 
-L 80.495406 25.830133 
-L 84.563966 26.890909 
-L 88.684688 27.64 
-L 92.805409 30.865695 
-L 96.873969 32.587481 
-L 100.94253 39.333237 
-L 105.01109 39.598065 
-L 109.131812 61.002154 
-L 113.252533 75.182 
-L 117.321093 95.441772 
-L 121.389654 112.597447 
-L 125.458214 145.160305 
-L 129.526775 180.806479 
-L 133.647496 196.736954 
-L 137.768217 228.516026 
-L 141.836778 254.676966 
-L 145.905338 273.973735 
-L 149.973899 291.184932 
-L 154.09462 300.484 
-L 158.215341 304.825806 
-L 162.283902 306.685373 
-L 166.352462 305.763077 
-L 170.421023 301.077681 
-L 174.489583 292.577099 
-L 178.610304 276.400769 
-L 182.731026 270.0536 
-L 186.799586 237.226667 
-L 190.868147 240.725255 
-L 194.936707 208.470638 
-L 199.057428 194.715973 
-L 203.17815 175.424593 
-L 207.24671 156.666667 
-L 211.315271 130.946861 
-L 215.383831 112.829867 
-L 219.504552 92.926774 
-L 223.625274 89.984118 
-L 227.693834 76.993333 
-L 231.762395 72.888649 
-L 235.830955 60.118519 
-L 239.899515 56.348451 
-L 244.020237 49.536471 
-L 248.140958 43.122302 
-L 252.209519 41.61 
-L 256.278079 37.334309 
-L 260.346639 37.296993 
-L 264.467361 32.648986 
-L 268.588082 32.348611 
-L 272.656643 28.632 
-L 276.725203 27.690769 
-L 280.793763 28.603243 
-L 284.862324 28.140923 
-L 288.983045 28.284722 
-L 293.103767 27.861517 
-L 297.172327 27.656667 
-L 301.240887 28.543333 
-L 305.309448 25.846389 
-L 309.430169 26.642466 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 27.124029 
-L 325.756572 25.44 
-L 329.877293 25.44 
-L 333.998014 25.82755 
-L 338.066575 25.44 
-L 342.135135 25.846389 
-L 346.203696 25.840822 
-L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
+L 72.358285 25.44 
+L 76.426845 25.832752 
+L 80.495406 25.855035 
+L 84.563966 26.618255 
+L 88.684688 28.120305 
+L 92.805409 31.480774 
+L 96.873969 33.14 
+L 100.94253 37.22255 
+L 105.01109 48.848 
+L 109.131812 62.942254 
+L 113.252533 76.238611 
+L 117.321093 103.615573 
+L 121.389654 119.852267 
+L 125.458214 156.877778 
+L 129.526775 182.067059 
+L 133.647496 214.401527 
+L 137.768217 236.347651 
+L 141.836778 265.456812 
+L 145.905338 279.026667 
+L 149.973899 290.547383 
+L 154.09462 296.955588 
+L 158.215341 308.079149 
+L 162.283902 307.249078 
+L 166.352462 303.41 
+L 170.421023 298.533333 
+L 174.489583 291.09 
+L 178.610304 279.961918 
+L 182.731026 267.114198 
+L 186.799586 257.269231 
+L 190.868147 236.762222 
+L 194.936707 217.072394 
+L 199.057428 195.798222 
+L 203.17815 189.550435 
+L 207.24671 145.223125 
+L 211.315271 141.667222 
+L 215.383831 135.977778 
+L 219.452391 111.947826 
+L 223.573113 98.056058 
+L 227.693834 86.504348 
+L 231.762395 72.328696 
+L 235.830955 68.076 
+L 239.899515 56.52875 
+L 244.020237 53.864 
+L 248.140958 47.753381 
+L 252.209519 39.652 
+L 256.278079 42.16 
+L 260.346639 37.313623 
+L 264.4152 40.42112 
+L 268.535921 35.529655 
+L 272.656643 32.801006 
+L 276.725203 30.528696 
+L 280.793763 30.992993 
+L 284.862324 29.29 
+L 288.983045 27.844932 
+L 293.103767 29.475862 
+L 297.172327 28.784 
+L 301.240887 28.040889 
+L 305.309448 27.112 
+L 309.378008 26.300588 
+L 313.498729 26.77 
+L 317.619451 26.340308 
+L 321.688011 27.64 
+L 325.756572 26.510488 
+L 329.825132 25.873481 
+L 333.945853 25.849231 
+L 338.066575 25.900787 
+L 342.135135 25.44 
+L 346.203696 25.44 
+L 350.272256 25.931765 
+L 354.340816 25.44 
+L 358.461538 25.44 
 L 362.582259 25.44 
-L 366.65082 25.849231 
-L 370.71938 25.44 
-L 374.840101 25.855035 
-L 378.960823 25.830133 
-L 383.029383 25.815128 
+L 366.65082 25.886718 
+L 370.71938 26.32 
+L 374.78794 25.803478 
+L 378.856501 25.44 
+L 382.977222 25.44 
 L 387.097944 25.44 
 L 391.166504 25.44 
 L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
-L 411.613628 25.843586 
-L 415.682188 25.864058 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
+L 399.303625 25.44 
+L 403.424346 25.44 
+L 407.545068 25.82755 
+L 411.613628 25.44 
+L 415.682188 25.44 
+L 419.750749 25.44 
+L 423.819309 25.44 
+L 427.940031 25.44 
 L 432.060752 25.44 
 L 436.129312 25.44 
 L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
+L 444.266433 25.44 
+L 448.387155 25.44 
 L 452.507876 25.44 
 L 456.576436 25.44 
 L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.830133 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
+L 464.713557 25.44 
+L 468.782118 25.44 
+L 472.902839 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
-     <path id="m55e6d7755b" d="M 0 1 
+     <path id="me874039bf3" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1906,176 +1906,176 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m55e6d7755b" x="68.060216" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="72.358285" y="25.82755" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="76.426845" y="26.440342" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="80.495406" y="25.830133" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="84.563966" y="26.890909" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="88.684688" y="27.64" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="92.805409" y="30.865695" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="96.873969" y="32.587481" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="100.94253" y="39.333237" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="105.01109" y="39.598065" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="109.131812" y="61.002154" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="113.252533" y="75.182" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="117.321093" y="95.441772" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="121.389654" y="112.597447" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="125.458214" y="145.160305" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="129.526775" y="180.806479" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="133.647496" y="196.736954" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="137.768217" y="228.516026" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="141.836778" y="254.676966" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="145.905338" y="273.973735" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="149.973899" y="291.184932" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="154.09462" y="300.484" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="158.215341" y="304.825806" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="162.283902" y="306.685373" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="166.352462" y="305.763077" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="170.421023" y="301.077681" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="174.489583" y="292.577099" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="178.610304" y="276.400769" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="182.731026" y="270.0536" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="186.799586" y="237.226667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="190.868147" y="240.725255" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="194.936707" y="208.470638" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="199.057428" y="194.715973" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="203.17815" y="175.424593" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="207.24671" y="156.666667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="211.315271" y="130.946861" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="215.383831" y="112.829867" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="219.504552" y="92.926774" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="223.625274" y="89.984118" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="227.693834" y="76.993333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="231.762395" y="72.888649" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="235.830955" y="60.118519" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="239.899515" y="56.348451" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="244.020237" y="49.536471" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="248.140958" y="43.122302" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="252.209519" y="41.61" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="256.278079" y="37.334309" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="260.346639" y="37.296993" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="264.467361" y="32.648986" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="268.588082" y="32.348611" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="272.656643" y="28.632" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="276.725203" y="27.690769" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="280.793763" y="28.603243" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="284.862324" y="28.140923" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="288.983045" y="28.284722" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="293.103767" y="27.861517" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="297.172327" y="27.656667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="301.240887" y="28.543333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="305.309448" y="25.846389" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="309.430169" y="26.642466" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="313.55089" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="317.619451" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="321.688011" y="27.124029" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="325.756572" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="329.877293" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="333.998014" y="25.82755" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="338.066575" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="342.135135" y="25.846389" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="346.203696" y="25.840822" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="350.272256" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="354.392977" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="358.513699" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="362.582259" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="366.65082" y="25.849231" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="370.71938" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="374.840101" y="25.855035" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="378.960823" y="25.830133" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="383.029383" y="25.815128" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="387.097944" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="391.166504" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="395.235064" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="399.355786" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="403.476507" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="407.545068" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="411.613628" y="25.843586" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="415.682188" y="25.864058" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="419.80291" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="423.923631" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="427.992192" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="432.060752" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="436.129312" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="440.197873" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="444.318594" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="448.439316" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="452.507876" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="456.576436" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="460.644997" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="464.765718" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="468.88644" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m55e6d7755b" x="472.955" y="25.830133" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#me874039bf3" x="68.060216" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="72.358285" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="76.426845" y="25.832752" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="80.495406" y="25.855035" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="84.563966" y="26.618255" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="88.684688" y="28.120305" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="92.805409" y="31.480774" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="96.873969" y="33.14" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="100.94253" y="37.22255" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="105.01109" y="48.848" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="109.131812" y="62.942254" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="113.252533" y="76.238611" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="117.321093" y="103.615573" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="121.389654" y="119.852267" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="125.458214" y="156.877778" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="129.526775" y="182.067059" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="133.647496" y="214.401527" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="137.768217" y="236.347651" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="141.836778" y="265.456812" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="145.905338" y="279.026667" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="149.973899" y="290.547383" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="154.09462" y="296.955588" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="158.215341" y="308.079149" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="162.283902" y="307.249078" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="166.352462" y="303.41" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="170.421023" y="298.533333" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="174.489583" y="291.09" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="178.610304" y="279.961918" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="182.731026" y="267.114198" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="186.799586" y="257.269231" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="190.868147" y="236.762222" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="194.936707" y="217.072394" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="199.057428" y="195.798222" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="203.17815" y="189.550435" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="207.24671" y="145.223125" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="211.315271" y="141.667222" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="215.383831" y="135.977778" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="219.452391" y="111.947826" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="223.573113" y="98.056058" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="227.693834" y="86.504348" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="231.762395" y="72.328696" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="235.830955" y="68.076" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="239.899515" y="56.52875" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="244.020237" y="53.864" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="248.140958" y="47.753381" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="252.209519" y="39.652" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="256.278079" y="42.16" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="260.346639" y="37.313623" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="264.4152" y="40.42112" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="268.535921" y="35.529655" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="272.656643" y="32.801006" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="276.725203" y="30.528696" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="280.793763" y="30.992993" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="284.862324" y="29.29" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="288.983045" y="27.844932" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="293.103767" y="29.475862" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="297.172327" y="28.784" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="301.240887" y="28.040889" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="305.309448" y="27.112" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="309.378008" y="26.300588" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="313.498729" y="26.77" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="317.619451" y="26.340308" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="321.688011" y="27.64" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="325.756572" y="26.510488" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="329.825132" y="25.873481" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="333.945853" y="25.849231" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="338.066575" y="25.900787" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="342.135135" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="346.203696" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="350.272256" y="25.931765" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="354.340816" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="358.461538" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="362.582259" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="366.65082" y="25.886718" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="370.71938" y="26.32" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="374.78794" y="25.803478" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="378.856501" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="382.977222" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="387.097944" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="391.166504" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="395.235064" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="399.303625" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="403.424346" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="407.545068" y="25.82755" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="411.613628" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="415.682188" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="419.750749" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="423.819309" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="427.940031" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="432.060752" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="436.129312" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="440.197873" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="444.266433" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="448.387155" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="452.507876" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="456.576436" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="460.644997" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="464.713557" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="468.782118" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
+     <use xlink:href="#me874039bf3" x="472.902839" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
    <g id="line2d_21">
-    <path d="M 68.081081 25.44 
+    <path d="M 68.055 25.44 
 L 72.358285 25.44 
 L 76.426845 25.44 
-L 80.547567 25.44 
-L 84.668288 25.44 
-L 88.736849 25.44 
+L 80.495406 25.44 
+L 84.563966 25.44 
+L 88.684688 25.44 
 L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.994691 25.44 
-L 105.115412 25.44 
-L 109.183973 25.44 
-L 113.252533 25.90816 
-L 117.321093 27.699459 
-L 121.389654 30.476557 
-L 125.510375 40.199469 
-L 129.631097 49.158333 
-L 133.699657 74.1712 
-L 137.768217 103.245 
-L 141.836778 142.48 
-L 145.957499 198.500925 
-L 150.078221 245.401538 
-L 154.146781 284.907353 
-L 158.215341 298.226142 
-L 162.283902 304.985538 
-L 166.352462 296.016344 
-L 170.473184 277.883172 
-L 174.593905 246.79 
-L 178.662465 211.14065 
-L 182.731026 161.986667 
-L 186.799586 134.8192 
-L 190.868147 94.313538 
-L 194.988868 72.745366 
-L 199.109589 49.448205 
-L 203.17815 41.635572 
-L 207.24671 36.285405 
-L 211.315271 33.348108 
-L 215.435992 29.328372 
-L 219.556713 27.925405 
-L 223.625274 26.903 
-L 227.693834 26.418595 
-L 231.762395 26.067 
-L 235.830955 25.6528 
-L 239.951676 26.185478 
-L 244.072398 25.636376 
-L 248.140958 25.44 
-L 252.209519 25.44 
-L 256.278079 25.641793 
-L 260.3988 25.642491 
-L 264.519522 25.664215 
+L 96.873969 25.656741 
+L 100.94253 25.666822 
+L 105.01109 26.087823 
+L 109.079651 25.44 
+L 113.200372 26.021325 
+L 117.321093 27.314306 
+L 121.389654 29.155556 
+L 125.458214 38.006795 
+L 129.526775 50.102 
+L 133.647496 74.744252 
+L 137.768217 115.346159 
+L 141.836778 149.457385 
+L 145.905338 200.379647 
+L 149.973899 239.85728 
+L 154.09462 280.42 
+L 158.215341 298.661246 
+L 162.283902 304.964103 
+L 166.352462 302.651407 
+L 170.421023 277.076 
+L 174.489583 248.780375 
+L 178.610304 212.536201 
+L 182.731026 172.741293 
+L 186.799586 140.122051 
+L 190.868147 101.611934 
+L 194.936707 72.430037 
+L 199.057428 56.365203 
+L 203.17815 45.858849 
+L 207.24671 38.373768 
+L 211.315271 34.443077 
+L 215.383831 30.333659 
+L 219.452391 30.077434 
+L 223.573113 28.265103 
+L 227.693834 27.040156 
+L 231.762395 26.043299 
+L 235.830955 25.850667 
+L 239.899515 25.646056 
+L 244.020237 25.44 
+L 248.140958 25.873481 
+L 252.209519 25.671304 
+L 256.278079 25.44 
+L 260.346639 25.657546 
+L 264.467361 25.44 
 L 268.588082 25.44 
 L 272.656643 25.44 
-L 276.725203 25.44 
+L 276.725203 25.631242 
 L 280.793763 25.44 
-L 284.914485 25.44 
-L 289.035206 25.44 
+L 284.862324 25.44 
+L 288.983045 25.44 
 L 293.103767 25.44 
 L 297.172327 25.44 
 L 301.240887 25.44 
 L 305.309448 25.44 
-L 309.430169 25.635067 
+L 309.430169 25.44 
 L 313.55089 25.44 
 L 317.619451 25.44 
 L 321.688011 25.44 
-L 325.756572 25.643902 
-L 329.877293 25.44 
-L 333.998014 25.44 
+L 325.756572 25.44 
+L 329.825132 25.44 
+L 333.945853 25.44 
 L 338.066575 25.44 
 L 342.135135 25.44 
 L 346.203696 25.44 
@@ -2107,12 +2107,12 @@ L 448.439316 25.44
 L 452.507876 25.44 
 L 456.576436 25.44 
 L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.834279 25.44 
+L 464.765718 25.44 
+L 468.88644 25.44 
 L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
-     <path id="m4c1a3ef8b4" d="M 0 1 
+     <path id="m41c5f4e4dc" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2124,107 +2124,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m4c1a3ef8b4" x="68.081081" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="72.358285" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="76.426845" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="80.547567" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="84.668288" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="88.736849" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="92.805409" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="96.873969" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="100.994691" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="105.115412" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="109.183973" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="113.252533" y="25.90816" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="117.321093" y="27.699459" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="121.389654" y="30.476557" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="125.510375" y="40.199469" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="129.631097" y="49.158333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="133.699657" y="74.1712" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="137.768217" y="103.245" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="141.836778" y="142.48" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="145.957499" y="198.500925" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="150.078221" y="245.401538" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="154.146781" y="284.907353" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="158.215341" y="298.226142" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="162.283902" y="304.985538" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="166.352462" y="296.016344" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="170.473184" y="277.883172" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="174.593905" y="246.79" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="178.662465" y="211.14065" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="182.731026" y="161.986667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="186.799586" y="134.8192" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="190.868147" y="94.313538" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="194.988868" y="72.745366" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="199.109589" y="49.448205" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="203.17815" y="41.635572" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="207.24671" y="36.285405" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="211.315271" y="33.348108" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="215.435992" y="29.328372" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="219.556713" y="27.925405" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="223.625274" y="26.903" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="227.693834" y="26.418595" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="231.762395" y="26.067" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="235.830955" y="25.6528" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="239.951676" y="26.185478" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="244.072398" y="25.636376" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="248.140958" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="252.209519" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="256.278079" y="25.641793" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="260.3988" y="25.642491" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="264.519522" y="25.664215" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="268.588082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="272.656643" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="276.725203" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="280.793763" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="284.914485" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="289.035206" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="293.103767" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="297.172327" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="301.240887" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="305.309448" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="309.430169" y="25.635067" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="313.55089" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="317.619451" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="321.688011" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="325.756572" y="25.643902" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="329.877293" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="333.998014" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="338.066575" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="342.135135" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="346.203696" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="350.272256" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="354.392977" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="358.513699" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="362.582259" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="366.65082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="370.71938" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="374.840101" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="378.960823" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="383.029383" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="387.097944" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="391.166504" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="395.235064" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="399.355786" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="403.476507" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="407.545068" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="411.613628" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="415.682188" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="419.80291" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="423.923631" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="427.992192" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="432.060752" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="436.129312" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="440.197873" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="444.318594" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="448.439316" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="452.507876" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="456.576436" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="460.644997" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="464.713557" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="468.834279" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m4c1a3ef8b4" x="472.955" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#m41c5f4e4dc" x="68.055" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="72.358285" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="76.426845" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="80.495406" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="84.563966" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="88.684688" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="92.805409" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="96.873969" y="25.656741" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="100.94253" y="25.666822" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="105.01109" y="26.087823" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="109.079651" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="113.200372" y="26.021325" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="117.321093" y="27.314306" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="121.389654" y="29.155556" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="125.458214" y="38.006795" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="129.526775" y="50.102" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="133.647496" y="74.744252" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="137.768217" y="115.346159" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="141.836778" y="149.457385" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="145.905338" y="200.379647" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="149.973899" y="239.85728" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="154.09462" y="280.42" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="158.215341" y="298.661246" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="162.283902" y="304.964103" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="166.352462" y="302.651407" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="170.421023" y="277.076" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="174.489583" y="248.780375" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="178.610304" y="212.536201" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="182.731026" y="172.741293" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="186.799586" y="140.122051" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="190.868147" y="101.611934" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="194.936707" y="72.430037" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="199.057428" y="56.365203" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="203.17815" y="45.858849" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="207.24671" y="38.373768" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="211.315271" y="34.443077" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="215.383831" y="30.333659" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="219.452391" y="30.077434" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="223.573113" y="28.265103" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="227.693834" y="27.040156" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="231.762395" y="26.043299" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="235.830955" y="25.850667" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="239.899515" y="25.646056" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="244.020237" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="248.140958" y="25.873481" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="252.209519" y="25.671304" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="256.278079" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="260.346639" y="25.657546" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="264.467361" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="268.588082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="272.656643" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="276.725203" y="25.631242" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="280.793763" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="284.862324" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="288.983045" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="293.103767" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="297.172327" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="301.240887" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="305.309448" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="309.430169" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="313.55089" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="317.619451" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="321.688011" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="325.756572" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="329.825132" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="333.945853" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="338.066575" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="342.135135" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="346.203696" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="350.272256" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="354.392977" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="358.513699" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="362.582259" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="366.65082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="370.71938" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="374.840101" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="378.960823" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="383.029383" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="387.097944" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="391.166504" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="395.235064" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="399.355786" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="403.476507" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="407.545068" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="411.613628" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="415.682188" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="419.80291" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="423.923631" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="427.992192" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="432.060752" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="436.129312" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="440.197873" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="444.318594" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="448.439316" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="452.507876" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="456.576436" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="460.644997" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="464.765718" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="468.88644" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
+     <use xlink:href="#m41c5f4e4dc" x="472.955" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_22">
@@ -2233,486 +2233,50 @@ L 72.358285 25.44
 L 76.426845 25.44 
 L 80.495406 25.44 
 L 84.563966 25.44 
-L 88.684688 25.44 
+L 88.684688 25.649749 
 L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.94253 25.940171 
-L 105.01109 25.66 
-L 109.079651 25.911935 
-L 113.200372 26.775057 
-L 117.321093 27.771474 
-L 121.389654 30.06 
-L 125.458214 31.879094 
-L 129.526775 43.017436 
-L 133.647496 58.102326 
-L 137.768217 93.916528 
-L 141.836778 135.932308 
-L 145.905338 196.43461 
-L 149.973899 244.95279 
-L 154.042459 279.864844 
-L 158.16318 299.261194 
-L 162.283902 305.199281 
-L 166.352462 297.200144 
-L 170.421023 274.6288 
-L 174.489583 242.036846 
-L 178.610304 200.232525 
-L 182.731026 158.4193 
-L 186.799586 124.148434 
-L 190.868147 89.945 
-L 194.936707 60.343 
-L 199.005267 48.260541 
-L 203.125989 38.318919 
-L 207.24671 32.582205 
-L 211.315271 31.435902 
-L 215.383831 28.16186 
-L 219.452391 28.306286 
-L 223.573113 26.120465 
-L 227.693834 26.220267 
-L 231.762395 25.825 
-L 235.830955 25.856512 
-L 239.899515 25.44 
-L 244.020237 25.44 
-L 248.140958 25.44 
+L 96.873969 25.665077 
+L 100.94253 25.891892 
+L 105.01109 25.44 
+L 109.079651 25.871882 
+L 113.200372 26.649091 
+L 117.321093 27.390667 
+L 121.389654 30.256461 
+L 125.458214 34.02 
+L 129.526775 44.866721 
+L 133.647496 71.048114 
+L 137.768217 103.007686 
+L 141.836778 146.491452 
+L 145.905338 195.836471 
+L 149.973899 242.093088 
+L 154.042459 283.440584 
+L 158.16318 301.919396 
+L 162.283902 304.68943 
+L 166.352462 297.15477 
+L 170.421023 279.243407 
+L 174.489583 250.304252 
+L 178.610304 206.464903 
+L 182.731026 167.272824 
+L 186.799586 133.493 
+L 190.868147 85.932584 
+L 194.936707 72.562846 
+L 199.005267 54.483259 
+L 203.125989 42.334895 
+L 207.24671 36.677536 
+L 211.315271 34.160627 
+L 215.383831 32.390651 
+L 219.452391 29.924291 
+L 223.573113 27.63176 
+L 227.693834 28.271613 
+L 231.762395 26.32 
+L 235.830955 26.285054 
+L 239.899515 26.071511 
+L 243.968076 25.647518 
+L 248.088797 25.876716 
 L 252.209519 25.44 
 L 256.278079 25.44 
-L 260.346639 25.653577 
-L 264.4152 25.44 
-L 268.535921 25.44 
-L 272.656643 25.44 
-L 276.725203 25.44 
-L 280.793763 25.44 
-L 284.862324 25.44 
-L 288.983045 25.44 
-L 293.103767 25.44 
-L 297.172327 25.44 
-L 301.240887 25.44 
-L 305.309448 25.44 
-L 309.378008 25.44 
-L 313.498729 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.908662 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.87147 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.387155 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.834279 25.44 
-L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
-    <defs>
-     <path id="m212723961c" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #e377c2"/>
-    </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m212723961c" x="68.055" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="72.358285" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="76.426845" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="80.495406" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="84.563966" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="88.684688" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="92.805409" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="96.873969" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="100.94253" y="25.940171" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="105.01109" y="25.66" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="109.079651" y="25.911935" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="113.200372" y="26.775057" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="117.321093" y="27.771474" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="121.389654" y="30.06" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="125.458214" y="31.879094" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="129.526775" y="43.017436" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="133.647496" y="58.102326" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="137.768217" y="93.916528" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="141.836778" y="135.932308" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="145.905338" y="196.43461" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="149.973899" y="244.95279" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="154.042459" y="279.864844" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="158.16318" y="299.261194" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="162.283902" y="305.199281" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="166.352462" y="297.200144" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="170.421023" y="274.6288" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="174.489583" y="242.036846" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="178.610304" y="200.232525" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="182.731026" y="158.4193" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="186.799586" y="124.148434" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="190.868147" y="89.945" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="194.936707" y="60.343" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="199.005267" y="48.260541" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="203.125989" y="38.318919" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="207.24671" y="32.582205" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="211.315271" y="31.435902" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="215.383831" y="28.16186" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="219.452391" y="28.306286" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="223.573113" y="26.120465" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="227.693834" y="26.220267" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="231.762395" y="25.825" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="235.830955" y="25.856512" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="239.899515" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="244.020237" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="248.140958" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="252.209519" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="256.278079" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="260.346639" y="25.653577" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="264.4152" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="268.535921" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="272.656643" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="276.725203" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="280.793763" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="284.862324" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="288.983045" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="293.103767" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="297.172327" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="301.240887" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="305.309448" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="309.378008" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="313.498729" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="317.619451" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="321.688011" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="325.756572" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="329.825132" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="333.945853" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="338.066575" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="342.135135" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="346.203696" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="350.272256" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="354.340816" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="358.461538" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="362.582259" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="366.65082" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="370.71938" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="374.78794" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="378.908662" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="383.029383" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="387.097944" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="391.166504" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="395.235064" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="399.303625" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="403.424346" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="407.545068" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="411.613628" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="415.682188" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="419.750749" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="423.87147" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="427.992192" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="432.060752" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="436.129312" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="440.197873" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="444.266433" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="448.387155" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="452.507876" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="456.576436" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="460.644997" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="464.713557" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="468.834279" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m212723961c" x="472.955" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-    </g>
-   </g>
-   <g id="line2d_23">
-    <path d="M 68.065432 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.838095 
-L 88.684688 25.44 
-L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.94253 26.77 
-L 105.01109 28.760284 
-L 109.131812 33.212188 
-L 113.252533 37.891064 
-L 117.321093 49.251586 
-L 121.389654 61.250746 
-L 125.458214 86.398333 
-L 129.526775 114.195333 
-L 133.647496 156.089302 
-L 137.768217 193.325246 
-L 141.836778 235.678519 
-L 145.905338 260.747692 
-L 149.973899 282.235 
-L 154.09462 295.859032 
-L 158.215341 302.248889 
-L 162.283902 303.294803 
-L 166.352462 304.501791 
-L 170.421023 290.243 
-L 174.489583 275.663448 
-L 178.610304 259.52 
-L 182.731026 239.478904 
-L 186.799586 204.806179 
-L 190.868147 175.577377 
-L 194.936707 155.95223 
-L 199.057428 121.313191 
-L 203.17815 94.681221 
-L 207.24671 83.476364 
-L 211.315271 69.801935 
-L 215.383831 55.40224 
-L 219.452391 50.984444 
-L 223.573113 48.299375 
-L 227.693834 36.188571 
-L 231.762395 33.983066 
-L 235.830955 32.116779 
-L 239.899515 31.847299 
-L 244.020237 31.247328 
-L 248.140958 29.90339 
-L 252.209519 27.076923 
-L 256.278079 27.088451 
-L 260.346639 27.838361 
-L 264.4152 26.833333 
-L 268.535921 25.44 
-L 272.656643 27.919661 
-L 276.725203 26.340308 
-L 280.793763 26.80093 
-L 284.862324 26.750149 
-L 288.983045 25.886718 
-L 293.103767 25.890154 
-L 297.172327 25.940171 
-L 301.240887 26.37632 
-L 305.309448 25.940171 
-L 309.378008 25.44 
-L 313.498729 25.846389 
-L 317.619451 26.833333 
-L 321.688011 25.843586 
-L 325.756572 25.817548 
-L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.840822 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.908662 25.873481 
-L 383.029383 25.900787 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.87147 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.387155 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.834279 25.44 
-L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
-    <defs>
-     <path id="m3ec912d9ec" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #7f7f7f"/>
-    </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m3ec912d9ec" x="68.065432" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="72.358285" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="76.426845" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="80.495406" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="84.563966" y="25.838095" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="88.684688" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="92.805409" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="96.873969" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="100.94253" y="26.77" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="105.01109" y="28.760284" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="109.131812" y="33.212188" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="113.252533" y="37.891064" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="117.321093" y="49.251586" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="121.389654" y="61.250746" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="125.458214" y="86.398333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="129.526775" y="114.195333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="133.647496" y="156.089302" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="137.768217" y="193.325246" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="141.836778" y="235.678519" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="145.905338" y="260.747692" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="149.973899" y="282.235" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="154.09462" y="295.859032" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="158.215341" y="302.248889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="162.283902" y="303.294803" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="166.352462" y="304.501791" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="170.421023" y="290.243" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="174.489583" y="275.663448" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="178.610304" y="259.52" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="182.731026" y="239.478904" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="186.799586" y="204.806179" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="190.868147" y="175.577377" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="194.936707" y="155.95223" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="199.057428" y="121.313191" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="203.17815" y="94.681221" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="207.24671" y="83.476364" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="211.315271" y="69.801935" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="215.383831" y="55.40224" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="219.452391" y="50.984444" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="223.573113" y="48.299375" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="227.693834" y="36.188571" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="231.762395" y="33.983066" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="235.830955" y="32.116779" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="239.899515" y="31.847299" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="244.020237" y="31.247328" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="248.140958" y="29.90339" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="252.209519" y="27.076923" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="256.278079" y="27.088451" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="260.346639" y="27.838361" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="264.4152" y="26.833333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="268.535921" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="272.656643" y="27.919661" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="276.725203" y="26.340308" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="280.793763" y="26.80093" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="284.862324" y="26.750149" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="288.983045" y="25.886718" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="293.103767" y="25.890154" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="297.172327" y="25.940171" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="301.240887" y="26.37632" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="305.309448" y="25.940171" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="309.378008" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="313.498729" y="25.846389" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="317.619451" y="26.833333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="321.688011" y="25.843586" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="325.756572" y="25.817548" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="329.825132" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="333.945853" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="338.066575" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="342.135135" y="25.840822" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="346.203696" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="350.272256" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="354.340816" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="358.461538" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="362.582259" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="366.65082" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="370.71938" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="374.78794" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="378.908662" y="25.873481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="383.029383" y="25.900787" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="387.097944" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="391.166504" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="395.235064" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="399.303625" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="403.424346" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="407.545068" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="411.613628" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="415.682188" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="419.750749" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="423.87147" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="427.992192" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="432.060752" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="436.129312" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="440.197873" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="444.266433" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="448.387155" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="452.507876" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="456.576436" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="460.644997" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="464.713557" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="468.834279" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m3ec912d9ec" x="472.955" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-    </g>
-   </g>
-   <g id="line2d_24">
-    <path d="M 68.055 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.44 
-L 88.684688 25.44 
-L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.94253 25.697797 
-L 105.01109 25.994692 
-L 109.079651 25.927667 
-L 113.200372 29.436488 
-L 117.321093 29.30696 
-L 121.389654 32.502759 
-L 125.458214 39.93578 
-L 129.526775 54.837371 
-L 133.647496 82.045794 
-L 137.768217 116.628932 
-L 141.836778 165.103711 
-L 145.905338 217.680935 
-L 149.973899 256.138844 
-L 154.042459 281.4981 
-L 158.16318 301.591135 
-L 162.283902 304.535385 
-L 166.352462 292.800458 
-L 170.421023 282.536234 
-L 174.489583 252.856832 
-L 178.610304 222.35564 
-L 182.731026 183.617822 
-L 186.799586 144.040533 
-L 190.868147 117.595327 
-L 194.936707 85.656232 
-L 199.005267 64.251192 
-L 203.125989 53.376683 
-L 207.24671 42.797627 
-L 211.315271 34.707873 
-L 215.383831 34.813333 
-L 219.452391 31.04 
-L 223.573113 28.89931 
-L 227.693834 28.33703 
-L 231.762395 27.729913 
-L 235.830955 27.043288 
-L 239.899515 27.05913 
-L 243.968076 25.707215 
-L 248.088797 25.44 
-L 252.209519 26.034112 
-L 256.278079 25.726863 
-L 260.346639 26.002692 
-L 264.4152 25.698938 
+L 260.346639 25.665077 
+L 264.4152 25.642491 
 L 268.535921 25.44 
 L 272.656643 25.44 
 L 276.725203 25.44 
@@ -2761,12 +2325,12 @@ L 448.387155 25.44
 L 452.507876 25.44 
 L 456.576436 25.44 
 L 460.644997 25.44 
-L 464.713557 25.722705 
+L 464.713557 25.44 
 L 468.782118 25.44 
 L 472.902839 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
-     <path id="m343f3fb6a2" d="M 0 1 
+     <path id="ma92c121c75" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2776,113 +2340,331 @@ C -0.894634 -0.51958 -1 -0.265203 -1 0
 C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
 C -0.51958 0.894634 -0.265203 1 0 1 
 z
-" style="stroke: #bcbd22"/>
+" style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m343f3fb6a2" x="68.055" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="72.358285" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="76.426845" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="80.495406" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="84.563966" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="88.684688" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="92.805409" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="96.873969" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="100.94253" y="25.697797" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="105.01109" y="25.994692" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="109.079651" y="25.927667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="113.200372" y="29.436488" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="117.321093" y="29.30696" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="121.389654" y="32.502759" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="125.458214" y="39.93578" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="129.526775" y="54.837371" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="133.647496" y="82.045794" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="137.768217" y="116.628932" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="141.836778" y="165.103711" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="145.905338" y="217.680935" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="149.973899" y="256.138844" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="154.042459" y="281.4981" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="158.16318" y="301.591135" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="162.283902" y="304.535385" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="166.352462" y="292.800458" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="170.421023" y="282.536234" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="174.489583" y="252.856832" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="178.610304" y="222.35564" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="182.731026" y="183.617822" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="186.799586" y="144.040533" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="190.868147" y="117.595327" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="194.936707" y="85.656232" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="199.005267" y="64.251192" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="203.125989" y="53.376683" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="207.24671" y="42.797627" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="211.315271" y="34.707873" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="215.383831" y="34.813333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="219.452391" y="31.04" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="223.573113" y="28.89931" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="227.693834" y="28.33703" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="231.762395" y="27.729913" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="235.830955" y="27.043288" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="239.899515" y="27.05913" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="243.968076" y="25.707215" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="248.088797" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="252.209519" y="26.034112" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="256.278079" y="25.726863" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="260.346639" y="26.002692" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="264.4152" y="25.698938" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="268.535921" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="272.656643" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="276.725203" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="280.793763" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="284.862324" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="288.930884" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="293.051605" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="297.172327" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="301.240887" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="305.309448" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="309.378008" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="313.498729" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="317.619451" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="321.688011" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="325.756572" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="329.825132" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="333.893692" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="338.014414" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="342.135135" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="346.203696" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="350.272256" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="354.340816" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="358.461538" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="362.582259" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="366.65082" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="370.71938" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="374.78794" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="378.856501" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="382.977222" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="387.097944" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="391.166504" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="395.235064" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="399.303625" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="403.424346" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="407.545068" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="411.613628" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="415.682188" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="419.750749" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="423.819309" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="427.940031" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="432.060752" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="436.129312" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="440.197873" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="444.266433" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="448.387155" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="452.507876" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="456.576436" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="460.644997" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="464.713557" y="25.722705" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="468.782118" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m343f3fb6a2" x="472.902839" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#ma92c121c75" x="68.055" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="72.358285" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="76.426845" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="80.495406" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="84.563966" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="88.684688" y="25.649749" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="92.805409" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="96.873969" y="25.665077" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="100.94253" y="25.891892" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="105.01109" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="109.079651" y="25.871882" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="113.200372" y="26.649091" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="117.321093" y="27.390667" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="121.389654" y="30.256461" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="125.458214" y="34.02" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="129.526775" y="44.866721" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="133.647496" y="71.048114" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="137.768217" y="103.007686" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="141.836778" y="146.491452" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="145.905338" y="195.836471" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="149.973899" y="242.093088" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="154.042459" y="283.440584" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="158.16318" y="301.919396" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="162.283902" y="304.68943" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="166.352462" y="297.15477" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="170.421023" y="279.243407" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="174.489583" y="250.304252" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="178.610304" y="206.464903" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="182.731026" y="167.272824" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="186.799586" y="133.493" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="190.868147" y="85.932584" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="194.936707" y="72.562846" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="199.005267" y="54.483259" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="203.125989" y="42.334895" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="207.24671" y="36.677536" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="211.315271" y="34.160627" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="215.383831" y="32.390651" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="219.452391" y="29.924291" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="223.573113" y="27.63176" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="227.693834" y="28.271613" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="231.762395" y="26.32" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="235.830955" y="26.285054" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="239.899515" y="26.071511" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="243.968076" y="25.647518" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="248.088797" y="25.876716" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="252.209519" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="256.278079" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="260.346639" y="25.665077" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="264.4152" y="25.642491" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="268.535921" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="272.656643" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="276.725203" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="280.793763" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="284.862324" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="288.930884" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="293.051605" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="297.172327" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="301.240887" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="305.309448" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="309.378008" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="313.498729" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="317.619451" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="321.688011" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="325.756572" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="329.825132" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="333.893692" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="338.014414" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="342.135135" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="346.203696" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="350.272256" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="354.340816" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="358.461538" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="362.582259" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="366.65082" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="370.71938" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="374.78794" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="378.856501" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="382.977222" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="387.097944" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="391.166504" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="395.235064" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="399.303625" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="403.424346" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="407.545068" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="411.613628" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="415.682188" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="419.750749" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="423.819309" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="427.940031" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="432.060752" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="436.129312" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="440.197873" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="444.266433" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="448.387155" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="452.507876" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="456.576436" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="460.644997" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="464.713557" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="468.782118" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
+     <use xlink:href="#ma92c121c75" x="472.902839" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
-   <g id="line2d_25">
+   <g id="line2d_23">
     <path d="M 68.060216 25.44 
+L 72.358285 25.44 
+L 76.426845 25.44 
+L 80.495406 25.953333 
+L 84.563966 25.44 
+L 88.684688 25.876716 
+L 92.805409 26.326667 
+L 96.873969 27.545036 
+L 100.94253 27.607407 
+L 105.01109 29.650072 
+L 109.131812 38.044308 
+L 113.252533 43.75542 
+L 117.321093 49.903279 
+L 121.389654 68.97888 
+L 125.458214 84.911545 
+L 129.526775 121.36 
+L 133.647496 143.037333 
+L 137.768217 194.339187 
+L 141.836778 237.455082 
+L 145.905338 269.096 
+L 149.973899 277.563667 
+L 154.09462 297.434366 
+L 158.215341 308.860392 
+L 162.283902 307.04 
+L 166.352462 302.12256 
+L 170.421023 295.664706 
+L 174.489583 277.373559 
+L 178.610304 256.770738 
+L 182.731026 235.023256 
+L 186.799586 201 
+L 190.868147 186.029767 
+L 194.936707 154.984274 
+L 199.057428 135.727692 
+L 203.17815 112.371884 
+L 207.24671 88.385882 
+L 211.315271 72.400494 
+L 215.383831 64.029275 
+L 219.504552 51.392348 
+L 223.625274 45.965672 
+L 227.693834 40.706087 
+L 231.762395 34.728889 
+L 235.830955 33.8 
+L 239.899515 30.243881 
+L 244.020237 29.215484 
+L 248.140958 31.477778 
+L 252.209519 28.691111 
+L 256.278079 30.350769 
+L 260.346639 29.28438 
+L 264.467361 27.56029 
+L 268.588082 27.011007 
+L 272.656643 25.44 
+L 276.725203 26.448966 
+L 280.793763 25.840822 
+L 284.862324 26.391545 
+L 288.983045 25.849231 
+L 293.103767 25.44 
+L 297.172327 25.44 
+L 301.240887 25.873481 
+L 305.309448 25.44 
+L 309.430169 25.44 
+L 313.55089 25.44 
+L 317.619451 25.44 
+L 321.688011 25.44 
+L 325.756572 25.44 
+L 329.825132 25.855035 
+L 333.945853 25.44 
+L 338.066575 25.44 
+L 342.135135 25.44 
+L 346.203696 25.44 
+L 350.272256 25.44 
+L 354.392977 25.44 
+L 358.513699 25.44 
+L 362.582259 25.44 
+L 366.65082 25.44 
+L 370.71938 25.44 
+L 374.78794 25.44 
+L 378.908662 25.44 
+L 383.029383 25.44 
+L 387.097944 25.44 
+L 391.166504 25.44 
+L 395.235064 25.44 
+L 399.355786 25.44 
+L 403.476507 25.44 
+L 407.545068 25.44 
+L 411.613628 25.44 
+L 415.682188 25.44 
+L 419.750749 25.44 
+L 423.87147 25.44 
+L 427.992192 25.44 
+L 432.060752 25.44 
+L 436.129312 25.44 
+L 440.197873 25.44 
+L 444.318594 25.44 
+L 448.439316 25.44 
+L 452.507876 25.44 
+L 456.576436 25.44 
+L 460.644997 25.44 
+L 464.713557 25.44 
+L 468.834279 25.44 
+L 472.955 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
+    <defs>
+     <path id="m33a79e1f90" d="M 0 1 
+C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
+C 0.894634 0.51958 1 0.265203 1 0 
+C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
+C 0.51958 -0.894634 0.265203 -1 0 -1 
+C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
+C -0.894634 -0.51958 -1 -0.265203 -1 0 
+C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
+C -0.51958 0.894634 -0.265203 1 0 1 
+z
+" style="stroke: #7f7f7f"/>
+    </defs>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#m33a79e1f90" x="68.060216" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="72.358285" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="76.426845" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="80.495406" y="25.953333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="84.563966" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="88.684688" y="25.876716" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="92.805409" y="26.326667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="96.873969" y="27.545036" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="100.94253" y="27.607407" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="105.01109" y="29.650072" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="109.131812" y="38.044308" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="113.252533" y="43.75542" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="117.321093" y="49.903279" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="121.389654" y="68.97888" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="125.458214" y="84.911545" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="129.526775" y="121.36" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="133.647496" y="143.037333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="137.768217" y="194.339187" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="141.836778" y="237.455082" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="145.905338" y="269.096" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="149.973899" y="277.563667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="154.09462" y="297.434366" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="158.215341" y="308.860392" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="162.283902" y="307.04" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="166.352462" y="302.12256" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="170.421023" y="295.664706" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="174.489583" y="277.373559" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="178.610304" y="256.770738" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="182.731026" y="235.023256" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="186.799586" y="201" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="190.868147" y="186.029767" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="194.936707" y="154.984274" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="199.057428" y="135.727692" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="203.17815" y="112.371884" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="207.24671" y="88.385882" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="211.315271" y="72.400494" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="215.383831" y="64.029275" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="219.504552" y="51.392348" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="223.625274" y="45.965672" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="227.693834" y="40.706087" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="231.762395" y="34.728889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="235.830955" y="33.8" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="239.899515" y="30.243881" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="244.020237" y="29.215484" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="248.140958" y="31.477778" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="252.209519" y="28.691111" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="256.278079" y="30.350769" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="260.346639" y="29.28438" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="264.467361" y="27.56029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="268.588082" y="27.011007" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="272.656643" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="276.725203" y="26.448966" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="280.793763" y="25.840822" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="284.862324" y="26.391545" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="288.983045" y="25.849231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="293.103767" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="297.172327" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="301.240887" y="25.873481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="305.309448" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="309.430169" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="313.55089" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="317.619451" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="321.688011" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="325.756572" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="329.825132" y="25.855035" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="333.945853" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="338.066575" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="342.135135" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="346.203696" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="350.272256" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="354.392977" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="358.513699" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="362.582259" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="366.65082" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="370.71938" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="374.78794" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="378.908662" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="383.029383" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="387.097944" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="391.166504" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="395.235064" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="399.355786" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="403.476507" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="407.545068" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="411.613628" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="415.682188" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="419.750749" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="423.87147" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="427.992192" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="432.060752" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="436.129312" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="440.197873" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="444.318594" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="448.439316" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="452.507876" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="456.576436" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="460.644997" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="464.713557" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="468.834279" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+     <use xlink:href="#m33a79e1f90" x="472.955" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+    </g>
+   </g>
+   <g id="line2d_24">
+    <path d="M 68.055 25.44 
 L 72.358285 25.44 
 L 76.426845 25.44 
 L 80.495406 25.44 
@@ -2890,65 +2672,65 @@ L 84.563966 25.44
 L 88.684688 25.44 
 L 92.805409 25.44 
 L 96.873969 25.44 
-L 100.94253 25.633775 
-L 105.01109 25.973617 
-L 109.131812 26.630814 
-L 113.252533 27.43913 
-L 117.321093 29.956013 
-L 121.389654 30.680597 
-L 125.458214 40.866476 
-L 129.526775 50.342128 
-L 133.647496 72.332248 
-L 137.768217 103.985116 
-L 141.836778 140.29913 
-L 145.905338 198.082581 
-L 149.973899 246.696173 
-L 154.09462 278.504749 
-L 158.215341 299.265666 
-L 162.283902 305.958452 
-L 166.352462 298.093746 
-L 170.421023 284.03 
-L 174.489583 258.19 
-L 178.610304 217.527262 
-L 182.731026 176.219544 
-L 186.799586 128.807103 
-L 190.868147 99.707907 
-L 194.936707 76.737595 
-L 199.057428 62.68 
-L 203.17815 47.891069 
-L 207.24671 42.214463 
-L 211.315271 35.07439 
-L 215.383831 31.271174 
-L 219.452391 31.51283 
-L 223.573113 30.461518 
-L 227.693834 29.086647 
-L 231.762395 27.197357 
-L 235.830955 27.727427 
-L 239.899515 27.651512 
-L 244.020237 26.805467 
-L 248.140958 26.092033 
-L 252.209519 26.160246 
-L 256.278079 26.207475 
-L 260.346639 25.812739 
-L 264.4152 25.610612 
-L 268.535921 25.616798 
-L 272.656643 25.44 
-L 276.725203 25.44 
-L 280.793763 25.44 
+L 100.94253 25.44 
+L 105.01109 26.079563 
+L 109.079651 26.782202 
+L 113.200372 27.948 
+L 117.321093 29.522791 
+L 121.389654 34.306667 
+L 125.458214 46.295532 
+L 129.526775 65.034383 
+L 133.647496 84.211159 
+L 137.768217 128.354483 
+L 141.836778 174.011324 
+L 145.905338 216.210044 
+L 149.973899 258.983119 
+L 154.042459 285.807059 
+L 158.16318 302.65446 
+L 162.283902 306.56 
+L 166.352462 294.579279 
+L 170.421023 279.8975 
+L 174.489583 253.429683 
+L 178.610304 220.228 
+L 182.731026 180.119624 
+L 186.799586 142.754742 
+L 190.868147 108.961502 
+L 194.936707 84.792038 
+L 199.005267 68.919813 
+L 203.125989 58.763889 
+L 207.24671 46.17767 
+L 211.315271 38.627606 
+L 215.383831 33.42 
+L 219.452391 30.316667 
+L 223.573113 30.833548 
+L 227.693834 28.505333 
+L 231.762395 28.962037 
+L 235.830955 27.058065 
+L 239.899515 25.951092 
+L 244.020237 27.20569 
+L 248.140958 26.846731 
+L 252.209519 27.112 
+L 256.278079 26.010927 
+L 260.346639 26.010927 
+L 264.4152 25.957876 
+L 268.535921 26.499186 
+L 272.656643 25.694435 
+L 276.725203 25.70125 
+L 280.793763 25.72 
 L 284.862324 25.44 
-L 288.983045 25.44 
-L 293.103767 25.44 
-L 297.172327 25.617872 
-L 301.240887 25.63 
-L 305.309448 25.44 
+L 288.983045 25.724078 
+L 293.103767 25.744792 
+L 297.172327 25.44 
+L 301.240887 25.44 
+L 305.309448 25.70125 
 L 309.378008 25.44 
 L 313.498729 25.44 
 L 317.619451 25.44 
 L 321.688011 25.44 
-L 325.756572 25.44 
+L 325.756572 25.713458 
 L 329.825132 25.44 
 L 333.945853 25.44 
-L 338.066575 25.620062 
+L 338.066575 25.44 
 L 342.135135 25.44 
 L 346.203696 25.44 
 L 350.272256 25.44 
@@ -2974,17 +2756,235 @@ L 427.992192 25.44
 L 432.060752 25.44 
 L 436.129312 25.44 
 L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.387155 25.44 
+L 444.318594 25.44 
+L 448.439316 25.44 
 L 452.507876 25.44 
 L 456.576436 25.44 
 L 460.644997 25.44 
 L 464.713557 25.44 
 L 468.834279 25.44 
 L 472.955 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
-     <path id="m1c3b959e2a" d="M 0 1 
+     <path id="m047d9af936" d="M 0 1 
+C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
+C 0.894634 0.51958 1 0.265203 1 0 
+C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
+C 0.51958 -0.894634 0.265203 -1 0 -1 
+C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
+C -0.894634 -0.51958 -1 -0.265203 -1 0 
+C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
+C -0.51958 0.894634 -0.265203 1 0 1 
+z
+" style="stroke: #bcbd22"/>
+    </defs>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#m047d9af936" x="68.055" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="72.358285" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="76.426845" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="80.495406" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="84.563966" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="88.684688" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="92.805409" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="96.873969" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="100.94253" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="105.01109" y="26.079563" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="109.079651" y="26.782202" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="113.200372" y="27.948" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="117.321093" y="29.522791" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="121.389654" y="34.306667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="125.458214" y="46.295532" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="129.526775" y="65.034383" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="133.647496" y="84.211159" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="137.768217" y="128.354483" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="141.836778" y="174.011324" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="145.905338" y="216.210044" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="149.973899" y="258.983119" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="154.042459" y="285.807059" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="158.16318" y="302.65446" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="162.283902" y="306.56" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="166.352462" y="294.579279" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="170.421023" y="279.8975" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="174.489583" y="253.429683" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="178.610304" y="220.228" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="182.731026" y="180.119624" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="186.799586" y="142.754742" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="190.868147" y="108.961502" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="194.936707" y="84.792038" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="199.005267" y="68.919813" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="203.125989" y="58.763889" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="207.24671" y="46.17767" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="211.315271" y="38.627606" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="215.383831" y="33.42" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="219.452391" y="30.316667" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="223.573113" y="30.833548" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="227.693834" y="28.505333" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="231.762395" y="28.962037" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="235.830955" y="27.058065" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="239.899515" y="25.951092" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="244.020237" y="27.20569" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="248.140958" y="26.846731" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="252.209519" y="27.112" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="256.278079" y="26.010927" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="260.346639" y="26.010927" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="264.4152" y="25.957876" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="268.535921" y="26.499186" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="272.656643" y="25.694435" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="276.725203" y="25.70125" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="280.793763" y="25.72" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="284.862324" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="288.983045" y="25.724078" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="293.103767" y="25.744792" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="297.172327" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="301.240887" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="305.309448" y="25.70125" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="309.378008" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="313.498729" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="317.619451" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="321.688011" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="325.756572" y="25.713458" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="329.825132" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="333.945853" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="338.066575" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="342.135135" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="346.203696" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="350.272256" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="354.340816" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="358.461538" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="362.582259" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="366.65082" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="370.71938" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="374.78794" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="378.908662" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="383.029383" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="387.097944" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="391.166504" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="395.235064" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="399.303625" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="403.424346" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="407.545068" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="411.613628" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="415.682188" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="419.750749" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="423.87147" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="427.992192" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="432.060752" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="436.129312" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="440.197873" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="444.318594" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="448.439316" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="452.507876" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="456.576436" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="460.644997" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="464.713557" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="468.834279" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+     <use xlink:href="#m047d9af936" x="472.955" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
+    </g>
+   </g>
+   <g id="line2d_25">
+    <path d="M 68.060216 25.44 
+L 72.358285 25.44 
+L 76.426845 25.44 
+L 80.495406 25.6411 
+L 84.563966 25.44 
+L 88.684688 25.44 
+L 92.805409 25.44 
+L 96.873969 25.44 
+L 100.94253 25.63 
+L 105.01109 25.44 
+L 109.131812 26.808889 
+L 113.252533 27.309649 
+L 117.321093 29.912866 
+L 121.389654 30.970854 
+L 125.458214 38.348824 
+L 129.526775 56.120388 
+L 133.647496 75.414222 
+L 137.768217 111.726246 
+L 141.836778 162.504543 
+L 145.905338 203.201379 
+L 149.973899 250.445696 
+L 154.09462 277.681379 
+L 158.215341 299.872597 
+L 162.283902 307.487213 
+L 166.352462 300.784103 
+L 170.421023 283.304444 
+L 174.541744 256.656636 
+L 178.662465 222.132222 
+L 182.731026 190.74 
+L 186.799586 146.488219 
+L 190.868147 109.692199 
+L 194.936707 85.696499 
+L 199.057428 68.23275 
+L 203.17815 52.196471 
+L 207.24671 42.818667 
+L 211.315271 36.162609 
+L 215.383831 32.43907 
+L 219.504552 30.481723 
+L 223.625274 29.171141 
+L 227.693834 28.126164 
+L 231.762395 27.432941 
+L 235.830955 27.464277 
+L 239.899515 26.58 
+L 244.020237 26.673855 
+L 248.140958 25.999108 
+L 252.209519 26.237275 
+L 256.278079 25.7873 
+L 260.346639 25.970393 
+L 264.467361 26.1715 
+L 268.588082 25.625778 
+L 272.656643 25.44 
+L 276.725203 25.44 
+L 280.793763 25.44 
+L 284.862324 25.44 
+L 288.983045 25.612625 
+L 293.103767 25.44 
+L 297.172327 25.44 
+L 301.240887 25.44 
+L 305.309448 25.44 
+L 309.430169 25.44 
+L 313.55089 25.44 
+L 317.619451 25.44 
+L 321.688011 25.612625 
+L 325.756572 25.44 
+L 329.825132 25.44 
+L 333.945853 25.44 
+L 338.066575 25.44 
+L 342.135135 25.44 
+L 346.203696 25.44 
+L 350.272256 25.44 
+L 354.392977 25.44 
+L 358.513699 25.44 
+L 362.582259 25.44 
+L 366.65082 25.44 
+L 370.71938 25.44 
+L 374.840101 25.44 
+L 378.960823 25.44 
+L 383.029383 25.620062 
+L 387.097944 25.44 
+L 391.166504 25.44 
+L 395.235064 25.44 
+L 399.355786 25.44 
+L 403.476507 25.44 
+L 407.545068 25.44 
+L 411.613628 25.44 
+L 415.682188 25.44 
+L 419.80291 25.44 
+L 423.923631 25.44 
+L 427.992192 25.44 
+L 432.060752 25.44 
+L 436.129312 25.44 
+L 440.197873 25.44 
+L 444.318594 25.44 
+L 448.439316 25.44 
+L 452.507876 25.44 
+L 456.576436 25.44 
+L 460.644997 25.44 
+L 464.765718 25.44 
+L 468.88644 25.44 
+L 472.955 25.44 
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
+    <defs>
+     <path id="m5d8c125293" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -2996,118 +2996,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p8afa6f7f60)">
-     <use xlink:href="#m1c3b959e2a" x="68.060216" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="72.358285" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="76.426845" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="80.495406" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="84.563966" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="88.684688" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="92.805409" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="96.873969" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="100.94253" y="25.633775" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="105.01109" y="25.973617" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="109.131812" y="26.630814" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="113.252533" y="27.43913" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="117.321093" y="29.956013" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="121.389654" y="30.680597" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="125.458214" y="40.866476" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="129.526775" y="50.342128" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="133.647496" y="72.332248" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="137.768217" y="103.985116" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="141.836778" y="140.29913" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="145.905338" y="198.082581" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="149.973899" y="246.696173" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="154.09462" y="278.504749" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="158.215341" y="299.265666" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="162.283902" y="305.958452" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="166.352462" y="298.093746" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="170.421023" y="284.03" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="174.489583" y="258.19" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="178.610304" y="217.527262" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="182.731026" y="176.219544" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="186.799586" y="128.807103" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="190.868147" y="99.707907" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="194.936707" y="76.737595" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="199.057428" y="62.68" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="203.17815" y="47.891069" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="207.24671" y="42.214463" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="211.315271" y="35.07439" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="215.383831" y="31.271174" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="219.452391" y="31.51283" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="223.573113" y="30.461518" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="227.693834" y="29.086647" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="231.762395" y="27.197357" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="235.830955" y="27.727427" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="239.899515" y="27.651512" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="244.020237" y="26.805467" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="248.140958" y="26.092033" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="252.209519" y="26.160246" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="256.278079" y="26.207475" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="260.346639" y="25.812739" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="264.4152" y="25.610612" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="268.535921" y="25.616798" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="272.656643" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="276.725203" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="280.793763" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="284.862324" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="288.983045" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="293.103767" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="297.172327" y="25.617872" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="301.240887" y="25.63" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="305.309448" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="309.378008" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="313.498729" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="317.619451" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="321.688011" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="325.756572" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="329.825132" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="333.945853" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="338.066575" y="25.620062" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="342.135135" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="346.203696" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="350.272256" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="354.340816" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="358.461538" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="362.582259" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="366.65082" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="370.71938" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="374.78794" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="378.908662" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="383.029383" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="387.097944" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="391.166504" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="395.235064" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="399.303625" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="403.424346" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="407.545068" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="411.613628" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="415.682188" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="419.750749" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="423.87147" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="427.992192" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="432.060752" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="436.129312" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="440.197873" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="444.266433" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="448.387155" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="452.507876" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="456.576436" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="460.644997" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="464.713557" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="468.834279" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m1c3b959e2a" x="472.955" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p977ae3448e)">
+     <use xlink:href="#m5d8c125293" x="68.060216" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="72.358285" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="76.426845" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="80.495406" y="25.6411" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="84.563966" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="88.684688" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="92.805409" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="96.873969" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="100.94253" y="25.63" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="105.01109" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="109.131812" y="26.808889" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="113.252533" y="27.309649" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="117.321093" y="29.912866" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="121.389654" y="30.970854" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="125.458214" y="38.348824" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="129.526775" y="56.120388" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="133.647496" y="75.414222" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="137.768217" y="111.726246" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="141.836778" y="162.504543" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="145.905338" y="203.201379" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="149.973899" y="250.445696" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="154.09462" y="277.681379" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="158.215341" y="299.872597" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="162.283902" y="307.487213" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="166.352462" y="300.784103" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="170.421023" y="283.304444" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="174.541744" y="256.656636" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="178.662465" y="222.132222" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="182.731026" y="190.74" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="186.799586" y="146.488219" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="190.868147" y="109.692199" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="194.936707" y="85.696499" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="199.057428" y="68.23275" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="203.17815" y="52.196471" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="207.24671" y="42.818667" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="211.315271" y="36.162609" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="215.383831" y="32.43907" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="219.504552" y="30.481723" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="223.625274" y="29.171141" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="227.693834" y="28.126164" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="231.762395" y="27.432941" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="235.830955" y="27.464277" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="239.899515" y="26.58" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="244.020237" y="26.673855" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="248.140958" y="25.999108" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="252.209519" y="26.237275" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="256.278079" y="25.7873" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="260.346639" y="25.970393" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="264.467361" y="26.1715" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="268.588082" y="25.625778" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="272.656643" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="276.725203" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="280.793763" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="284.862324" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="288.983045" y="25.612625" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="293.103767" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="297.172327" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="301.240887" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="305.309448" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="309.430169" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="313.55089" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="317.619451" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="321.688011" y="25.612625" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="325.756572" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="329.825132" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="333.945853" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="338.066575" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="342.135135" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="346.203696" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="350.272256" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="354.392977" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="358.513699" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="362.582259" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="366.65082" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="370.71938" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="374.840101" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="378.960823" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="383.029383" y="25.620062" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="387.097944" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="391.166504" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="395.235064" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="399.355786" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="403.476507" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="407.545068" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="411.613628" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="415.682188" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="419.80291" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="423.923631" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="427.992192" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="432.060752" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="436.129312" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="440.197873" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="444.318594" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="448.439316" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="452.507876" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="456.576436" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="460.644997" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="464.765718" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="468.88644" y="25.44" style="fill: #17becf; stroke: #17becf"/>
+     <use xlink:href="#m5d8c125293" x="472.955" y="25.44" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_26">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_27">
     <path d="M 162.023097 318.04 
 L 162.023097 25.44 
-" clip-path="url(#p8afa6f7f60)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#p977ae3448e)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -3343,7 +3343,7 @@ L 378.72875 200.69375
 L 386.72875 200.69375 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1a09366b54" x="378.72875" y="200.69375" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#me3d1f519f4" x="378.72875" y="200.69375" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
@@ -3404,7 +3404,7 @@ L 378.72875 212.43625
 L 386.72875 212.43625 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m087ed5a55f" x="378.72875" y="212.43625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m305b67a360" x="378.72875" y="212.43625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
@@ -3498,7 +3498,7 @@ L 378.72875 224.17875
 L 386.72875 224.17875 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m50c4c5b6d6" x="378.72875" y="224.17875" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#mda5000919b" x="378.72875" y="224.17875" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_22">
@@ -3547,7 +3547,7 @@ L 378.72875 235.92125
 L 386.72875 235.92125 
 " style="fill: none; stroke: #d62728; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3c58dab356" x="378.72875" y="235.92125" style="fill: #d62728; stroke: #d62728"/>
+      <use xlink:href="#mbfc1946f7d" x="378.72875" y="235.92125" style="fill: #d62728; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_23">
@@ -3591,7 +3591,7 @@ L 378.72875 247.66375
 L 386.72875 247.66375 
 " style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m55e6d7755b" x="378.72875" y="247.66375" style="fill: #9467bd; stroke: #9467bd"/>
+      <use xlink:href="#me874039bf3" x="378.72875" y="247.66375" style="fill: #9467bd; stroke: #9467bd"/>
      </g>
     </g>
     <g id="text_24">
@@ -3640,7 +3640,7 @@ L 378.72875 259.40625
 L 386.72875 259.40625 
 " style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4c1a3ef8b4" x="378.72875" y="259.40625" style="fill: #8c564b; stroke: #8c564b"/>
+      <use xlink:href="#m41c5f4e4dc" x="378.72875" y="259.40625" style="fill: #8c564b; stroke: #8c564b"/>
      </g>
     </g>
     <g id="text_25">
@@ -3680,7 +3680,7 @@ L 378.72875 271.14875
 L 386.72875 271.14875 
 " style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m212723961c" x="378.72875" y="271.14875" style="fill: #e377c2; stroke: #e377c2"/>
+      <use xlink:href="#ma92c121c75" x="378.72875" y="271.14875" style="fill: #e377c2; stroke: #e377c2"/>
      </g>
     </g>
     <g id="text_26">
@@ -3759,7 +3759,7 @@ L 378.72875 282.89125
 L 386.72875 282.89125 
 " style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3ec912d9ec" x="378.72875" y="282.89125" style="fill: #7f7f7f; stroke: #7f7f7f"/>
+      <use xlink:href="#m33a79e1f90" x="378.72875" y="282.89125" style="fill: #7f7f7f; stroke: #7f7f7f"/>
      </g>
     </g>
     <g id="text_27">
@@ -3793,7 +3793,7 @@ L 378.72875 294.63375
 L 386.72875 294.63375 
 " style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m343f3fb6a2" x="378.72875" y="294.63375" style="fill: #bcbd22; stroke: #bcbd22"/>
+      <use xlink:href="#m047d9af936" x="378.72875" y="294.63375" style="fill: #bcbd22; stroke: #bcbd22"/>
      </g>
     </g>
     <g id="text_28">
@@ -3845,7 +3845,7 @@ L 378.72875 306.37625
 L 386.72875 306.37625 
 " style="fill: none; stroke: #17becf; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1c3b959e2a" x="378.72875" y="306.37625" style="fill: #17becf; stroke: #17becf"/>
+      <use xlink:href="#m5d8c125293" x="378.72875" y="306.37625" style="fill: #17becf; stroke: #17becf"/>
      </g>
     </g>
     <g id="text_29">
@@ -3868,7 +3868,7 @@ L 386.72875 306.37625
   </g>
  </g>
  <defs>
-  <clipPath id="p8afa6f7f60">
+  <clipPath id="p977ae3448e">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/shendure/shendure_power_mwu_all_cell_types.ipynb
+++ b/analyses/simulation/activity_power/shendure/shendure_power_mwu_all_cell_types.ipynb
@@ -7523,7 +7523,7 @@
     "            root=ct_dir,\n",
     "            n_sims=n_sims,\n",
     "            client=client,\n",
-    "            flatten_overtransfection=False,\n",
+    "            flatten_overtransfection=True,\n",
     "            bound=bound_ct,\n",
     "            n_cres=n_cres_per_ct[cell_type],\n",
     "            min=min_activity,\n",

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:40.976110</dc:date>
+    <dc:date>2026-08-16T17:12:23.423233</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m910b1e4773" d="M 0 0 
+       <path id="m4c64647b98" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m910b1e4773" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -91,7 +91,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m910b1e4773" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -133,7 +133,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m910b1e4773" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -164,7 +164,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m910b1e4773" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -179,7 +179,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m910b1e4773" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -220,7 +220,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m910b1e4773" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -235,7 +235,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m910b1e4773" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -284,7 +284,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m910b1e4773" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -299,7 +299,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m910b1e4773" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c64647b98" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,12 +617,12 @@ z
     <g id="ytick_1">
      <g id="line2d_10">
       <defs>
-       <path id="m9011483ebe" d="M 0 0 
+       <path id="md9b03d171b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -637,7 +637,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -652,7 +652,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -667,7 +667,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -714,7 +714,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -770,7 +770,7 @@ z
     <g id="ytick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9011483ebe" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9b03d171b" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1020,9 +1020,9 @@ L 460.682097 123.348462
 L 464.808332 112.769846 
 L 468.881666 111.68 
 L 472.955 117.748333 
-" clip-path="url(#p828b358537)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="mfe4ca4a998" d="M 0 1 
+     <path id="m337a4558d7" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1034,107 +1034,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p828b358537)">
-     <use xlink:href="#mfe4ca4a998" x="68.055" y="207.175477" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="72.339936" y="212.891765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="76.41327" y="219.461667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="80.539505" y="223.925361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="84.612839" y="224.063765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="88.686173" y="226.127232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="92.759507" y="234.23358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="96.832842" y="241.210061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="100.959076" y="244.253913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="105.032411" y="252.80459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="109.105745" y="260.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="113.231979" y="269.046512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="117.305314" y="271.923696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="121.378648" y="280.977333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="125.504882" y="281.608431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="129.578217" y="277.481584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="133.651551" y="285.102514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="137.777785" y="283.055217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="141.85112" y="284.422128" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="145.924454" y="279.026667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="149.997788" y="291.030769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="154.071122" y="290.752584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="158.197357" y="288.458462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="162.270691" y="286.381639" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="166.344025" y="286.555556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="170.47026" y="289.750711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="174.543594" y="284.030995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="178.616928" y="282.4625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="182.743163" y="282.152044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="186.816497" y="287.997647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="190.889831" y="277.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="194.963166" y="275.086897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="199.0365" y="272.456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="203.162735" y="270.898889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="207.236069" y="264.636503" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="211.309403" y="256.933481" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="215.435638" y="254.486022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="219.508972" y="254.850851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="223.582306" y="252.754682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="227.708541" y="246.550703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="231.781875" y="240.88514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="235.855209" y="233.232941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="239.928543" y="233.2525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="244.001877" y="217.9575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="248.128112" y="232.277931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="252.201446" y="224.470588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="256.274781" y="213.812071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="260.401015" y="211.78" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="264.474349" y="205.090108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="268.547684" y="205.357872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="272.673918" y="195.148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="276.747252" y="196.844734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="280.820587" y="193.60092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="284.893921" y="191.190289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="288.967255" y="185.689535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="293.09349" y="188.027586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="297.166824" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="301.240158" y="184.010323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="305.366393" y="180.072318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="309.439727" y="172.09253" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="313.513061" y="160.317647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="317.639296" y="167.472917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="321.71263" y="162.286769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="325.785964" y="160.861282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="329.859298" y="168.488889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="333.932633" y="168.767059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="338.058867" y="157.01913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="342.132201" y="160.514465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="346.205536" y="159.149333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="350.33177" y="148.011741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="354.405105" y="148.825542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="358.478439" y="148.533793" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="362.604673" y="153.657978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="366.678008" y="133.961266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="370.751342" y="142.129581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="374.877576" y="140.963938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="378.950911" y="133.939243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="383.024245" y="124.959042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="387.097579" y="129.313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="391.170913" y="145.59645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="395.297148" y="137.351959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="399.370482" y="135.635556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="403.443816" y="129.246834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="407.570051" y="134.033814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="411.643385" y="137.744277" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="415.716719" y="130.602178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="419.842954" y="131.738987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="423.916288" y="126.293617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="427.989622" y="125.374154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="432.062957" y="120.92" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="436.136291" y="120.379362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="440.262525" y="126.106528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="444.33586" y="121.249488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="448.409194" y="124.68268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="452.535429" y="117.930146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="456.608763" y="124.864286" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="460.682097" y="123.348462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="464.808332" y="112.769846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="468.881666" y="111.68" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mfe4ca4a998" x="472.955" y="117.748333" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p8b40560f1b)">
+     <use xlink:href="#m337a4558d7" x="68.055" y="207.175477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="72.339936" y="212.891765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="76.41327" y="219.461667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="80.539505" y="223.925361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="84.612839" y="224.063765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="88.686173" y="226.127232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="92.759507" y="234.23358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="96.832842" y="241.210061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="100.959076" y="244.253913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="105.032411" y="252.80459" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="109.105745" y="260.08" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="113.231979" y="269.046512" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="117.305314" y="271.923696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="121.378648" y="280.977333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="125.504882" y="281.608431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="129.578217" y="277.481584" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="133.651551" y="285.102514" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="137.777785" y="283.055217" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="141.85112" y="284.422128" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="145.924454" y="279.026667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="149.997788" y="291.030769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="154.071122" y="290.752584" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="158.197357" y="288.458462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="162.270691" y="286.381639" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="166.344025" y="286.555556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="170.47026" y="289.750711" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="174.543594" y="284.030995" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="178.616928" y="282.4625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="182.743163" y="282.152044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="186.816497" y="287.997647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="190.889831" y="277.44" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="194.963166" y="275.086897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="199.0365" y="272.456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="203.162735" y="270.898889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="207.236069" y="264.636503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="211.309403" y="256.933481" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="215.435638" y="254.486022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="219.508972" y="254.850851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="223.582306" y="252.754682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="227.708541" y="246.550703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="231.781875" y="240.88514" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="235.855209" y="233.232941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="239.928543" y="233.2525" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="244.001877" y="217.9575" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="248.128112" y="232.277931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="252.201446" y="224.470588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="256.274781" y="213.812071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="260.401015" y="211.78" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="264.474349" y="205.090108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="268.547684" y="205.357872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="272.673918" y="195.148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="276.747252" y="196.844734" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="280.820587" y="193.60092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="284.893921" y="191.190289" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="288.967255" y="185.689535" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="293.09349" y="188.027586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="297.166824" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="301.240158" y="184.010323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="305.366393" y="180.072318" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="309.439727" y="172.09253" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="313.513061" y="160.317647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="317.639296" y="167.472917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="321.71263" y="162.286769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="325.785964" y="160.861282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="329.859298" y="168.488889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="333.932633" y="168.767059" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="338.058867" y="157.01913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="342.132201" y="160.514465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="346.205536" y="159.149333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="350.33177" y="148.011741" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="354.405105" y="148.825542" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="358.478439" y="148.533793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="362.604673" y="153.657978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="366.678008" y="133.961266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="370.751342" y="142.129581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="374.877576" y="140.963938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="378.950911" y="133.939243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="383.024245" y="124.959042" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="387.097579" y="129.313" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="391.170913" y="145.59645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="395.297148" y="137.351959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="399.370482" y="135.635556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="403.443816" y="129.246834" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="407.570051" y="134.033814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="411.643385" y="137.744277" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="415.716719" y="130.602178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="419.842954" y="131.738987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="423.916288" y="126.293617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="427.989622" y="125.374154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="432.062957" y="120.92" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="436.136291" y="120.379362" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="440.262525" y="126.106528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="444.33586" y="121.249488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="448.409194" y="124.68268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="452.535429" y="117.930146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="456.608763" y="124.864286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="460.682097" y="123.348462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="464.808332" y="112.769846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="468.881666" y="111.68" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m337a4558d7" x="472.955" y="117.748333" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_17">
@@ -1238,9 +1238,9 @@ L 460.682097 146.1584
 L 464.808332 151.510864 
 L 468.881666 153.773333 
 L 472.955 134.4335 
-" clip-path="url(#p828b358537)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="m4c12832359" d="M 0 1 
+     <path id="mbe2357430f" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1252,107 +1252,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p828b358537)">
-     <use xlink:href="#m4c12832359" x="68.1079" y="213.513711" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="72.392836" y="226.835957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="76.519071" y="233.785301" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="80.592405" y="228.987826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="84.665739" y="228.309333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="88.791974" y="251.958427" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="92.865308" y="249.820552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="96.938643" y="253.416687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="101.011977" y="253.379012" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="105.085311" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="109.211546" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="113.28488" y="266.602038" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="117.358214" y="271.777568" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="121.484449" y="277.784204" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="125.557783" y="280.929756" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="129.631117" y="275.149565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="133.704451" y="287.203114" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="137.777785" y="287.771034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="141.90402" y="290.655641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="145.977354" y="286.417391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="150.050689" y="291.883333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="154.176923" y="287.154444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="158.250257" y="289.666667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="162.323592" y="290.021333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="166.449826" y="287.597778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="170.52316" y="289.468471" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="174.596495" y="291.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="178.669829" y="289.606554" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="182.743163" y="281.465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="186.869398" y="281.610331" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="190.942732" y="282.522081" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="195.016066" y="282.66597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="199.142301" y="286.323053" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="203.215635" y="275.731622" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="207.288969" y="273.78425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="211.362303" y="273.388902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="215.435638" y="270.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="219.561872" y="267.410337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="223.635206" y="259.864235" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="227.708541" y="262.017805" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="231.834775" y="257.297722" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="235.908109" y="248.749448" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="239.981444" y="253.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="244.107678" y="243.994286" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="248.181013" y="241.709565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="252.254347" y="243.1344" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="256.327681" y="237.436981" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="260.401015" y="233.286897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="264.52725" y="226.181333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="268.600584" y="231.010256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="272.673918" y="230.26" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="276.800153" y="217.612129" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="280.873487" y="213.119527" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="284.946821" y="212.0352" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="289.073056" y="212.97" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="293.14639" y="210.12" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="297.219724" y="209.572994" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="301.293059" y="207.029333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="305.366393" y="207.284027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="309.492627" y="195.712048" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="313.565962" y="196.583396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="317.639296" y="194.880261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="321.76553" y="194.896687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="325.838865" y="187.284375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="329.912199" y="178.603457" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="333.985533" y="188.38491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="338.058867" y="180.535951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="342.185102" y="187.833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="346.258436" y="185.828148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="350.33177" y="176.559294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="354.458005" y="176.342697" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="358.531339" y="176.971921" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="362.604673" y="170.114444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="366.730908" y="178.220403" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="370.804242" y="169.65" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="374.877576" y="165.30695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="378.950911" y="170.467826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="383.024245" y="163.925217" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="387.150479" y="158.499441" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="391.223814" y="155.845679" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="395.297148" y="161.877079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="399.423383" y="153.5" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="403.496717" y="167.466067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="407.570051" y="159.715342" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="411.643385" y="156.941839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="415.716719" y="150.645581" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="419.842954" y="149.660368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="423.916288" y="156.249412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="427.989622" y="159.341695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="432.115857" y="145.406" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="436.189191" y="144.38" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="440.262525" y="147.294937" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="444.38876" y="140.604359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="448.462094" y="148.982222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="452.535429" y="141.465202" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="456.608763" y="149.364706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="460.682097" y="146.1584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="464.808332" y="151.510864" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="468.881666" y="153.773333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m4c12832359" x="472.955" y="134.4335" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p8b40560f1b)">
+     <use xlink:href="#mbe2357430f" x="68.1079" y="213.513711" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="72.392836" y="226.835957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="76.519071" y="233.785301" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="80.592405" y="228.987826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="84.665739" y="228.309333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="88.791974" y="251.958427" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="92.865308" y="249.820552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="96.938643" y="253.416687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="101.011977" y="253.379012" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="105.085311" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="109.211546" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="113.28488" y="266.602038" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="117.358214" y="271.777568" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="121.484449" y="277.784204" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="125.557783" y="280.929756" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="129.631117" y="275.149565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="133.704451" y="287.203114" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="137.777785" y="287.771034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="141.90402" y="290.655641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="145.977354" y="286.417391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="150.050689" y="291.883333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="154.176923" y="287.154444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="158.250257" y="289.666667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="162.323592" y="290.021333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="166.449826" y="287.597778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="170.52316" y="289.468471" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="174.596495" y="291.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="178.669829" y="289.606554" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="182.743163" y="281.465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="186.869398" y="281.610331" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="190.942732" y="282.522081" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="195.016066" y="282.66597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="199.142301" y="286.323053" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="203.215635" y="275.731622" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="207.288969" y="273.78425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="211.362303" y="273.388902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="215.435638" y="270.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="219.561872" y="267.410337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="223.635206" y="259.864235" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="227.708541" y="262.017805" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="231.834775" y="257.297722" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="235.908109" y="248.749448" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="239.981444" y="253.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="244.107678" y="243.994286" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="248.181013" y="241.709565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="252.254347" y="243.1344" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="256.327681" y="237.436981" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="260.401015" y="233.286897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="264.52725" y="226.181333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="268.600584" y="231.010256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="272.673918" y="230.26" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="276.800153" y="217.612129" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="280.873487" y="213.119527" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="284.946821" y="212.0352" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="289.073056" y="212.97" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="293.14639" y="210.12" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="297.219724" y="209.572994" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="301.293059" y="207.029333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="305.366393" y="207.284027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="309.492627" y="195.712048" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="313.565962" y="196.583396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="317.639296" y="194.880261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="321.76553" y="194.896687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="325.838865" y="187.284375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="329.912199" y="178.603457" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="333.985533" y="188.38491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="338.058867" y="180.535951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="342.185102" y="187.833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="346.258436" y="185.828148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="350.33177" y="176.559294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="354.458005" y="176.342697" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="358.531339" y="176.971921" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="362.604673" y="170.114444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="366.730908" y="178.220403" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="370.804242" y="169.65" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="374.877576" y="165.30695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="378.950911" y="170.467826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="383.024245" y="163.925217" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="387.150479" y="158.499441" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="391.223814" y="155.845679" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="395.297148" y="161.877079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="399.423383" y="153.5" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="403.496717" y="167.466067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="407.570051" y="159.715342" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="411.643385" y="156.941839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="415.716719" y="150.645581" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="419.842954" y="149.660368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="423.916288" y="156.249412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="427.989622" y="159.341695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="432.115857" y="145.406" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="436.189191" y="144.38" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="440.262525" y="147.294937" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="444.38876" y="140.604359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="448.462094" y="148.982222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="452.535429" y="141.465202" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="456.608763" y="149.364706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="460.682097" y="146.1584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="464.808332" y="151.510864" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="468.881666" y="153.773333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#mbe2357430f" x="472.955" y="134.4335" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_18">
@@ -1456,9 +1456,9 @@ L 460.682097 152.143853
 L 464.808332 158.798077 
 L 468.881666 147.185126 
 L 472.955 153.437928 
-" clip-path="url(#p828b358537)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m1516952069" d="M 0 1 
+     <path id="mb0aa4e19a1" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1470,118 +1470,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p828b358537)">
-     <use xlink:href="#m1516952069" x="68.055" y="237.827241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="72.339936" y="234.649" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="76.41327" y="235.706667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="80.539505" y="252.101972" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="84.612839" y="250.896" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="88.686173" y="250.190725" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="92.812408" y="259.52" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="96.885742" y="262.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="100.959076" y="267.522735" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="105.085311" y="271.575622" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="109.158645" y="269.618584" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="113.231979" y="277.423379" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="117.305314" y="276.474393" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="121.378648" y="277.633333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="125.504882" y="284.146063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="129.578217" y="280.985852" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="133.651551" y="280.456034" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="137.777785" y="283.675064" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="141.85112" y="283.495154" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="145.924454" y="286.033143" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="150.050689" y="288.922732" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="154.124023" y="287.374498" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="158.197357" y="289.732651" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="162.270691" y="291.931077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="166.344025" y="293.908041" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="170.47026" y="289.982466" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="174.543594" y="289.872697" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="178.616928" y="287.915781" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="182.743163" y="282.981935" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="186.816497" y="285.248621" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="190.889831" y="283.342301" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="195.016066" y="283.213463" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="199.0894" y="281.767273" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="203.162735" y="280.485827" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="207.236069" y="278.672" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="211.309403" y="277.049032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="215.435638" y="272.32125" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="219.508972" y="268.523077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="223.582306" y="268.032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="227.708541" y="264.458397" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="231.781875" y="270.556667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="235.855209" y="268.246667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="239.981444" y="253.413565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="244.054778" y="260.132775" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="248.128112" y="252.846667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="252.201446" y="246.596833" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="256.274781" y="242.8" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="260.401015" y="239.456" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="264.474349" y="242.169849" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="268.547684" y="232.57" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="272.673918" y="229.626667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="276.747252" y="235.245037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="280.820587" y="224.304425" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="284.946821" y="223.197241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="289.020155" y="226.047471" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="293.09349" y="232.02569" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="297.219724" y="210.549289" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="301.293059" y="213.666667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="305.366393" y="216.80872" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="309.439727" y="203.682167" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="313.513061" y="204.707149" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="317.639296" y="207.062883" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="321.71263" y="210.352511" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="325.785964" y="198.156923" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="329.912199" y="202.612756" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="333.985533" y="190.476667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="338.058867" y="186.944978" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="342.185102" y="198.088557" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="346.258436" y="187.378966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="350.33177" y="182.532623" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="354.405105" y="181.408522" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="358.478439" y="185.722655" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="362.604673" y="177.738912" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="366.678008" y="177.76" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="370.751342" y="185.828148" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="374.877576" y="170.421982" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="378.950911" y="176.769063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="383.024245" y="170.910769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="387.150479" y="165.008826" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="391.223814" y="170.2" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="395.297148" y="168.801223" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="399.370482" y="179.272277" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="403.443816" y="162.468313" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="407.570051" y="171.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="411.643385" y="165.166167" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="415.716719" y="156.642374" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="419.842954" y="166.822353" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="423.916288" y="162.613028" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="427.989622" y="164.855294" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="432.115857" y="165.413514" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="436.189191" y="165.20875" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="440.262525" y="151.206667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="444.33586" y="157.172255" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="448.409194" y="154.036471" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="452.535429" y="155.039087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="456.608763" y="153.979563" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="460.682097" y="152.143853" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="464.808332" y="158.798077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="468.881666" y="147.185126" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m1516952069" x="472.955" y="153.437928" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p8b40560f1b)">
+     <use xlink:href="#mb0aa4e19a1" x="68.055" y="237.827241" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="72.339936" y="234.649" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="76.41327" y="235.706667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="80.539505" y="252.101972" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="84.612839" y="250.896" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="88.686173" y="250.190725" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="92.812408" y="259.52" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="96.885742" y="262.88" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="100.959076" y="267.522735" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="105.085311" y="271.575622" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="109.158645" y="269.618584" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="113.231979" y="277.423379" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="117.305314" y="276.474393" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="121.378648" y="277.633333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="125.504882" y="284.146063" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="129.578217" y="280.985852" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="133.651551" y="280.456034" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="137.777785" y="283.675064" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="141.85112" y="283.495154" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="145.924454" y="286.033143" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="150.050689" y="288.922732" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="154.124023" y="287.374498" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="158.197357" y="289.732651" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="162.270691" y="291.931077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="166.344025" y="293.908041" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="170.47026" y="289.982466" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="174.543594" y="289.872697" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="178.616928" y="287.915781" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="182.743163" y="282.981935" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="186.816497" y="285.248621" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="190.889831" y="283.342301" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="195.016066" y="283.213463" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="199.0894" y="281.767273" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="203.162735" y="280.485827" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="207.236069" y="278.672" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="211.309403" y="277.049032" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="215.435638" y="272.32125" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="219.508972" y="268.523077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="223.582306" y="268.032" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="227.708541" y="264.458397" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="231.781875" y="270.556667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="235.855209" y="268.246667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="239.981444" y="253.413565" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="244.054778" y="260.132775" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="248.128112" y="252.846667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="252.201446" y="246.596833" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="256.274781" y="242.8" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="260.401015" y="239.456" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="264.474349" y="242.169849" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="268.547684" y="232.57" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="272.673918" y="229.626667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="276.747252" y="235.245037" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="280.820587" y="224.304425" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="284.946821" y="223.197241" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="289.020155" y="226.047471" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="293.09349" y="232.02569" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="297.219724" y="210.549289" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="301.293059" y="213.666667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="305.366393" y="216.80872" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="309.439727" y="203.682167" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="313.513061" y="204.707149" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="317.639296" y="207.062883" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="321.71263" y="210.352511" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="325.785964" y="198.156923" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="329.912199" y="202.612756" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="333.985533" y="190.476667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="338.058867" y="186.944978" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="342.185102" y="198.088557" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="346.258436" y="187.378966" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="350.33177" y="182.532623" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="354.405105" y="181.408522" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="358.478439" y="185.722655" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="362.604673" y="177.738912" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="366.678008" y="177.76" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="370.751342" y="185.828148" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="374.877576" y="170.421982" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="378.950911" y="176.769063" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="383.024245" y="170.910769" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="387.150479" y="165.008826" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="391.223814" y="170.2" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="395.297148" y="168.801223" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="399.370482" y="179.272277" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="403.443816" y="162.468313" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="407.570051" y="171.88" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="411.643385" y="165.166167" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="415.716719" y="156.642374" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="419.842954" y="166.822353" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="423.916288" y="162.613028" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="427.989622" y="164.855294" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="432.115857" y="165.413514" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="436.189191" y="165.20875" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="440.262525" y="151.206667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="444.33586" y="157.172255" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="448.409194" y="154.036471" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="452.535429" y="155.039087" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="456.608763" y="153.979563" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="460.682097" y="152.143853" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="464.808332" y="158.798077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="468.881666" y="147.185126" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#mb0aa4e19a1" x="472.955" y="153.437928" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_19">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p828b358537)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#p8b40560f1b)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_20">
     <path d="M 157.615452 318.04 
 L 157.615452 25.44 
-" clip-path="url(#p828b358537)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#p8b40560f1b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -1827,7 +1827,7 @@ L 444.195 49.596875
 L 452.195 49.596875 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mfe4ca4a998" x="444.195" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m337a4558d7" x="444.195" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
@@ -1861,7 +1861,7 @@ L 444.195 61.339375
 L 452.195 61.339375 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4c12832359" x="444.195" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#mbe2357430f" x="444.195" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
@@ -1941,7 +1941,7 @@ L 444.195 73.081875
 L 452.195 73.081875 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1516952069" x="444.195" y="73.081875" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#mb0aa4e19a1" x="444.195" y="73.081875" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_22">
@@ -1985,7 +1985,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p828b358537">
+  <clipPath id="p8b40560f1b">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-09T13:40:40.871008</dc:date>
+    <dc:date>2026-08-16T17:12:23.366884</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m6eab525eec" d="M 0 0 
+       <path id="m0e2fd97e60" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6eab525eec" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -91,7 +91,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m6eab525eec" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -133,7 +133,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m6eab525eec" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -164,7 +164,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6eab525eec" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -179,7 +179,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m6eab525eec" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -220,7 +220,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6eab525eec" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -235,7 +235,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m6eab525eec" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -284,7 +284,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6eab525eec" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -299,7 +299,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m6eab525eec" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2fd97e60" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -617,12 +617,12 @@ z
     <g id="ytick_1">
      <g id="line2d_10">
       <defs>
-       <path id="m5b82bfe0e0" d="M 0 0 
+       <path id="m6423196eb5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -637,7 +637,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -652,7 +652,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -667,7 +667,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -714,7 +714,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -770,7 +770,7 @@ z
     <g id="ytick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m5b82bfe0e0" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6423196eb5" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1020,9 +1020,9 @@ L 460.682097 65.391154
 L 464.808332 58.451282 
 L 468.881666 60.688889 
 L 472.955 62.363333 
-" clip-path="url(#p4738936a83)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
+" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
-     <path id="mb2294bd3c0" d="M 0 1 
+     <path id="m625fdeae2f" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1034,107 +1034,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p4738936a83)">
-     <use xlink:href="#mb2294bd3c0" x="68.055" y="74.255678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="72.339936" y="81.769412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="76.41327" y="81.521667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="80.539505" y="90.897938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="84.612839" y="88.435059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="88.686173" y="107.764746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="92.759507" y="111.775062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="96.832842" y="116.989693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="100.959076" y="127.779324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="105.032411" y="129.688743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="109.105745" y="148.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="113.231979" y="155.068605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="117.305314" y="172.058043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="121.378648" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="125.504882" y="204.15549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="129.578217" y="217.513069" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="133.651551" y="245.449617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="137.777785" y="259.201957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="141.85112" y="271.348511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="145.924454" y="283.233987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="149.997788" y="285.243077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="154.071122" y="293.711461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="158.197357" y="293.603077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="162.270691" y="290.538798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="166.344025" y="296.137778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="170.47026" y="283.6491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="174.543594" y="270.549948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="178.616928" y="262.5125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="182.743163" y="245.617459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="186.816497" y="231.042353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="190.889831" y="217.52" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="194.963166" y="208.206897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="199.0365" y="192.376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="203.162735" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="207.236069" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="211.309403" y="166.728619" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="215.435638" y="158.211183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="219.508972" y="147.149149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="223.582306" y="142.141734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="227.708541" y="144.377946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="231.781875" y="132.672179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="235.855209" y="129.336471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="239.928543" y="129.18" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="244.001877" y="110.56" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="248.128112" y="121.628046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="252.201446" y="110.872941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="256.274781" y="106.467692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="260.401015" y="117.224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="264.474349" y="102.837419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="268.547684" y="96.099787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="272.673918" y="95.664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="276.747252" y="103.697515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="280.820587" y="102.794023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="284.893921" y="102.226358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="288.967255" y="98.930233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="293.09349" y="90.878621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="297.166824" y="90.567097" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="301.240158" y="93.39871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="305.366393" y="85.510199" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="309.439727" y="86.427711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="313.513061" y="84.585882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="317.639296" y="83.96" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="321.71263" y="79.758564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="325.785964" y="86.210769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="329.859298" y="90.079739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="333.932633" y="92.722353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="338.058867" y="85.777391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="342.132201" y="82.487799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="346.205536" y="80.768" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="350.33177" y="75.225672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="354.405105" y="77.614458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="358.478439" y="77.569885" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="362.604673" y="77.713483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="366.678008" y="68.033671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="370.751342" y="70.293653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="374.877576" y="73.650777" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="378.950911" y="74.47027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="383.024245" y="64.336527" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="387.097579" y="67.867" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="391.170913" y="77.380828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="395.297148" y="67.670928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="399.370482" y="64.453333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="403.443816" y="61.904724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="407.570051" y="70.385773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="411.643385" y="67.046705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="415.716719" y="65.998416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="419.842954" y="74.700506" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="423.916288" y="67.773617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="427.989622" y="66.854154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="432.062957" y="72.324444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="436.136291" y="67.46234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="440.262525" y="61.219067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="444.33586" y="64.634791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="448.409194" y="63.749485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="452.535429" y="64.263024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="456.608763" y="63.955714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="460.682097" y="65.391154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="464.808332" y="58.451282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="468.881666" y="60.688889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb2294bd3c0" x="472.955" y="62.363333" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p3bd2ef8389)">
+     <use xlink:href="#m625fdeae2f" x="68.055" y="74.255678" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="72.339936" y="81.769412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="76.41327" y="81.521667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="80.539505" y="90.897938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="84.612839" y="88.435059" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="88.686173" y="107.764746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="92.759507" y="111.775062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="96.832842" y="116.989693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="100.959076" y="127.779324" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="105.032411" y="129.688743" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="109.105745" y="148.08" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="113.231979" y="155.068605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="117.305314" y="172.058043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="121.378648" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="125.504882" y="204.15549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="129.578217" y="217.513069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="133.651551" y="245.449617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="137.777785" y="259.201957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="141.85112" y="271.348511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="145.924454" y="283.233987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="149.997788" y="285.243077" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="154.071122" y="293.711461" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="158.197357" y="293.603077" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="162.270691" y="290.538798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="166.344025" y="296.137778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="170.47026" y="283.6491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="174.543594" y="270.549948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="178.616928" y="262.5125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="182.743163" y="245.617459" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="186.816497" y="231.042353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="190.889831" y="217.52" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="194.963166" y="208.206897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="199.0365" y="192.376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="203.162735" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="207.236069" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="211.309403" y="166.728619" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="215.435638" y="158.211183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="219.508972" y="147.149149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="223.582306" y="142.141734" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="227.708541" y="144.377946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="231.781875" y="132.672179" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="235.855209" y="129.336471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="239.928543" y="129.18" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="244.001877" y="110.56" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="248.128112" y="121.628046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="252.201446" y="110.872941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="256.274781" y="106.467692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="260.401015" y="117.224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="264.474349" y="102.837419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="268.547684" y="96.099787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="272.673918" y="95.664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="276.747252" y="103.697515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="280.820587" y="102.794023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="284.893921" y="102.226358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="288.967255" y="98.930233" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="293.09349" y="90.878621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="297.166824" y="90.567097" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="301.240158" y="93.39871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="305.366393" y="85.510199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="309.439727" y="86.427711" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="313.513061" y="84.585882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="317.639296" y="83.96" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="321.71263" y="79.758564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="325.785964" y="86.210769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="329.859298" y="90.079739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="333.932633" y="92.722353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="338.058867" y="85.777391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="342.132201" y="82.487799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="346.205536" y="80.768" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="350.33177" y="75.225672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="354.405105" y="77.614458" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="358.478439" y="77.569885" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="362.604673" y="77.713483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="366.678008" y="68.033671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="370.751342" y="70.293653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="374.877576" y="73.650777" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="378.950911" y="74.47027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="383.024245" y="64.336527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="387.097579" y="67.867" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="391.170913" y="77.380828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="395.297148" y="67.670928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="399.370482" y="64.453333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="403.443816" y="61.904724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="407.570051" y="70.385773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="411.643385" y="67.046705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="415.716719" y="65.998416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="419.842954" y="74.700506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="423.916288" y="67.773617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="427.989622" y="66.854154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="432.062957" y="72.324444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="436.136291" y="67.46234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="440.262525" y="61.219067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="444.33586" y="64.634791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="448.409194" y="63.749485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="452.535429" y="64.263024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="456.608763" y="63.955714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="460.682097" y="65.391154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="464.808332" y="58.451282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="468.881666" y="60.688889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m625fdeae2f" x="472.955" y="62.363333" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_17">
@@ -1238,9 +1238,9 @@ L 460.682097 83.6256
 L 464.808332 74.929136 
 L 468.881666 82.591111 
 L 472.955 75.182 
-" clip-path="url(#p4738936a83)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
+" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
-     <path id="m483cc9e9aa" d="M 0 1 
+     <path id="m279b9dd2f2" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1252,107 +1252,107 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p4738936a83)">
-     <use xlink:href="#m483cc9e9aa" x="68.1079" y="77.335094" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="72.392836" y="88.006596" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="76.519071" y="88.895422" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="80.592405" y="97.772174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="84.665739" y="92.933067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="88.791974" y="116.50764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="92.865308" y="130.840663" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="96.938643" y="128.119264" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="101.011977" y="130.920494" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="105.085311" y="144.367742" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="109.211546" y="156.826839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="113.28488" y="173.790064" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="117.358214" y="181.22973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="121.484449" y="203.236433" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="125.557783" y="224.193902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="129.631117" y="222.081739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="133.704451" y="244.802395" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="137.777785" y="269.273333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="141.90402" y="271.899231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="145.977354" y="285.326957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="150.050689" y="284.79" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="154.176923" y="294.306889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="158.250257" y="294.277333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="162.323592" y="290.730667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="166.449826" y="292.917778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="170.52316" y="282.583765" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="174.596495" y="276.189333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="178.669829" y="263.818079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="182.743163" y="259.1875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="186.869398" y="252.156556" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="190.942732" y="239.224046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="195.016066" y="228.949851" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="199.142301" y="221.10229" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="203.215635" y="203.767838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="207.288969" y="193.685" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="211.362303" y="190.175491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="215.435638" y="180.429333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="219.561872" y="173.712584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="223.635206" y="164.511059" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="227.708541" y="169.242195" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="231.834775" y="160.998987" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="235.908109" y="148.583313" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="239.981444" y="142.86" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="244.107678" y="153.228571" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="248.181013" y="141.843913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="252.254347" y="129.995733" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="256.327681" y="129.230189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="260.401015" y="129.69977" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="264.52725" y="124.746667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="268.600584" y="130.475897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="272.673918" y="110.14" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="276.800153" y="115.674065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="280.873487" y="111.661775" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="284.946821" y="116.7312" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="289.073056" y="106.9025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="293.14639" y="108.28" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="297.219724" y="108.188025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="301.293059" y="103.112" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="305.366393" y="105.168591" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="309.492627" y="98.766265" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="313.565962" y="95.73761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="317.639296" y="101.554248" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="321.76553" y="101.91092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="325.838865" y="94.9325" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="329.912199" y="94.797037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="333.985533" y="96.224671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="338.058867" y="85.755092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="342.185102" y="94.56675" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="346.258436" y="95.158272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="350.33177" y="90.844706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="354.458005" y="88.233933" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="358.531339" y="87.060397" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="362.604673" y="87.211111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="366.730908" y="97.706309" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="370.804242" y="82.706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="374.877576" y="75.659291" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="378.950911" y="89.048696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="383.024245" y="85.777391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="387.150479" y="74.806034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="391.223814" y="86.127407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="395.297148" y="83.631236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="399.423383" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="403.496717" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="407.570051" y="77.947671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="411.643385" y="82.614713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="415.716719" y="79.877209" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="419.842954" y="79.292761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="423.916288" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="427.989622" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="432.115857" y="74.08475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="436.189191" y="80.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="440.262525" y="72.107848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="444.38876" y="73.831538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="448.462094" y="74.671111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="452.535429" y="71.782428" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="456.608763" y="79.370196" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="460.682097" y="83.6256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="464.808332" y="74.929136" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="468.881666" y="82.591111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m483cc9e9aa" x="472.955" y="75.182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p3bd2ef8389)">
+     <use xlink:href="#m279b9dd2f2" x="68.1079" y="77.335094" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="72.392836" y="88.006596" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="76.519071" y="88.895422" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="80.592405" y="97.772174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="84.665739" y="92.933067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="88.791974" y="116.50764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="92.865308" y="130.840663" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="96.938643" y="128.119264" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="101.011977" y="130.920494" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="105.085311" y="144.367742" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="109.211546" y="156.826839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="113.28488" y="173.790064" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="117.358214" y="181.22973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="121.484449" y="203.236433" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="125.557783" y="224.193902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="129.631117" y="222.081739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="133.704451" y="244.802395" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="137.777785" y="269.273333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="141.90402" y="271.899231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="145.977354" y="285.326957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="150.050689" y="284.79" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="154.176923" y="294.306889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="158.250257" y="294.277333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="162.323592" y="290.730667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="166.449826" y="292.917778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="170.52316" y="282.583765" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="174.596495" y="276.189333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="178.669829" y="263.818079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="182.743163" y="259.1875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="186.869398" y="252.156556" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="190.942732" y="239.224046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="195.016066" y="228.949851" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="199.142301" y="221.10229" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="203.215635" y="203.767838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="207.288969" y="193.685" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="211.362303" y="190.175491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="215.435638" y="180.429333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="219.561872" y="173.712584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="223.635206" y="164.511059" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="227.708541" y="169.242195" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="231.834775" y="160.998987" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="235.908109" y="148.583313" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="239.981444" y="142.86" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="244.107678" y="153.228571" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="248.181013" y="141.843913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="252.254347" y="129.995733" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="256.327681" y="129.230189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="260.401015" y="129.69977" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="264.52725" y="124.746667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="268.600584" y="130.475897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="272.673918" y="110.14" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="276.800153" y="115.674065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="280.873487" y="111.661775" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="284.946821" y="116.7312" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="289.073056" y="106.9025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="293.14639" y="108.28" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="297.219724" y="108.188025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="301.293059" y="103.112" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="305.366393" y="105.168591" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="309.492627" y="98.766265" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="313.565962" y="95.73761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="317.639296" y="101.554248" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="321.76553" y="101.91092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="325.838865" y="94.9325" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="329.912199" y="94.797037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="333.985533" y="96.224671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="338.058867" y="85.755092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="342.185102" y="94.56675" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="346.258436" y="95.158272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="350.33177" y="90.844706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="354.458005" y="88.233933" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="358.531339" y="87.060397" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="362.604673" y="87.211111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="366.730908" y="97.706309" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="370.804242" y="82.706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="374.877576" y="75.659291" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="378.950911" y="89.048696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="383.024245" y="85.777391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="387.150479" y="74.806034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="391.223814" y="86.127407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="395.297148" y="83.631236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="399.423383" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="403.496717" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="407.570051" y="77.947671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="411.643385" y="82.614713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="415.716719" y="79.877209" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="419.842954" y="79.292761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="423.916288" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="427.989622" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="432.115857" y="74.08475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="436.189191" y="80.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="440.262525" y="72.107848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="444.38876" y="73.831538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="448.462094" y="74.671111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="452.535429" y="71.782428" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="456.608763" y="79.370196" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="460.682097" y="83.6256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="464.808332" y="74.929136" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="468.881666" y="82.591111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m279b9dd2f2" x="472.955" y="75.182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_18">
@@ -1456,9 +1456,9 @@ L 460.682097 70.806422
 L 464.808332 82.553269 
 L 468.881666 75.72603 
 L 472.955 78.364462 
-" clip-path="url(#p4738936a83)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
+" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
     <defs>
-     <path id="m915b6ec5b7" d="M 0 1 
+     <path id="m9b7f166b95" d="M 0 1 
 C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
 C 0.894634 0.51958 1 0.265203 1 0 
 C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
@@ -1470,118 +1470,118 @@ C -0.51958 0.894634 -0.265203 1 0 1
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p4738936a83)">
-     <use xlink:href="#m915b6ec5b7" x="68.055" y="85.221207" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="72.339936" y="89.812" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="76.41327" y="92.826667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="80.539505" y="105.939343" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="84.612839" y="107.778667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="88.686173" y="116.753816" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="92.812408" y="120.44318" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="96.885742" y="131.28" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="100.959076" y="146.731453" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="105.085311" y="157.04721" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="109.158645" y="168.373805" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="113.231979" y="178.821187" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="117.305314" y="190.608598" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="121.378648" y="208.524" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="125.504882" y="226.155656" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="129.578217" y="244.187249" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="133.651551" y="258.258793" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="137.777785" y="266.741617" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="141.85112" y="274.730044" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="145.924454" y="280.300571" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="150.050689" y="287.495415" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="154.124023" y="287.88559" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="158.197357" y="291.365767" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="162.270691" y="289.455231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="166.344025" y="284.255258" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="170.47026" y="281.164384" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="174.543594" y="274.089295" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="178.616928" y="270.384473" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="182.743163" y="265.992258" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="186.816497" y="250.943793" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="190.889831" y="240.617522" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="195.016066" y="235.25561" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="199.0894" y="224.94" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="203.162735" y="207.22063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="207.236069" y="216.162" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="211.309403" y="193.449032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="215.435638" y="190.0275" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="219.508972" y="179.742735" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="223.582306" y="181.05" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="227.708541" y="164.455865" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="231.781875" y="166.093333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="235.855209" y="160.96" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="239.981444" y="148.332" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="244.054778" y="151.97801" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="248.128112" y="139.143333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="252.201446" y="136.628" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="256.274781" y="133.36" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="260.401015" y="137.185333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="264.474349" y="125.71799" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="268.547684" y="121.176667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="272.673918" y="120.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="276.747252" y="127.308148" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="280.820587" y="113.737876" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="284.946821" y="114.228966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="289.020155" y="115.610895" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="293.09349" y="113.472241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="297.219724" y="102.56887" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="301.293059" y="106.253333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="305.366393" y="100.323412" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="309.439727" y="102.2475" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="313.513061" y="92.963077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="317.639296" y="102.148649" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="321.71263" y="96.519087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="325.785964" y="97.227692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="329.912199" y="94.097323" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="333.985533" y="93.713333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="338.058867" y="87.793188" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="342.185102" y="90.07403" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="346.258436" y="94.049655" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="350.33177" y="90.435574" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="354.405105" y="88.794261" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="358.478439" y="90.692389" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="362.604673" y="81.021757" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="366.678008" y="89.84" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="370.751342" y="93.592922" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="374.877576" y="87.914054" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="378.950911" y="85.560156" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="383.024245" y="89.172308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="387.150479" y="81.487324" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="391.223814" y="77.24" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="395.297148" y="81.404541" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="399.370482" y="87.146733" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="403.443816" y="79.866008" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="407.570051" y="81.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="411.643385" y="79.835242" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="415.716719" y="72.736986" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="419.842954" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="423.916288" y="88.255046" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="427.989622" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="432.115857" y="76.315495" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="436.189191" y="78.2125" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="440.262525" y="72.153333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="444.33586" y="78.481532" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="448.409194" y="78.058824" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="452.535429" y="79.951781" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="456.608763" y="77.315808" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="460.682097" y="70.806422" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="464.808332" y="82.553269" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="468.881666" y="75.72603" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m915b6ec5b7" x="472.955" y="78.364462" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p3bd2ef8389)">
+     <use xlink:href="#m9b7f166b95" x="68.055" y="85.221207" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="72.339936" y="89.812" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="76.41327" y="92.826667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="80.539505" y="105.939343" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="84.612839" y="107.778667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="88.686173" y="116.753816" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="92.812408" y="120.44318" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="96.885742" y="131.28" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="100.959076" y="146.731453" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="105.085311" y="157.04721" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="109.158645" y="168.373805" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="113.231979" y="178.821187" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="117.305314" y="190.608598" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="121.378648" y="208.524" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="125.504882" y="226.155656" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="129.578217" y="244.187249" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="133.651551" y="258.258793" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="137.777785" y="266.741617" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="141.85112" y="274.730044" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="145.924454" y="280.300571" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="150.050689" y="287.495415" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="154.124023" y="287.88559" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="158.197357" y="291.365767" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="162.270691" y="289.455231" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="166.344025" y="284.255258" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="170.47026" y="281.164384" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="174.543594" y="274.089295" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="178.616928" y="270.384473" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="182.743163" y="265.992258" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="186.816497" y="250.943793" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="190.889831" y="240.617522" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="195.016066" y="235.25561" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="199.0894" y="224.94" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="203.162735" y="207.22063" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="207.236069" y="216.162" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="211.309403" y="193.449032" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="215.435638" y="190.0275" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="219.508972" y="179.742735" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="223.582306" y="181.05" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="227.708541" y="164.455865" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="231.781875" y="166.093333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="235.855209" y="160.96" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="239.981444" y="148.332" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="244.054778" y="151.97801" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="248.128112" y="139.143333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="252.201446" y="136.628" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="256.274781" y="133.36" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="260.401015" y="137.185333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="264.474349" y="125.71799" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="268.547684" y="121.176667" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="272.673918" y="120.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="276.747252" y="127.308148" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="280.820587" y="113.737876" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="284.946821" y="114.228966" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="289.020155" y="115.610895" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="293.09349" y="113.472241" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="297.219724" y="102.56887" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="301.293059" y="106.253333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="305.366393" y="100.323412" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="309.439727" y="102.2475" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="313.513061" y="92.963077" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="317.639296" y="102.148649" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="321.71263" y="96.519087" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="325.785964" y="97.227692" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="329.912199" y="94.097323" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="333.985533" y="93.713333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="338.058867" y="87.793188" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="342.185102" y="90.07403" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="346.258436" y="94.049655" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="350.33177" y="90.435574" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="354.405105" y="88.794261" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="358.478439" y="90.692389" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="362.604673" y="81.021757" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="366.678008" y="89.84" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="370.751342" y="93.592922" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="374.877576" y="87.914054" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="378.950911" y="85.560156" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="383.024245" y="89.172308" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="387.150479" y="81.487324" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="391.223814" y="77.24" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="395.297148" y="81.404541" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="399.370482" y="87.146733" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="403.443816" y="79.866008" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="407.570051" y="81.44" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="411.643385" y="79.835242" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="415.716719" y="72.736986" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="419.842954" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="423.916288" y="88.255046" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="427.989622" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="432.115857" y="76.315495" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="436.189191" y="78.2125" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="440.262525" y="72.153333" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="444.33586" y="78.481532" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="448.409194" y="78.058824" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="452.535429" y="79.951781" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="456.608763" y="77.315808" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="460.682097" y="70.806422" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="464.808332" y="82.553269" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="468.881666" y="75.72603" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m9b7f166b95" x="472.955" y="78.364462" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_19">
     <path d="M 47.81 83.96 
 L 493.2 83.96 
-" clip-path="url(#p4738936a83)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
+" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
    </g>
    <g id="line2d_20">
     <path d="M 157.615452 318.04 
 L 157.615452 25.44 
-" clip-path="url(#p4738936a83)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
    </g>
    <g id="patch_3">
     <path d="M 47.81 318.04 
@@ -1782,7 +1782,7 @@ L 63.01 282.89125
 L 71.01 282.89125 
 " style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb2294bd3c0" x="63.01" y="282.89125" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m625fdeae2f" x="63.01" y="282.89125" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
@@ -1816,7 +1816,7 @@ L 63.01 294.63375
 L 71.01 294.63375 
 " style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m483cc9e9aa" x="63.01" y="294.63375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m279b9dd2f2" x="63.01" y="294.63375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
@@ -1896,7 +1896,7 @@ L 63.01 306.37625
 L 71.01 306.37625 
 " style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m915b6ec5b7" x="63.01" y="306.37625" style="fill: #2ca02c; stroke: #2ca02c"/>
+      <use xlink:href="#m9b7f166b95" x="63.01" y="306.37625" style="fill: #2ca02c; stroke: #2ca02c"/>
      </g>
     </g>
     <g id="text_22">
@@ -1940,7 +1940,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p4738936a83">
+  <clipPath id="p3bd2ef8389">
    <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
   </clipPath>
  </defs>

--- a/scMPRAforge/core.py
+++ b/scMPRAforge/core.py
@@ -1566,8 +1566,14 @@ class scMPRA_data:
             return
         
         groupby_columns=list(set(self.data.columns)-{"umis_mpra_bc"})
-        
-        self.data= self.data.groupby(groupby_columns).agg("sum").reset_index()
+
+        umis_in=self.data["umis_mpra_bc"].sum()
+        #dropna=False: a NaN in any key column (e.g. cre_id_original when
+        #set_negative_controls was never called) would otherwise take the row
+        #with it, silently.
+        self.data= self.data.groupby(groupby_columns,dropna=False).agg("sum").reset_index()
+        assert self.data["umis_mpra_bc"].sum()==umis_in, \
+            f"flattening changed total UMIs: {umis_in} -> {self.data['umis_mpra_bc'].sum()}"
         self.operations.append("overtransfection_flattened")
     
     def overtransfected(self, log=True, threshold_pct=WARN_MULTI_TRANSFECTION_PERCENT):
@@ -7284,7 +7290,7 @@ class de_novo_simulation:
         n_sims:int=None,
         experiment_bounds:Bounds=None,
         ground_truth:pd.DataFrame=None,
-        flatten_overtransfection=None,
+        flatten_overtransfection=True,
         negative_controls=["reference"],
         reference_cell_type="reference"
         ):
@@ -7358,23 +7364,28 @@ class de_novo_simulation:
             
             self.futures = pd.DataFrame(index=range(n_sims))
             
-            required = ("libraries", 
+            required = ("libraries",
                         "library_mapping",
                         "n_sims",
                         "experiment_bounds",
-                        "ground_truth",
-                        "flatten_overtransfection")
-                        
-            
+                        "ground_truth")
+
+            #validate before writing: set_state_field saves state.parquet on
+            #every call, so a half-initalized object would persist to disk.
+            if any(x is None for x in [libraries,library_mapping,n_sims,experiment_bounds,ground_truth]):
+                raise ValueError(f"When initalizing a new object, required params include all of: {required}.")
+
+            if not flatten_overtransfection:
+                logger.warning("flatten_overtransfection disabled: debug-only setting. "
+                               "Simulated data will retain repeat integrations of the same "
+                               "barcode in one cell, which a real experiment cannot resolve.")
+
             #lightweight, just save.
             self.set_state_field("n_sims",n_sims)
             self.set_state_field("reference_cell_type",reference_cell_type)
             self.set_state_field("negative_controls",negative_controls)
             self.set_state_field("alpha",DEFAULT_SIGNIFICANCE_THRESHOLD)
             self.set_state_field("flatten_overtransfection",flatten_overtransfection)
-            
-            if any(x is None for x in [libraries,library_mapping,n_sims,experiment_bounds,ground_truth]):
-                raise ValueError(f"When initalizing a new object, required params include all of: {required}.")
 
             #if `libraries` is a single dataframe, put it in a one-element list. 
             if isinstance(libraries, pd.DataFrame):
@@ -8504,7 +8515,7 @@ def one_library_replicate(root,min,max,client,flatten_overtransfection,bound,n_c
                             client=client,
                             libraries=libraries,
                             library_mapping="corresponding",
-                            flatten_overtransfection=True,
+                            flatten_overtransfection=flatten_overtransfection,
                             n_sims=n_sims,
                             experiment_bounds=bound,
                             ground_truth=gt_df)


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. `flatten_overtransfection` defaults to True

Intended behaviour is on everywhere, disablable for debug only. Three things stood between the code and that:

- **`de_novo_simulation.__init__` defaulted to `None`, and failed open.** The parameter was listed in the `required` tuple used to *format* the error message but not in the tuple actually checked, so omitting it silently gave `None` -> falsy -> no flattening, no warning. Default is now `True`, and it is removed from the `required` tuple since it no longer is one.
- **`set_state_field` ran before validation**, so a constructor that was about to raise had already written `state.parquet`. The raise now comes first.
- **`one_library_replicate` ignored its own argument.** It declared `flatten_overtransfection` as a required positional and then hardcoded `flatten_overtransfection=True` in the body. Five live scripts and a notebook passed a value that was discarded. It now passes the argument through.

Disabling it now logs a warning, which is the only way the setting has ever been observable at runtime.

`shendure_power_mwu_all_cell_types.ipynb` passed `False` to `one_library_replicate`. That was discarded before this change and would take effect after it, so the notebook is set to `True` in the same commit. This is not cosmetic: the April power sims behind Fig. 4 were flattened *only* because of the hardcode, verified from their `state.parquet` on cold storage.

### Also: `flatten_overtransfection` was dropping rows

`groupby` defaults to `dropna=True`, so any row with a NaN in a key column -- `cre_id_original` when `set_negative_controls` was never called, or a NaN `cell_type` -- vanished silently. Now `dropna=False`, with an assert that total UMIs are unchanged. Flattening is a pure regrouping, so that total is exactly invariant; the assert catches both this and any future change to the key columns.

### Not changed

`two_thirds_inactive.ipynb` and `shendure_calibration_mwu_all_cell_types.ipynb` set `False` on direct `de_novo_simulation` calls. That is honoured today and unaffected by this change, and both were confirmed to be dead ends with respect to the manuscript (different data roots and sim dates from the scripts that produce the figure inputs). Editing their source without re-running would desynchronise the saved cell outputs from the code.

## 2. Power figures read the MWU arms

`replot_overlay_ct.py` and `main_figs_power_at_fc.py` were reading April t-test parquets whose producer is no longer in the tree, while the 2026-08-13 MWU rerun sat unread beside them.

The rerun was deliberate. From the `ARMS` comment in `shendure_power_ttest_all_cell_types.py`: the 2026-04-10 run computed only the t-test arms, and the t-test over-rejects in exactly the deflated condition, so the reporter's power benefit could only be measured with a test that is miscalibrated against it. The aggregation block says outright that "the MWU pair is what the reporter figure now uses" -- the readers were simply never repointed.

Effect on the measured benefit, mean power gain at the figure's fold change:

| dataset | t-test (what the figures showed) | MWU (this change) |
|---|---|---|
| Lalanne et al. | +0.480 | +0.593 |
| Zhao et al. | +0.028 | +0.035 |

It goes up, not down: the t-test inflates the *deflated* arm (Cardiomyocytes reads 0.209 under t-test against 0.087 under MWU), and inflating the arm being subtracted understates the difference. The figures were understating the reporter benefit.

Yin et al. is untouched and remains t-test -- it is the one analysis of the four where no MWU arm has been run on its power sims. A comment in both readers names the inconsistency rather than hiding it.

Regenerated SVGs are included so the tracked outputs match their inputs.
