### PR TITLE
Fig 4 replot: 4B continuous, Yin dropped

### DIFF
--- a/analyses/simulation/activity_power/main_figs_power_at_fc.py
+++ b/analyses/simulation/activity_power/main_figs_power_at_fc.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
-"""
-Main-text figures: reporter effect (Fig A) and dataset comparison (Fig B).
+"""Main-text power figures for the transfection-reporter panel (manuscript Fig 4).
 
-Both use power at FC=1.5 (upregulation), computed from existing parquets.
-No re-simulation. FC=1.5 is in the sim range for all three datasets (Cohen
-caps at 1.6) and gives a clean 3-tier visual under the "bigger=better"
-convention: Cohen near-saturated, Shendure mid-range, Seelig floored.
+Fig 4A -- fig_a_reporter_dumbbell -> output/fig_a_reporter_dumbbell.svg
+    Power at a single fold change, per cell type, with the transfection
+    reporter and without it. The two dots are the paired arms of the same
+    simulation and the segment between them is the reporter's contribution.
 
-Fig A: Reporter dumbbell for cohen + shendure (the two datasets with
-       reporters). Per cell type, -reporter dot and +reporter dot connected
-       by a line; line length is the reporter's power contribution.
-Fig B: Best-available power@FC=1.5 bars across all three datasets.
-       cohen+rep, shendure+rep, seelig-rep. Horizontal bars, bigger=better.
+Fig 4B -- fig_b_power_curves -> output/fig_b_slope.svg
+    The same two arms as continuous power-vs-fold-change curves, one curve per
+    cell type, over a fold-change window both datasets cover. Panel A reads one
+    vertical slice of this; panel B says whether that slice is representative.
 
-Full butterflies (FC@80% power, both directions) live in per-dataset
-subdirs and are supplemental.
+Only Zhao et al. (code name cohen) and Lalanne et al. (shendure) appear in
+either manuscript panel. Yin et al. (seelig) ran no transfection reporter, so
+it has no "+reporter" arm and never can have one -- a paired contrast cannot
+include it. It stays in DATASETS because the two supplementary/exploratory
+figures below (fig_b_dataset_bars, fig_b_telescope) do show all three.
+
+Also written, not manuscript figures:
+    output/fig_b_dataset_bars.svg     best-available power per dataset
+    output/fig_b_telescope.svg        nested bars over a per-dataset FC triplet
+    output/fig_b_slope_discrete.svg   the three-point slope form of Fig 4B,
+                                      kept for comparison against the curves
 
 Usage:
     python main_figs_power_at_fc.py
@@ -24,16 +31,25 @@ import numpy as np
 import pandas as pd
 import matplotlib
 matplotlib.use("Agg")
-matplotlib.rcParams["svg.fonttype"] = "none"
-matplotlib.rcParams["pdf.fonttype"] = 42
-matplotlib.rcParams["ps.fonttype"] = 42
 import matplotlib.pyplot as plt
 from pathlib import Path
 
 TARGET_FC = 1.5
 FC_TOL = 0.05  # +/- 5% window around target
 
-# Per-dataset FC triplets for multi-FC variants. Each spans the dataset's
+# Continuous power curves (Fig 4B) are drawn over a window both datasets cover.
+# Zhao et al.'s simulation stops at fc 1.60, Lalanne et al.'s runs to 4.0. A
+# shared axis wide enough for Lalanne would leave most of Zhao's panel empty,
+# and a per-panel axis would make the two datasets' slopes look comparable when
+# they are drawn at different fold-change-per-inch. Clipping both to the common
+# informative window keeps every panel full and every slope comparable.
+FC_WINDOW = (1.0, 1.6)
+# Bin *width*, not bin count, so a bin means the same fold-change interval in
+# both datasets even though their raw fc ranges differ by a factor of four.
+FC_BIN_WIDTH = 0.03
+MIN_BIN_N = 30  # a bin thinner than this is too noisy to draw
+
+# Per-dataset FC triplets for the discrete variants. Each spans the dataset's
 # informative regime. Cohen caps at 1.6; seelig needs higher FCs to show any
 # power; shendure is in the middle.
 FC_TRIPLET = {
@@ -57,36 +73,116 @@ DATASETS = {
         "reporter": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu.parquet",
         "deflated": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu_deflated.parquet",
         "ref_display": "Rod",
-        "title": "Cohen (episomal, CRE-reporter)",
+        "title": "Zhao et al. (episomal, CRE reporter)",
+        "n_cell_types": 4,
     },
     "shendure": {
         "reporter": SCRIPT_DIR / "shendure/output/power_df_mwu_2026-08-13.parquet",
         "deflated": SCRIPT_DIR / "shendure/output/power_df_mwu_deflated_2026-08-13.parquet",
         "ref_display": "Pluripotent",
-        "title": "Shendure (piggyBac, oBC reporter)",
+        "title": "Lalanne et al. (piggyBac, oBC reporter)",
+        "n_cell_types": 10,
     },
     "seelig": {
         "deflated": SCRIPT_DIR / "seelig/output/seelig_power_df_deflated.parquet",
         "ref_display": "HepG2",
-        "title": "Seelig (episomal, no reporter)",
+        "title": "Yin et al. (episomal, no reporter)",
+        "n_cell_types": 2,
     },
 }
 
-COLOR_REP = "steelblue"
-COLOR_DEFL = "coral"
+# The two datasets that ran both arms, in the order they appear in the
+# manuscript panels: the four-row dataset on top of the ten-row one.
+PAIRED_DSETS = ["cohen", "shendure"]
 
+# Cell-type identifiers as they come out of the fits, and what a reader sees.
+# Only the camel-case run-together names need rewriting; anything absent here
+# is passed through, and "reference" is handled separately per dataset.
+CT_DISPLAY = {
+    "EpiblastPrimitiveStreak": "Epiblast/prim. streak",
+    "ExEndodermParietal": "ExE endoderm parietal",
+    "ExEndodermVisceral": "ExE endoderm visceral",
+    "NeuroectodermBrain": "Neuroectoderm brain",
+    "NeuroectodermRostral": "Neuroectoderm rostral",
+    "SurfaceEctoderm": "Surface ectoderm",
+    "Haematoendothelial": "Haematoendothelial",
+    "Mueller Glia": "Mueller glia",
+}
+
+# Okabe-Ito, the palette scripts/figure_styling.py remaps everything else to,
+# and the pair already used by activity_calibration/fpr_dumbbell.py so the two
+# figures sit next to each other without changing colour conventions. The pair
+# passes every categorical check outright (worst CVD dE 21.9, normal-vision
+# 31.2, both above 3:1 on white), so nothing is leaning on shape or position to
+# tell the two arms apart.
+COLOR_REP = "#0072b2"   # with transfection reporter
+COLOR_DEFL = "#d55e00"  # without
+INK, MUTED, HAIR = "#1a1a1a", "#666666", "#c9c9c9"
+
+LABEL_REP = "with reporter"
+LABEL_DEFL = "without reporter"
+
+# Sized for a 0.49\textwidth inclusion: 3.38 in on the page, no downstream font
+# scaling, so a point size here is the point size a reader gets.
+FIG_W = 3.38
+
+plt.rcParams.update({
+    "svg.fonttype": "none",       # keep text editable downstream
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+    "font.size": 7,
+    "axes.labelsize": 7.5,
+    "axes.titlesize": 7.5,
+    "xtick.labelsize": 6.5,
+    "ytick.labelsize": 6.5,
+    "legend.fontsize": 6.5,
+    "axes.unicode_minus": False,  # the repo is plain ASCII
+})
+
+
+def display_ct(ct, dataset):
+    """Reader-facing name for a cell type in a given dataset."""
+    if ct == "reference":
+        return DATASETS[dataset]["ref_display"]
+    return CT_DISPLAY.get(ct, ct)
+
+
+def style_axes(ax, grid_axis):
+    """Hairline grid on one axis, no box, ticks without tick marks."""
+    ax.grid(axis=grid_axis, color=HAIR, lw=0.5, zorder=0)
+    ax.set_axisbelow(True)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_color(HAIR)
+        ax.spines[side].set_linewidth(0.8)
+    ax.tick_params(length=0, colors=INK, pad=2)
+
+
+# ----- power at a single fold change -----
 
 def power_at_fc(df, target_fc=TARGET_FC, tol=FC_TOL):
     """Mean reject_null over a window of fc around target, per cell type."""
     lo = target_fc * (1 - tol)
     hi = target_fc * (1 + tol)
     window = df[(df["fc"] >= lo) & (df["fc"] <= hi)]
-    return (
-        window.groupby("cell_type")["reject_null"]
-        .mean()
-        .rename("power")
+    assert len(window), \
+        f"fc window [{lo:.3f}, {hi:.3f}] is empty; data spans " \
+        f"[{df['fc'].min():.3f}, {df['fc'].max():.3f}]"
+    out = (
+        window.groupby("cell_type", observed=True)["reject_null"]
+        .agg(["mean", "size"])
+        .rename(columns={"mean": "power", "size": "n"})
         .reset_index()
     )
+    # Every cell type in the parquet must survive the window, or a dumbbell
+    # silently loses a row rather than failing.
+    assert len(out) == df["cell_type"].nunique(), \
+        f"fc window [{lo:.3f}, {hi:.3f}] dropped cell types: " \
+        f"{df['cell_type'].nunique()} in, {len(out)} out"
+    assert out["power"].between(0.0, 1.0).all(), \
+        f"power outside [0, 1]: {out['power'].min()} to {out['power'].max()}"
+    return out
 
 
 def rename_reference(df, display):
@@ -108,70 +204,241 @@ def load_powers():
         out[name]["deflated"] = rename_reference(
             power_at_fc(defl), d["ref_display"]
         )
+        for mode, tab in out[name].items():
+            assert len(tab) == d["n_cell_types"], \
+                f"{name} ({mode}): expected {d['n_cell_types']} cell types, " \
+                f"got {len(tab)}: {sorted(tab['cell_type'])}"
     return out
 
 
+# ----- Fig 4A: paired dumbbell at one fold change -----
+
 def fig_a_reporter_dumbbell(powers):
-    """Fig A: +rep vs -rep at FC=1.5, cohen + shendure panels."""
-    dsets = ["cohen", "shendure"]
-    n_cts = [len(powers[d]["reporter"]) for d in dsets]
+    """Fig 4A: power with and without the reporter, per cell type."""
+    n_rows = [DATASETS[d]["n_cell_types"] for d in PAIRED_DSETS]
+    total_rows = sum(n_rows)
+
+    # Geometry in inches rather than tight_layout, so the row pitch is the same
+    # in both panels and the figure height follows the number of rows.
+    pitch, top_in, gap_in, bottom_in = 0.165, 0.40, 0.30, 0.36
+    plot_in = pitch * total_rows
+    height = top_in + plot_in + gap_in + bottom_in
+
     fig, axes = plt.subplots(
-        2, 1, figsize=(6, 5),
-        gridspec_kw={"height_ratios": n_cts},
+        len(PAIRED_DSETS), 1, figsize=(FIG_W, height),
+        gridspec_kw={"height_ratios": n_rows,
+                     "hspace": gap_in / (plot_in / len(PAIRED_DSETS))},
         sharex=True,
     )
 
-    for ax, name in zip(axes, dsets):
+    for ax, name in zip(axes, PAIRED_DSETS):
         rep = powers[name]["reporter"].set_index("cell_type")["power"]
         defl = powers[name]["deflated"].set_index("cell_type")["power"]
-        # Sort by +reporter power ascending
-        cts = rep.sort_values().index.tolist()
+        assert set(rep.index) == set(defl.index), \
+            f"{name}: arms disagree on cell types, " \
+            f"{sorted(set(rep.index) ^ set(defl.index))} unmatched"
+
+        # Strongest achievable power at the top.
+        cts = rep.sort_values(ascending=True).index.tolist()
         y = np.arange(len(cts))
         rep_vals = rep.loc[cts].values
         defl_vals = defl.loc[cts].values
 
-        for yi, dv, rv in zip(y, defl_vals, rep_vals):
-            ax.plot([dv, rv], [yi, yi], color="gray", lw=1.5, zorder=1)
-        ax.scatter(
-            defl_vals, y, color=COLOR_DEFL, s=55,
-            label="-reporter", zorder=3, edgecolor="white", lw=0.6,
-        )
-        ax.scatter(
-            rep_vals, y, color=COLOR_REP, s=55,
-            label="+reporter", zorder=3, edgecolor="white", lw=0.6,
-        )
+        # The connector is the reporter's contribution. It is drawn under both
+        # dots and lighter than either, so it reads as the distance between
+        # them rather than as a third mark.
+        ax.hlines(y, defl_vals, rep_vals, color=HAIR, lw=1.8, zorder=2)
+        for vals, color, label in (
+            (defl_vals, COLOR_DEFL, LABEL_DEFL),
+            (rep_vals, COLOR_REP, LABEL_REP),
+        ):
+            ax.scatter(vals, y, s=26, color=color, label=label, zorder=3,
+                       edgecolors="white", linewidths=1.0, clip_on=False)
+
         ax.set_yticks(y)
-        ax.set_yticklabels(cts, fontsize=9)
-        ax.set_title(DATASETS[name]["title"], fontsize=10, loc="left")
-        ax.axvline(0.8, color="black", ls="--", lw=0.6, alpha=0.4)
-        ax.grid(axis="x", alpha=0.3)
-        ax.set_xlim(-0.02, 1.02)
+        ax.set_yticklabels([display_ct(c, name) for c in cts])
+        ax.set_ylim(-0.5, len(cts) - 0.5)
+        ax.set_xlim(0, 1.0)
+        ax.set_xticks(np.arange(0, 1.01, 0.25), ["0", "0.25", "0.5", "0.75", "1"])
+        ax.axvline(0.8, color=MUTED, ls="--", lw=0.7, zorder=1)
+        ax.set_title(DATASETS[name]["title"], loc="left", color=INK, pad=4)
+        style_axes(ax, grid_axis="x")
 
-    axes[0].legend(
-        loc="lower left", fontsize=8, frameon=True,
-        bbox_to_anchor=(0.0, 1.15), ncol=2,
+    # 80% power is the conventional target and the reason the dashed rule is
+    # there; naming it once beats a legend entry for a line that is not data.
+    # It goes on the bottom row of the lower panel, the only place right of the
+    # rule that no dumbbell reaches.
+    axes[-1].annotate("80%", xy=(0.8, 0.0), xytext=(3, 0),
+                      textcoords="offset points",
+                      fontsize=6, color=MUTED, ha="left", va="center")
+
+    axes[-1].set_xlabel(f"power at {TARGET_FC:g}-fold change", color=INK)
+
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="upper right", bbox_to_anchor=(0.995, 0.999),
+               ncol=2, frameon=False, handletextpad=0.15, columnspacing=1.0,
+               borderpad=0.0, borderaxespad=0.0)
+    fig.subplots_adjust(
+        left=1.12 / FIG_W, right=1 - 0.04 / FIG_W,
+        top=1 - top_in / height, bottom=bottom_in / height,
     )
-    axes[-1].set_xlabel(f"Power at FC = {TARGET_FC}", fontsize=10)
-    plt.tight_layout()
     out = OUT_DIR / "fig_a_reporter_dumbbell.svg"
-    fig.savefig(out, format="svg", bbox_inches="tight")
-    print(f"Saved: {out}")
+    fig.savefig(out, format="svg")
     plt.close(fig)
+    print(f"Saved: {out}  ({FIG_W:.2f} x {height:.2f} in)")
 
+
+# ----- Fig 4B: continuous power curves -----
+
+def power_curve(df, lo=FC_WINDOW[0], hi=FC_WINDOW[1], width=FC_BIN_WIDTH):
+    """Power per cell type in fixed-width fc bins over [lo, hi]."""
+    edges = np.arange(lo, hi + width / 2, width)
+    n_bins = len(edges) - 1
+    assert n_bins >= 10, f"only {n_bins} bins over [{lo}, {hi}] at width {width}"
+
+    sub = df[(df["fc"] >= edges[0]) & (df["fc"] <= edges[-1])]
+    assert len(sub), \
+        f"fc window [{lo}, {hi}] is empty; data spans " \
+        f"[{df['fc'].min():.3f}, {df['fc'].max():.3f}]"
+
+    binned = pd.cut(sub["fc"], bins=edges, include_lowest=True)
+    out = (
+        sub.groupby(["cell_type", binned], observed=True)["reject_null"]
+        .agg(["mean", "size"])
+        .rename(columns={"mean": "power", "size": "n"})
+        .reset_index()
+    )
+    out["fc"] = out["fc"].apply(lambda iv: iv.mid).astype(float)
+
+    n_cts = sub["cell_type"].nunique()
+    assert len(out) == n_cts * n_bins, \
+        f"expected {n_cts} cell types x {n_bins} bins = {n_cts * n_bins} " \
+        f"curve points, got {len(out)} -- some bin is empty"
+    assert out["n"].min() >= MIN_BIN_N, \
+        f"thinnest bin has {out['n'].min()} draws (floor {MIN_BIN_N})"
+    assert out["power"].between(0.0, 1.0).all(), \
+        f"power outside [0, 1]: {out['power'].min()} to {out['power'].max()}"
+    return out
+
+
+def load_power_curves():
+    """{dataset: {arm: curve_df}} for the two datasets that ran both arms."""
+    out = {}
+    for name in PAIRED_DSETS:
+        d = DATASETS[name]
+        out[name] = {}
+        for arm in ("reporter", "deflated"):
+            curve = power_curve(pd.read_parquet(d[arm]))
+            assert curve["cell_type"].nunique() == d["n_cell_types"], \
+                f"{name} ({arm}): expected {d['n_cell_types']} cell types, " \
+                f"got {curve['cell_type'].nunique()}"
+            out[name][arm] = curve
+        print(f"  {name}: {out[name]['reporter']['fc'].nunique()} bins of "
+              f"width {FC_BIN_WIDTH:g}, thinnest "
+              f"{min(out[name][a]['n'].min() for a in out[name])} draws")
+    return out
+
+
+def fig_b_power_curves(curves):
+    """Fig 4B: power vs fold change, both arms, one curve per cell type."""
+    # Enough right margin to carry the direct labels; no legend box, since two
+    # series that are labelled where they separate do not need one.
+    left_in, right_in = 0.40, 0.70
+    top_in, gap_in, bottom_in = 0.26, 0.30, 0.38
+    panel_in = 1.20
+    height = top_in + panel_in * len(PAIRED_DSETS) + gap_in + bottom_in
+
+    fig, axes = plt.subplots(
+        len(PAIRED_DSETS), 1, figsize=(FIG_W, height),
+        gridspec_kw={"hspace": gap_in / panel_in},
+        sharex=True, sharey=True,
+    )
+
+    for ax, name in zip(axes, PAIRED_DSETS):
+        ref_display = DATASETS[name]["ref_display"]
+        for arm, color in (("deflated", COLOR_DEFL), ("reporter", COLOR_REP)):
+            df = curves[name][arm]
+            for ct, sub in df.groupby("cell_type", observed=True):
+                sub = sub.sort_values("fc")
+                is_ref = ct == "reference"
+                # The reference cell type is the one the other cell types are
+                # measured against, so it is drawn solid and on top while the
+                # rest of its arm reads as a band.
+                ax.plot(sub["fc"], sub["power"], color=color,
+                        lw=1.6 if is_ref else 0.8,
+                        alpha=1.0 if is_ref else 0.45,
+                        solid_capstyle="round",
+                        zorder=4 if is_ref else 3)
+                if is_ref and arm == "reporter":
+                    ax.annotate(
+                        ref_display,
+                        xy=(sub["fc"].iloc[-1], sub["power"].iloc[-1]),
+                        xytext=(4, 0), textcoords="offset points",
+                        fontsize=6, color=INK, va="center", ha="left",
+                        annotation_clip=False,
+                    )
+
+        ax.axhline(0.8, color=MUTED, ls="--", lw=0.7, zorder=1)
+        ax.axvline(TARGET_FC, color=HAIR, lw=0.8, zorder=1)
+        ax.set_xlim(*FC_WINDOW)
+        ax.set_ylim(0, 1.02)
+        ax.set_yticks([0, 0.5, 1.0], ["0", "0.5", "1"])
+        ax.set_title(DATASETS[name]["title"], loc="left", color=INK, pad=4)
+        style_axes(ax, grid_axis="y")
+
+    # Panel A's fold change, so the two panels of the figure lock together.
+    axes[0].annotate(f"{TARGET_FC:g}x", xy=(TARGET_FC, 1.0),
+                     xycoords=("data", "axes fraction"),
+                     xytext=(2, 1), textcoords="offset points",
+                     fontsize=6, color=MUTED, ha="left", va="bottom")
+    # Direct labels go where the two arms are furthest apart: Lalanne et al.'s
+    # right edge, where the bands are separated by most of the axis. One
+    # labelling serves both panels, which share colours and axes.
+    lower = axes[-1]
+    lower.annotate("80%", xy=(FC_WINDOW[0], 0.8),
+                   xytext=(2, 2), textcoords="offset points",
+                   fontsize=6, color=MUTED, ha="left", va="bottom")
+    for arm, color, label in (("reporter", COLOR_REP, LABEL_REP),
+                              ("deflated", COLOR_DEFL, LABEL_DEFL)):
+        df = curves["shendure"][arm]
+        at_edge = df[df["fc"] == df["fc"].max()]
+        # Anchor on the weakest cell type in the arm, keeping clear of the
+        # reference label that rides the top of the +reporter band.
+        y = at_edge["power"].min()
+        # A short key in the arm's colour carries the identity; the text stays
+        # ink, which the vermillion is too light to be at this size.
+        lower.plot([FC_WINDOW[1] + 0.012, FC_WINDOW[1] + 0.042], [y, y],
+                   color=color, lw=1.6, solid_capstyle="round",
+                   clip_on=False, zorder=5)
+        lower.annotate(label.replace(" ", "\n"), xy=(FC_WINDOW[1] + 0.052, y),
+                       xytext=(0, 0), textcoords="offset points",
+                       fontsize=6, color=INK, va="center", ha="left",
+                       linespacing=1.25, annotation_clip=False)
+
+    lower.set_xlabel("fold change", color=INK)
+    for ax in axes:
+        ax.set_ylabel("power", color=INK)
+
+    fig.subplots_adjust(
+        left=left_in / FIG_W, right=1 - right_in / FIG_W,
+        top=1 - top_in / height, bottom=bottom_in / height,
+    )
+    out = OUT_DIR / "fig_b_slope.svg"
+    fig.savefig(out, format="svg")
+    plt.close(fig)
+    print(f"Saved: {out}  ({FIG_W:.2f} x {height:.2f} in)")
+
+
+# ----- discrete variants, not manuscript panels -----
 
 def fig_b_dataset_bars(powers):
-    """Fig B: best-available power@FC=1.5 across all three datasets."""
-    best_mode = {
-        "cohen": "reporter",
-        "shendure": "reporter",
-        "seelig": "deflated",
-    }
-    mode_label = {"reporter": "+reporter", "deflated": "-reporter"}
+    """Best-available power at TARGET_FC across all three datasets."""
+    best_mode = {"cohen": "reporter", "shendure": "reporter", "seelig": "deflated"}
+    mode_label = {"reporter": LABEL_REP, "deflated": LABEL_DEFL}
     mode_color = {"reporter": COLOR_REP, "deflated": COLOR_DEFL}
 
     dsets = ["cohen", "shendure", "seelig"]
-    n_cts = [len(powers[d][best_mode[d]]) for d in dsets]
-    heights = [max(n, 1) for n in n_cts]
+    heights = [max(DATASETS[d]["n_cell_types"], 1) for d in dsets]
 
     fig, axes = plt.subplots(
         3, 1, figsize=(6, 5.5),
@@ -185,27 +452,22 @@ def fig_b_dataset_bars(powers):
         cts = df["cell_type"].tolist()
         vals = df["power"].values
         y = np.arange(len(cts))
-        ax.barh(
-            y, vals, color=mode_color[mode],
-            edgecolor="white", lw=0.6, height=0.7,
-        )
+        ax.barh(y, vals, color=mode_color[mode], height=0.7)
         ax.set_yticks(y)
-        ax.set_yticklabels(cts, fontsize=9)
-        ax.set_xlim(0, 1.02)
-        ax.axvline(0.8, color="black", ls="--", lw=0.6, alpha=0.4)
-        ax.set_title(
-            f"{DATASETS[name]['title']}  ({mode_label[mode]})",
-            fontsize=9, loc="left",
-        )
-        ax.grid(axis="x", alpha=0.3)
+        ax.set_yticklabels([display_ct(c, name) for c in cts])
+        ax.set_xlim(0, 1.0)
+        ax.axvline(0.8, color=MUTED, ls="--", lw=0.7)
+        ax.set_title(f"{DATASETS[name]['title'].split(' (')[0]}, "
+                     f"{mode_label[mode]}", loc="left")
+        style_axes(ax, grid_axis="x")
         ax.invert_yaxis()  # strongest at top
 
-    axes[-1].set_xlabel(f"Power at FC = {TARGET_FC}", fontsize=10)
+    axes[-1].set_xlabel(f"power at {TARGET_FC:g}-fold change")
     plt.tight_layout()
     out = OUT_DIR / "fig_b_dataset_bars.svg"
     fig.savefig(out, format="svg", bbox_inches="tight")
-    print(f"Saved: {out}")
     plt.close(fig)
+    print(f"Saved: {out}")
 
 
 def load_multi_fc_powers():
@@ -213,18 +475,15 @@ def load_multi_fc_powers():
     out = {}
     for name, d in DATASETS.items():
         out[name] = {}
-        triplet = FC_TRIPLET[name]
         for parquet_key in ("reporter", "deflated"):
             if parquet_key not in d:
                 continue
             raw = pd.read_parquet(d[parquet_key])
-            per_fc = {}
-            for fc in triplet:
-                per_fc[fc] = rename_reference(
-                    power_at_fc(raw, target_fc=fc, tol=FC_TOL),
-                    d["ref_display"],
-                )
-            out[name][parquet_key] = per_fc
+            out[name][parquet_key] = {
+                fc: rename_reference(power_at_fc(raw, target_fc=fc, tol=FC_TOL),
+                                     d["ref_display"])
+                for fc in FC_TRIPLET[name]
+            }
     return out
 
 
@@ -239,16 +498,11 @@ def _shades(base_color, n=3):
 
 def fig_b_telescope(mpows):
     """Telescope (nested) bars: 3 overlaid bars per CT, one per FC."""
-    best_mode = {
-        "cohen": "reporter",
-        "shendure": "reporter",
-        "seelig": "deflated",
-    }
+    best_mode = {"cohen": "reporter", "shendure": "reporter", "seelig": "deflated"}
     base_color = {"reporter": COLOR_REP, "deflated": COLOR_DEFL}
 
     dsets = ["cohen", "shendure", "seelig"]
-    n_cts = [len(mpows[d][best_mode[d]][FC_TRIPLET[d][0]]) for d in dsets]
-    heights = [max(n, 1) for n in n_cts]
+    heights = [max(DATASETS[d]["n_cell_types"], 1) for d in dsets]
 
     fig, axes = plt.subplots(
         3, 1, figsize=(6.5, 6),
@@ -267,117 +521,110 @@ def fig_b_telescope(mpows):
         y = np.arange(len(cts))
 
         fc_lo, fc_mi, fc_hi = triplet
-        hi = mpows[name][mode][fc_hi].set_index("cell_type").loc[cts, "power"].values
-        mi = mpows[name][mode][fc_mi].set_index("cell_type").loc[cts, "power"].values
-        lo = mpows[name][mode][fc_lo].set_index("cell_type").loc[cts, "power"].values
+        by_fc = {fc: mpows[name][mode][fc].set_index("cell_type").loc[cts, "power"].values
+                 for fc in triplet}
 
         # Draw longest first so shorter bars paint on top.
-        ax.barh(y, hi, color=light, edgecolor="white", lw=0.4,
-                height=0.75, label=f"FC={fc_hi}")
-        ax.barh(y, mi, color=mid, edgecolor="white", lw=0.4,
-                height=0.75, label=f"FC={fc_mi}")
-        ax.barh(y, lo, color=dark, edgecolor="white", lw=0.4,
-                height=0.75, label=f"FC={fc_lo}")
+        for fc, color in ((fc_hi, light), (fc_mi, mid), (fc_lo, dark)):
+            ax.barh(y, by_fc[fc], color=color, height=0.75, label=f"FC={fc}")
 
         ax.set_yticks(y)
-        ax.set_yticklabels(cts, fontsize=9)
-        ax.set_xlim(0, 1.02)
-        ax.axvline(0.8, color="black", ls="--", lw=0.6, alpha=0.4)
-        ax.set_title(DATASETS[name]["title"], fontsize=9, loc="left")
-        ax.grid(axis="x", alpha=0.3)
+        ax.set_yticklabels([display_ct(c, name) for c in cts])
+        ax.set_xlim(0, 1.0)
+        ax.axvline(0.8, color=MUTED, ls="--", lw=0.7)
+        ax.set_title(DATASETS[name]["title"], loc="left")
+        style_axes(ax, grid_axis="x")
         ax.invert_yaxis()
-        ax.legend(
-            loc="lower right", fontsize=7, frameon=True, ncol=3,
-            handlelength=1.2, handletextpad=0.4, columnspacing=0.8,
-        )
+        ax.legend(loc="lower right", frameon=False, ncol=3,
+                  handlelength=1.2, handletextpad=0.4, columnspacing=0.8)
 
-    axes[-1].set_xlabel("Power", fontsize=10)
+    axes[-1].set_xlabel("power")
     plt.tight_layout()
     out = OUT_DIR / "fig_b_telescope.svg"
     fig.savefig(out, format="svg", bbox_inches="tight")
-    print(f"Saved: {out}")
     plt.close(fig)
+    print(f"Saved: {out}")
 
 
-def fig_b_slope(mpows):
-    """Slope plot: one panel per dataset, x=FC triplet, y=power, lines per CT."""
-    best_mode = {
-        "cohen": "reporter",
-        "shendure": "reporter",
-        "seelig": "deflated",
-    }
-    base_color = {"reporter": COLOR_REP, "deflated": COLOR_DEFL}
-    ref_display = {d: DATASETS[d]["ref_display"] for d in DATASETS}
+def fig_b_slope_discrete(mpows):
+    """Three-point slope form of Fig 4B, kept for comparison with the curves.
 
-    dsets = ["cohen", "shendure", "seelig"]
-    fig, axes = plt.subplots(1, 3, figsize=(9, 3.6), sharey=True)
+    Each panel's fold changes are those of FC_TRIPLET, drawn as equally spaced
+    categories. Zhao et al.'s triplet spans 0.2 in fold change and Lalanne et
+    al.'s spans 0.8, so a line's slope means something different in each panel
+    -- which is why the manuscript uses the continuous version.
+    """
+    best_mode = {"cohen": "reporter", "shendure": "reporter"}
+    fig, axes = plt.subplots(1, 2, figsize=(FIG_W, 1.9), sharey=True)
 
-    for ax, name in zip(axes, dsets):
+    for ax, name in zip(axes, PAIRED_DSETS):
         mode = best_mode[name]
         triplet = FC_TRIPLET[name]
-        color = base_color[mode]
-        ref_ct = ref_display[name]
-
-        cts = mpows[name][mode][triplet[0]]["cell_type"].tolist()
-        vals_by_ct = {
-            ct: [
-                float(mpows[name][mode][fc].set_index("cell_type").loc[ct, "power"])
-                for fc in triplet
-            ]
-            for ct in cts
-        }
-
+        ref_ct = DATASETS[name]["ref_display"]
         x = np.arange(len(triplet))
-        for ct, v in vals_by_ct.items():
-            is_ref = (ct == ref_ct)
-            ax.plot(
-                x, v,
-                marker="o",
-                color=("black" if is_ref else color),
-                alpha=(1.0 if is_ref else 0.55),
-                lw=(1.8 if is_ref else 1.0),
-                markersize=(6 if is_ref else 4),
-                zorder=(3 if is_ref else 2),
-                label=(ref_ct if is_ref else None),
-            )
+
+        for ct in mpows[name][mode][triplet[0]]["cell_type"]:
+            v = [float(mpows[name][mode][fc].set_index("cell_type").loc[ct, "power"])
+                 for fc in triplet]
+            is_ref = ct == ref_ct
+            ax.plot(x, v, marker="o", color=COLOR_REP,
+                    alpha=1.0 if is_ref else 0.45,
+                    lw=1.6 if is_ref else 0.8,
+                    markersize=3.5 if is_ref else 2.5,
+                    zorder=4 if is_ref else 3)
+            if is_ref:
+                ax.annotate(ref_ct, xy=(x[-1], v[-1]), xytext=(3, 0),
+                            textcoords="offset points", fontsize=6, color=INK,
+                            va="center", annotation_clip=False)
 
         ax.set_xticks(x)
-        ax.set_xticklabels([f"{fc}" for fc in triplet], fontsize=9)
-        ax.set_xlabel("Fold change", fontsize=9)
-        ax.set_xlim(-0.25, len(triplet) - 0.75)
-        ax.set_ylim(0, 1.05)
-        ax.axhline(0.8, color="black", ls="--", lw=0.6, alpha=0.4)
-        ax.set_title(DATASETS[name]["title"], fontsize=9)
-        ax.grid(axis="y", alpha=0.3)
-        ax.legend(
-            loc="lower right", fontsize=7, frameon=True,
-            title="reference CT", title_fontsize=7,
-        )
+        ax.set_xticklabels([f"{fc:g}" for fc in triplet])
+        ax.set_xlim(-0.25, len(triplet) - 0.55)
+        ax.set_ylim(0, 1.02)
+        ax.set_yticks([0, 0.5, 1.0], ["0", "0.5", "1"])
+        ax.axhline(0.8, color=MUTED, ls="--", lw=0.7, zorder=1)
+        ax.set_title(DATASETS[name]["title"].split(" (")[0], loc="left", color=INK, pad=4)
+        ax.set_xlabel("fold change", color=INK)
+        style_axes(ax, grid_axis="y")
 
-    axes[0].set_ylabel("Power", fontsize=10)
-    plt.tight_layout()
-    out = OUT_DIR / "fig_b_slope.svg"
-    fig.savefig(out, format="svg", bbox_inches="tight")
-    print(f"Saved: {out}")
+    axes[0].set_ylabel("power", color=INK)
+    fig.subplots_adjust(left=0.12, right=0.86, top=0.84, bottom=0.24, wspace=0.35)
+    out = OUT_DIR / "fig_b_slope_discrete.svg"
+    fig.savefig(out, format="svg")
     plt.close(fig)
+    print(f"Saved: {out}")
+
+
+def report(powers):
+    """Per-cell-type arms and gaps at TARGET_FC -- the numbers for the caption."""
+    print(f"=== power at fc {TARGET_FC:g} (+/- {FC_TOL:.0%}) ===")
+    for name in PAIRED_DSETS:
+        rep = powers[name]["reporter"].set_index("cell_type")["power"]
+        defl = powers[name]["deflated"].set_index("cell_type")["power"]
+        gap = (rep - defl).sort_values(ascending=False)
+        print(f"\n{DATASETS[name]['title']}")
+        print(f"{'cell type':<24}{'+rep':>8}{'-rep':>8}{'gap':>8}")
+        for ct in gap.index:
+            print(f"{display_ct(ct, name):<24}{rep[ct]:>8.3f}{defl[ct]:>8.3f}"
+                  f"{gap[ct]:>8.3f}")
+        print(f"{'mean':<24}{rep.mean():>8.3f}{defl.mean():>8.3f}{gap.mean():>8.3f}")
+    print()
 
 
 def main():
     powers = load_powers()
-
-    print("=== Power at FC = {:.2f} (+/- {:.0%}) ===".format(TARGET_FC, FC_TOL))
-    for name, modes in powers.items():
-        for mode, df in modes.items():
-            print(f"\n{name} ({mode}):")
-            print(df.to_string(index=False))
-    print()
+    report(powers)
 
     fig_a_reporter_dumbbell(powers)
-    fig_b_dataset_bars(powers)
+
+    print("binning power curves:")
+    curves = load_power_curves()
+    fig_b_power_curves(curves)
 
     mpows = load_multi_fc_powers()
+    fig_b_slope_discrete(mpows)
+    fig_b_dataset_bars(powers)
     fig_b_telescope(mpows)
-    fig_b_slope(mpows)
 
 
 if __name__ == "__main__":

--- a/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
+++ b/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="425.407998pt" height="352.479607pt" viewBox="0 0 425.407998 352.479607" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="243.36pt" height="242.64pt" viewBox="0 0 243.36 242.64" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:28.460945</dc:date>
+    <dc:date>2026-08-16T17:35:04.501253</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,590 +21,403 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 352.479607 
-L 425.407998 352.479607 
-L 425.407998 0 
+   <path d="M 0 242.64 
+L 243.36 242.64 
+L 243.36 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 118.680156 107.689071 
-L 415.973618 107.689071 
-L 415.973618 36.083357 
-L 118.680156 36.083357 
+    <path d="M 80.64 76.32 
+L 240.48 76.32 
+L 240.48 28.8 
+L 80.64 28.8 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="line2d_1">
-    <path d="M 383.550673 104.434266 
-L 397.018666 104.434266 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_2">
-    <path d="M 388.249671 82.735565 
-L 398.471184 82.735565 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_3">
-    <path d="M 389.96597 61.036864 
-L 399.729803 61.036864 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_4">
-    <path d="M 407.586638 39.338162 
-L 408.616417 39.338162 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_5">
-      <path d="M 124.397338 107.689071 
-L 124.397338 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_1">
+      <path d="M 80.64 76.32 
+L 80.64 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_6">
-      <defs>
-       <path id="mfb62cb133b" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mfb62cb133b" x="124.397338" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
     </g>
     <g id="xtick_2">
-     <g id="line2d_7">
-      <path d="M 181.569158 107.689071 
-L 181.569158 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_3">
+      <path d="M 120.6 76.32 
+L 120.6 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="181.569158" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
     </g>
     <g id="xtick_3">
-     <g id="line2d_9">
-      <path d="M 238.740977 107.689071 
-L 238.740977 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_5">
+      <path d="M 160.56 76.32 
+L 160.56 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="238.740977" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_6"/>
     </g>
     <g id="xtick_4">
-     <g id="line2d_11">
-      <path d="M 295.912797 107.689071 
-L 295.912797 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_7">
+      <path d="M 200.52 76.32 
+L 200.52 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="295.912797" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_8"/>
     </g>
     <g id="xtick_5">
-     <g id="line2d_13">
-      <path d="M 353.084616 107.689071 
-L 353.084616 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_9">
+      <path d="M 240.48 76.32 
+L 240.48 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="353.084616" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_15">
-      <path d="M 410.256436 107.689071 
-L 410.256436 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="410.256436" y="107.689071" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_10"/>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_17">
-      <defs>
-       <path id="mc9a84769e1" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="104.434266" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_11"/>
      <g id="text_1">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="107.853563" transform="rotate(-0 111.680156 107.853563)">Bipolar</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="72.849492" transform="rotate(-0 78.64 72.849492)">Bipolar</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_18">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="82.735565" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_12"/>
      <g id="text_2">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="86.154862" transform="rotate(-0 111.680156 86.154862)">Mueller Glia</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="60.969492" transform="rotate(-0 78.64 60.969492)">Mueller glia</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="61.036864" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_13"/>
      <g id="text_3">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="64.456161" transform="rotate(-0 111.680156 64.456161)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="49.089492" transform="rotate(-0 78.64 49.089492)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_20">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="39.338162" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_14"/>
      <g id="text_4">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="42.757459" transform="rotate(-0 111.680156 42.757459)">Rod</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="37.209492" transform="rotate(-0 78.64 37.209492)">Rod</text>
      </g>
     </g>
    </g>
-   <g id="line2d_21">
-    <path d="M 353.084616 107.689071 
-L 353.084616 36.083357 
-" clip-path="url(#pc85e101941)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+   <g id="line2d_15">
+    <path d="M 208.512 76.32 
+L 208.512 28.8 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 225.547297 70.38 
+L 233.078013 70.38 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 228.174773 58.5 
+L 233.890199 58.5 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 229.134452 46.62 
+L 234.593964 46.62 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 238.987165 34.74 
+L 239.562973 34.74 
+" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
    </g>
    <g id="patch_3">
-    <path d="M 118.680156 107.689071 
-L 118.680156 36.083357 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 80.64 76.32 
+L 80.64 28.8 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 415.973618 107.689071 
-L 415.973618 36.083357 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 118.680156 107.689071 
-L 415.973618 107.689071 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 118.680156 36.083357 
-L 415.973618 36.083357 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 80.64 76.32 
+L 240.48 76.32 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="PathCollection_1">
     <defs>
-     <path id="mee568a0668" d="M 0 3.708099 
-C 0.983399 3.708099 1.926654 3.317391 2.622022 2.622022 
-C 3.317391 1.926654 3.708099 0.983399 3.708099 0 
-C 3.708099 -0.983399 3.317391 -1.926654 2.622022 -2.622022 
-C 1.926654 -3.317391 0.983399 -3.708099 0 -3.708099 
-C -0.983399 -3.708099 -1.926654 -3.317391 -2.622022 -2.622022 
-C -3.317391 -1.926654 -3.708099 -0.983399 -3.708099 0 
-C -3.708099 0.983399 -3.317391 1.926654 -2.622022 2.622022 
-C -1.926654 3.317391 -0.983399 3.708099 0 3.708099 
+     <path id="m775593de40" d="M 0 2.54951 
+C 0.676138 2.54951 1.324674 2.280877 1.802776 1.802776 
+C 2.280877 1.324674 2.54951 0.676138 2.54951 0 
+C 2.54951 -0.676138 2.280877 -1.324674 1.802776 -1.802776 
+C 1.324674 -2.280877 0.676138 -2.54951 0 -2.54951 
+C -0.676138 -2.54951 -1.324674 -2.280877 -1.802776 -1.802776 
+C -2.280877 -1.324674 -2.54951 -0.676138 -2.54951 0 
+C -2.54951 0.676138 -2.280877 1.324674 -1.802776 1.802776 
+C -1.324674 2.280877 -0.676138 2.54951 0 2.54951 
 z
-" style="stroke: #ffffff; stroke-width: 0.6"/>
+" style="stroke: #ffffff"/>
     </defs>
-    <g clip-path="url(#pc85e101941)">
-     <use xlink:href="#mee568a0668" x="383.550673" y="104.434266" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="388.249671" y="82.735565" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="389.96597" y="61.036864" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="407.586638" y="39.338162" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+    <g>
+     <use xlink:href="#m775593de40" x="225.547297" y="70.38" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="228.174773" y="58.5" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="229.134452" y="46.62" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="238.987165" y="34.74" style="fill: #d55e00; stroke: #ffffff"/>
     </g>
    </g>
    <g id="PathCollection_2">
     <defs>
-     <path id="ma1fdce544a" d="M 0 3.708099 
-C 0.983399 3.708099 1.926654 3.317391 2.622022 2.622022 
-C 3.317391 1.926654 3.708099 0.983399 3.708099 0 
-C 3.708099 -0.983399 3.317391 -1.926654 2.622022 -2.622022 
-C 1.926654 -3.317391 0.983399 -3.708099 0 -3.708099 
-C -0.983399 -3.708099 -1.926654 -3.317391 -2.622022 -2.622022 
-C -3.317391 -1.926654 -3.708099 -0.983399 -3.708099 0 
-C -3.708099 0.983399 -3.317391 1.926654 -2.622022 2.622022 
-C -1.926654 3.317391 -0.983399 3.708099 0 3.708099 
+     <path id="mf02a5bacda" d="M 0 2.54951 
+C 0.676138 2.54951 1.324674 2.280877 1.802776 1.802776 
+C 2.280877 1.324674 2.54951 0.676138 2.54951 0 
+C 2.54951 -0.676138 2.280877 -1.324674 1.802776 -1.802776 
+C 1.324674 -2.280877 0.676138 -2.54951 0 -2.54951 
+C -0.676138 -2.54951 -1.324674 -2.280877 -1.802776 -1.802776 
+C -2.280877 -1.324674 -2.54951 -0.676138 -2.54951 0 
+C -2.54951 0.676138 -2.280877 1.324674 -1.802776 1.802776 
+C -1.324674 2.280877 -0.676138 2.54951 0 2.54951 
 z
-" style="stroke: #ffffff; stroke-width: 0.6"/>
+" style="stroke: #ffffff"/>
     </defs>
-    <g clip-path="url(#pc85e101941)">
-     <use xlink:href="#ma1fdce544a" x="397.018666" y="104.434266" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="398.471184" y="82.735565" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="399.729803" y="61.036864" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="408.616417" y="39.338162" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+    <g>
+     <use xlink:href="#mf02a5bacda" x="233.078013" y="70.38" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="233.890199" y="58.5" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="234.593964" y="46.62" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="239.562973" y="34.74" style="fill: #0072b2; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_5">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="30.083357" transform="rotate(-0 118.680156 30.083357)">Cohen (episomal, CRE-reporter)</text>
-   </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 124.280156 21.3425 
-L 263.152656 21.3425 
-Q 264.752656 21.3425 264.752656 19.7425 
-L 264.752656 8.8 
-Q 264.752656 7.2 263.152656 7.2 
-L 124.280156 7.2 
-Q 122.680156 7.2 122.680156 8.8 
-L 122.680156 19.7425 
-Q 122.680156 21.3425 124.280156 21.3425 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="PathCollection_3">
-     <g>
-      <use xlink:href="#mee568a0668" x="133.880156" y="14.37875" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     </g>
-    </g>
-    <g id="text_6">
-     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="148.280156" y="16.47875" transform="rotate(-0 148.280156 16.47875)">-reporter</text>
-    </g>
-    <g id="PathCollection_4">
-     <g>
-      <use xlink:href="#ma1fdce544a" x="207.807656" y="14.37875" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     </g>
-    </g>
-    <g id="text_7">
-     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="222.207656" y="16.47875" transform="rotate(-0 222.207656 16.47875)">+reporter</text>
-    </g>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="24.8" transform="rotate(-0 80.64 24.8)">Zhao et al. (episomal, CRE reporter)</text>
    </g>
   </g>
   <g id="axes_2">
-   <g id="patch_8">
-    <path d="M 118.680156 314.923357 
-L 415.973618 314.923357 
-L 415.973618 135.909071 
-L 118.680156 135.909071 
+   <g id="patch_5">
+    <path d="M 80.64 216.72 
+L 240.48 216.72 
+L 240.48 97.92 
+L 80.64 97.92 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="line2d_22">
-    <path d="M 134.225617 306.786344 
-L 262.232962 306.786344 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_23">
-    <path d="M 138.980908 288.704093 
-L 307.643059 288.704093 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_24">
-    <path d="M 148.966615 270.621842 
-L 360.491914 270.621842 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_25">
-    <path d="M 152.321026 252.539591 
-L 369.750533 252.539591 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_26">
-    <path d="M 151.322081 234.45734 
-L 369.834714 234.45734 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_27">
-    <path d="M 160.374785 216.375089 
-L 385.406034 216.375089 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_28">
-    <path d="M 177.952449 198.292838 
-L 400.380039 198.292838 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_29">
-    <path d="M 181.144965 180.210587 
-L 401.01845 180.210587 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_30">
-    <path d="M 188.637879 162.128335 
-L 402.961515 162.128335 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_31">
-    <path d="M 183.527822 144.046084 
-L 403.162895 144.046084 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #808080; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
    <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_16">
+      <path d="M 80.64 216.72 
+L 80.64 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="80.64" y="223.658984" transform="rotate(-0 80.64 223.658984)">0</text>
+     </g>
+    </g>
     <g id="xtick_7">
-     <g id="line2d_32">
-      <path d="M 124.397338 314.923357 
-L 124.397338 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_18">
+      <path d="M 120.6 216.72 
+L 120.6 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="124.397338" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="124.397338" y="329.521795" transform="rotate(-0 124.397338 329.521795)">0.0</text>
+     <g id="line2d_19"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="120.6" y="223.658984" transform="rotate(-0 120.6 223.658984)">0.25</text>
      </g>
     </g>
     <g id="xtick_8">
-     <g id="line2d_34">
-      <path d="M 181.569158 314.923357 
-L 181.569158 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_20">
+      <path d="M 160.56 216.72 
+L 160.56 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="181.569158" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="181.569158" y="329.521795" transform="rotate(-0 181.569158 329.521795)">0.2</text>
+     <g id="line2d_21"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="223.658984" transform="rotate(-0 160.56 223.658984)">0.5</text>
      </g>
     </g>
     <g id="xtick_9">
-     <g id="line2d_36">
-      <path d="M 238.740977 314.923357 
-L 238.740977 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_22">
+      <path d="M 200.52 216.72 
+L 200.52 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="238.740977" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="238.740977" y="329.521795" transform="rotate(-0 238.740977 329.521795)">0.4</text>
+     <g id="line2d_23"/>
+     <g id="text_9">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="200.52" y="223.658984" transform="rotate(-0 200.52 223.658984)">0.75</text>
      </g>
     </g>
     <g id="xtick_10">
-     <g id="line2d_38">
-      <path d="M 295.912797 314.923357 
-L 295.912797 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_24">
+      <path d="M 240.48 216.72 
+L 240.48 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="295.912797" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="295.912797" y="329.521795" transform="rotate(-0 295.912797 329.521795)">0.6</text>
+     <g id="line2d_25"/>
+     <g id="text_10">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="240.48" y="223.658984" transform="rotate(-0 240.48 223.658984)">1</text>
      </g>
     </g>
-    <g id="xtick_11">
-     <g id="line2d_40">
-      <path d="M 353.084616 314.923357 
-L 353.084616 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="353.084616" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="353.084616" y="329.521795" transform="rotate(-0 353.084616 329.521795)">0.8</text>
-     </g>
-    </g>
-    <g id="xtick_12">
-     <g id="line2d_42">
-      <path d="M 410.256436 314.923357 
-L 410.256436 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#mfb62cb133b" x="410.256436" y="314.923357" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="410.256436" y="329.521795" transform="rotate(-0 410.256436 329.521795)">1.0</text>
-     </g>
-    </g>
-    <g id="text_14">
-     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="267.326887" y="343.19992" transform="rotate(-0 267.326887 343.19992)">Power at FC = 1.5</text>
+    <g id="text_11">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="234.709609" transform="rotate(-0 160.56 234.709609)">power at 1.5-fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_4">
     <g id="ytick_5">
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="306.786344" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="310.205641" transform="rotate(-0 111.680156 310.205641)">Cardiomyocytes</text>
+     <g id="line2d_26"/>
+     <g id="text_12">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="213.249492" transform="rotate(-0 78.64 213.249492)">Cardiomyocytes</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="288.704093" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="292.12339" transform="rotate(-0 111.680156 292.12339)">Haematoendothelial</text>
+     <g id="line2d_27"/>
+     <g id="text_13">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="201.369492" transform="rotate(-0 78.64 201.369492)">Haematoendothelial</text>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_46">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="270.621842" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_17">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="274.041139" transform="rotate(-0 111.680156 274.041139)">EpiblastPrimitiveStreak</text>
+     <g id="line2d_28"/>
+     <g id="text_14">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="189.489492" transform="rotate(-0 78.64 189.489492)">Epiblast/prim. streak</text>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="252.539591" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_18">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="255.958888" transform="rotate(-0 111.680156 255.958888)">NeuroectodermRostral</text>
+     <g id="line2d_29"/>
+     <g id="text_15">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="177.609492" transform="rotate(-0 78.64 177.609492)">Neuroectoderm rostral</text>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_48">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="234.45734" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_19">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="237.876637" transform="rotate(-0 111.680156 237.876637)">ExEndodermVisceral</text>
+     <g id="line2d_30"/>
+     <g id="text_16">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="165.729492" transform="rotate(-0 78.64 165.729492)">ExE endoderm visceral</text>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="216.375089" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_20">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="219.794386" transform="rotate(-0 111.680156 219.794386)">ExEndodermParietal</text>
+     <g id="line2d_31"/>
+     <g id="text_17">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="153.849492" transform="rotate(-0 78.64 153.849492)">ExE endoderm parietal</text>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="198.292838" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_21">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="201.712135" transform="rotate(-0 111.680156 201.712135)">SurfaceEctoderm</text>
+     <g id="line2d_32"/>
+     <g id="text_18">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="141.969492" transform="rotate(-0 78.64 141.969492)">Surface ectoderm</text>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="180.210587" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_22">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="183.629883" transform="rotate(-0 111.680156 183.629883)">Pluripotent</text>
+     <g id="line2d_33"/>
+     <g id="text_19">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="130.089492" transform="rotate(-0 78.64 130.089492)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_52">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="162.128335" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_23">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="165.547632" transform="rotate(-0 111.680156 165.547632)">NeuroectodermBrain</text>
+     <g id="line2d_34"/>
+     <g id="text_20">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="118.209492" transform="rotate(-0 78.64 118.209492)">Neuroectoderm brain</text>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#mc9a84769e1" x="118.680156" y="144.046084" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_24">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="147.465381" transform="rotate(-0 111.680156 147.465381)">Mesoderm</text>
+     <g id="line2d_35"/>
+     <g id="text_21">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="106.329492" transform="rotate(-0 78.64 106.329492)">Mesoderm</text>
      </g>
     </g>
    </g>
-   <g id="line2d_54">
-    <path d="M 353.084616 314.923357 
-L 353.084616 135.909071 
-" clip-path="url(#p083e34ad85)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+   <g id="line2d_36">
+    <path d="M 208.512 216.72 
+L 208.512 97.92 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="patch_9">
-    <path d="M 118.680156 314.923357 
-L 118.680156 135.909071 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="LineCollection_2">
+    <path d="M 86.135547 210.78 
+L 157.711698 210.78 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 88.794499 198.9 
+L 183.103054 198.9 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 94.378073 187.02 
+L 212.653839 187.02 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 96.253714 175.14 
+L 217.830857 175.14 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 95.695148 163.26 
+L 217.877927 163.26 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 100.757027 151.38 
+L 226.584734 151.38 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 110.585693 139.5 
+L 234.957547 139.5 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 112.37081 127.62 
+L 235.314519 127.62 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 116.560522 115.74 
+L 236.400997 115.74 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+    <path d="M 113.7032 103.86 
+L 236.5136 103.86 
+" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
    </g>
-   <g id="patch_10">
-    <path d="M 415.973618 314.923357 
-L 415.973618 135.909071 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_6">
+    <path d="M 80.64 216.72 
+L 80.64 97.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_11">
-    <path d="M 118.680156 314.923357 
-L 415.973618 314.923357 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_7">
+    <path d="M 80.64 216.72 
+L 240.48 216.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_12">
-    <path d="M 118.680156 135.909071 
-L 415.973618 135.909071 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="PathCollection_3">
+    <g>
+     <use xlink:href="#m775593de40" x="86.135547" y="210.78" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="88.794499" y="198.9" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="94.378073" y="187.02" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="96.253714" y="175.14" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="95.695148" y="163.26" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="100.757027" y="151.38" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="110.585693" y="139.5" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="112.37081" y="127.62" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="116.560522" y="115.74" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m775593de40" x="113.7032" y="103.86" style="fill: #d55e00; stroke: #ffffff"/>
+    </g>
    </g>
+   <g id="PathCollection_4">
+    <g>
+     <use xlink:href="#mf02a5bacda" x="157.711698" y="210.78" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="183.103054" y="198.9" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="212.653839" y="187.02" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="217.830857" y="175.14" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="217.877927" y="163.26" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="226.584734" y="151.38" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="234.957547" y="139.5" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="235.314519" y="127.62" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="236.400997" y="115.74" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#mf02a5bacda" x="236.5136" y="103.86" style="fill: #0072b2; stroke: #ffffff"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="211.512" y="212.435625" transform="rotate(-0 211.512 212.435625)">80%</text>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="93.92" transform="rotate(-0 80.64 93.92)">Lalanne et al. (piggyBac, oBC reporter)</text>
+   </g>
+  </g>
+  <g id="legend_1">
    <g id="PathCollection_5">
-    <g clip-path="url(#p083e34ad85)">
-     <use xlink:href="#mee568a0668" x="134.225617" y="306.786344" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="138.980908" y="288.704093" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="148.966615" y="270.621842" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="152.321026" y="252.539591" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="151.322081" y="234.45734" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="160.374785" y="216.375089" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="177.952449" y="198.292838" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="181.144965" y="180.210587" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="188.637879" y="162.128335" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#mee568a0668" x="183.527822" y="144.046084" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6"/>
+    <g>
+     <use xlink:href="#m775593de40" x="118.796559" y="3.475374" style="fill: #d55e00; stroke: #ffffff"/>
     </g>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="126.271559" y="5.181624" transform="rotate(-0 126.271559 5.181624)">without reporter</text>
    </g>
    <g id="PathCollection_6">
-    <g clip-path="url(#p083e34ad85)">
-     <use xlink:href="#ma1fdce544a" x="262.232962" y="306.786344" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="307.643059" y="288.704093" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="360.491914" y="270.621842" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="369.750533" y="252.539591" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="369.834714" y="234.45734" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="385.406034" y="216.375089" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="400.380039" y="198.292838" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="401.01845" y="180.210587" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="402.961515" y="162.128335" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
-     <use xlink:href="#ma1fdce544a" x="403.162895" y="144.046084" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6"/>
+    <g>
+     <use xlink:href="#mf02a5bacda" x="192.292262" y="3.475374" style="fill: #0072b2; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_25">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="129.909071" transform="rotate(-0 118.680156 129.909071)">Shendure (piggyBac, oBC reporter)</text>
+    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="199.767262" y="5.181624" transform="rotate(-0 199.767262 5.181624)">with reporter</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc85e101941">
-   <rect x="118.680156" y="36.083357" width="297.293462" height="71.605714"/>
+  <clipPath id="pfc72eab142">
+   <rect x="80.64" y="28.8" width="159.84" height="47.52"/>
   </clipPath>
-  <clipPath id="p083e34ad85">
-   <rect x="118.680156" y="135.909071" width="297.293462" height="179.014286"/>
+  <clipPath id="pcfc45feb06">
+   <rect x="80.64" y="97.92" width="159.84" height="118.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
+++ b/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="425.419666pt" height="387.634844pt" viewBox="0 0 425.419666 387.634844" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="430.98875pt" height="395.088203pt" viewBox="0 0 430.98875 395.088203" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:28.529059</dc:date>
+    <dc:date>2026-08-16T17:35:04.815506</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,684 +21,508 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 387.634844 
-L 425.419666 387.634844 
-L 425.419666 0 
+   <path d="M 0 395.088203 
+L 430.98875 395.088203 
+L 430.98875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 118.680156 88.798594 
-L 416.099862 88.798594 
-L 416.099862 20.038594 
-L 118.680156 20.038594 
+    <path d="M 83.705234 96.598828 
+L 418.620234 96.598828 
+L 418.620234 18.898828 
+L 83.705234 18.898828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 118.680156 23.164048 
-L 396.765037 23.164048 
-L 396.765037 34.990093 
-L 118.680156 34.990093 
-z
-" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 118.680156 40.058397 
-L 398.246665 40.058397 
-L 398.246665 51.884441 
-L 118.680156 51.884441 
-z
-" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 118.680156 56.952746 
-L 399.530508 56.952746 
-L 399.530508 68.77879 
-L 118.680156 68.77879 
-z
-" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 118.680156 73.847095 
-L 408.595217 73.847095 
-L 408.595217 85.673139 
-L 118.680156 85.673139 
-z
-" clip-path="url(#p35042fd7f6)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 118.680156 88.798594 
-L 118.680156 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 96.598828 
+L 83.705234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_2">
-      <defs>
-       <path id="mf22de96625" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mf22de96625" x="118.680156" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 176.997746 88.798594 
-L 176.997746 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 150.688234 96.598828 
+L 150.688234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#mf22de96625" x="176.997746" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 235.315335 88.798594 
-L 235.315335 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 217.671234 96.598828 
+L 217.671234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#mf22de96625" x="235.315335" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_6"/>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 293.632924 88.798594 
-L 293.632924 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 284.654234 96.598828 
+L 284.654234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#mf22de96625" x="293.632924" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_8"/>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 351.950514 88.798594 
-L 351.950514 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 351.637234 96.598828 
+L 351.637234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#mf22de96625" x="351.950514" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_10"/>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 410.268103 88.798594 
-L 410.268103 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 418.620234 96.598828 
+L 418.620234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#mf22de96625" x="410.268103" y="88.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_12"/>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_13">
-      <defs>
-       <path id="mbd02740f92" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="29.07707" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_13"/>
      <g id="text_1">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="32.496367" transform="rotate(-0 111.680156 32.496367)">Bipolar</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="31.581957" transform="rotate(-0 81.705234 31.581957)">Bipolar</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="45.971419" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_14"/>
      <g id="text_2">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="49.390716" transform="rotate(-0 111.680156 49.390716)">Mueller Glia</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="50.672866" transform="rotate(-0 81.705234 50.672866)">Mueller glia</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="62.865768" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_15"/>
      <g id="text_3">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="66.285065" transform="rotate(-0 111.680156 66.285065)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="69.763775" transform="rotate(-0 81.705234 69.763775)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="79.760117" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_16"/>
      <g id="text_4">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="83.179414" transform="rotate(-0 111.680156 83.179414)">Rod</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="88.854684" transform="rotate(-0 81.705234 88.854684)">Rod</text>
      </g>
     </g>
    </g>
+   <g id="patch_3">
+    <path d="M 83.705234 22.430646 
+L 403.110748 22.430646 
+L 403.110748 35.794283 
+L 83.705234 35.794283 
+z
+" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 83.705234 41.521555 
+L 404.812531 41.521555 
+L 404.812531 54.885192 
+L 83.705234 54.885192 
+z
+" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 83.705234 60.612464 
+L 406.28714 60.612464 
+L 406.28714 73.976101 
+L 83.705234 73.976101 
+z
+" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 83.705234 79.703374 
+L 416.698774 79.703374 
+L 416.698774 93.06701 
+L 83.705234 93.06701 
+z
+" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+   </g>
    <g id="line2d_17">
-    <path d="M 351.950514 88.798594 
-L 351.950514 20.038594 
-" clip-path="url(#p35042fd7f6)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 351.637234 96.598828 
+L 351.637234 18.898828 
+" clip-path="url(#p569d85fbd7)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_7">
-    <path d="M 118.680156 88.798594 
-L 118.680156 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 83.705234 96.598828 
+L 83.705234 18.898828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 416.099862 88.798594 
-L 416.099862 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 118.680156 88.798594 
-L 416.099862 88.798594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 118.680156 20.038594 
-L 416.099862 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 83.705234 96.598828 
+L 418.620234 96.598828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_5">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="14.038594" transform="rotate(-0 118.680156 14.038594)">Cohen (episomal, CRE-reporter)  (+reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="12.898828" transform="rotate(-0 83.705234 12.898828)">Zhao et al., with reporter</text>
    </g>
   </g>
   <g id="axes_2">
-   <g id="patch_11">
-    <path d="M 118.680156 288.198594 
-L 416.099862 288.198594 
-L 416.099862 116.298594 
-L 118.680156 116.298594 
+   <g id="patch_9">
+    <path d="M 83.705234 310.168828 
+L 418.620234 310.168828 
+L 418.620234 115.918828 
+L 83.705234 115.918828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 118.680156 124.11223 
-L 259.278118 124.11223 
-L 259.278118 135.389643 
-L 118.680156 135.389643 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 118.680156 140.222821 
-L 305.598271 140.222821 
-L 305.598271 151.500234 
-L 118.680156 151.500234 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 118.680156 156.333411 
-L 359.50626 156.333411 
-L 359.50626 167.610824 
-L 118.680156 167.610824 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 118.680156 172.444001 
-L 368.950429 172.444001 
-L 368.950429 183.721415 
-L 118.680156 183.721415 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 118.680156 188.554592 
-L 369.036297 188.554592 
-L 369.036297 199.832005 
-L 118.680156 199.832005 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 118.680156 204.665182 
-L 384.919679 204.665182 
-L 384.919679 215.942596 
-L 118.680156 215.942596 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 118.680156 220.775773 
-L 400.193775 220.775773 
-L 400.193775 232.053186 
-L 118.680156 232.053186 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 118.680156 236.886363 
-L 400.844981 236.886363 
-L 400.844981 248.163777 
-L 118.680156 248.163777 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 118.680156 252.996954 
-L 402.826986 252.996954 
-L 402.826986 264.274367 
-L 118.680156 264.274367 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 118.680156 269.107544 
-L 403.032402 269.107544 
-L 403.032402 280.384957 
-L 118.680156 280.384957 
-z
-" clip-path="url(#p2a019fcfcc)" style="fill: #4682b4; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
-      <path d="M 118.680156 288.198594 
-L 118.680156 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 310.168828 
+L 83.705234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#mf22de96625" x="118.680156" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_19"/>
     </g>
     <g id="xtick_8">
      <g id="line2d_20">
-      <path d="M 176.997746 288.198594 
-L 176.997746 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 150.688234 310.168828 
+L 150.688234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#mf22de96625" x="176.997746" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_21"/>
     </g>
     <g id="xtick_9">
      <g id="line2d_22">
-      <path d="M 235.315335 288.198594 
-L 235.315335 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 217.671234 310.168828 
+L 217.671234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#mf22de96625" x="235.315335" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_23"/>
     </g>
     <g id="xtick_10">
      <g id="line2d_24">
-      <path d="M 293.632924 288.198594 
-L 293.632924 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 284.654234 310.168828 
+L 284.654234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#mf22de96625" x="293.632924" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_25"/>
     </g>
     <g id="xtick_11">
      <g id="line2d_26">
-      <path d="M 351.950514 288.198594 
-L 351.950514 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 351.637234 310.168828 
+L 351.637234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#mf22de96625" x="351.950514" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_27"/>
     </g>
     <g id="xtick_12">
      <g id="line2d_28">
-      <path d="M 410.268103 288.198594 
-L 410.268103 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 418.620234 310.168828 
+L 418.620234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#mf22de96625" x="410.268103" y="288.198594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_29"/>
     </g>
    </g>
    <g id="matplotlib.axis_4">
     <g id="ytick_5">
-     <g id="line2d_30">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="129.750937" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_30"/>
      <g id="text_6">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="133.170234" transform="rotate(-0 111.680156 133.170234)">Cardiomyocytes</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="133.589703" transform="rotate(-0 81.705234 133.589703)">Cardiomyocytes</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="145.861527" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_31"/>
      <g id="text_7">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="149.280824" transform="rotate(-0 111.680156 149.280824)">Haematoendothelial</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="151.794951" transform="rotate(-0 81.705234 151.794951)">Haematoendothelial</text>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_32">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="161.972118" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_32"/>
      <g id="text_8">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="165.391415" transform="rotate(-0 111.680156 165.391415)">EpiblastPrimitiveStreak</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="170.000199" transform="rotate(-0 81.705234 170.000199)">Epiblast/prim. streak</text>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="178.082708" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_33"/>
      <g id="text_9">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="181.502005" transform="rotate(-0 111.680156 181.502005)">NeuroectodermRostral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="188.205448" transform="rotate(-0 81.705234 188.205448)">Neuroectoderm rostral</text>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_34">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="194.193299" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_34"/>
      <g id="text_10">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="197.612595" transform="rotate(-0 111.680156 197.612595)">ExEndodermVisceral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="206.410696" transform="rotate(-0 81.705234 206.410696)">ExE endoderm visceral</text>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="210.303889" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_35"/>
      <g id="text_11">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="213.723186" transform="rotate(-0 111.680156 213.723186)">ExEndodermParietal</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="224.615944" transform="rotate(-0 81.705234 224.615944)">ExE endoderm parietal</text>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_36">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="226.414479" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_36"/>
      <g id="text_12">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="229.833776" transform="rotate(-0 111.680156 229.833776)">SurfaceEctoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="242.821193" transform="rotate(-0 81.705234 242.821193)">Surface ectoderm</text>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="242.52507" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_37"/>
      <g id="text_13">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="245.944367" transform="rotate(-0 111.680156 245.944367)">Pluripotent</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="261.026441" transform="rotate(-0 81.705234 261.026441)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_38">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="258.63566" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_38"/>
      <g id="text_14">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="262.054957" transform="rotate(-0 111.680156 262.054957)">NeuroectodermBrain</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="279.23169" transform="rotate(-0 81.705234 279.23169)">Neuroectoderm brain</text>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="274.746251" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_39"/>
      <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="278.165548" transform="rotate(-0 111.680156 278.165548)">Mesoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="297.436938" transform="rotate(-0 81.705234 297.436938)">Mesoderm</text>
      </g>
     </g>
    </g>
+   <g id="patch_10">
+    <path d="M 83.705234 124.748374 
+L 245.194647 124.748374 
+L 245.194647 137.492047 
+L 83.705234 137.492047 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 83.705234 142.953622 
+L 298.397512 142.953622 
+L 298.397512 155.697296 
+L 83.705234 155.697296 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 83.705234 161.15887 
+L 360.315689 161.15887 
+L 360.315689 173.902544 
+L 83.705234 173.902544 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 83.705234 179.364119 
+L 371.163167 179.364119 
+L 371.163167 192.107793 
+L 83.705234 192.107793 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 83.705234 197.569367 
+L 371.261794 197.569367 
+L 371.261794 210.313041 
+L 83.705234 210.313041 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 83.705234 215.774615 
+L 389.505288 215.774615 
+L 389.505288 228.518289 
+L 83.705234 228.518289 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 83.705234 233.979864 
+L 407.048962 233.979864 
+L 407.048962 246.723538 
+L 83.705234 246.723538 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 83.705234 252.185112 
+L 407.79693 252.185112 
+L 407.79693 264.928786 
+L 83.705234 264.928786 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 83.705234 270.39036 
+L 410.073442 270.39036 
+L 410.073442 283.134034 
+L 83.705234 283.134034 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 83.705234 288.595609 
+L 410.309381 288.595609 
+L 410.309381 301.339283 
+L 83.705234 301.339283 
+z
+" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+   </g>
    <g id="line2d_40">
-    <path d="M 351.950514 288.198594 
-L 351.950514 116.298594 
-" clip-path="url(#p2a019fcfcc)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 351.637234 310.168828 
+L 351.637234 115.918828 
+" clip-path="url(#p9bbc121112)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="patch_22">
-    <path d="M 118.680156 288.198594 
-L 118.680156 116.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_20">
+    <path d="M 83.705234 310.168828 
+L 83.705234 115.918828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_23">
-    <path d="M 416.099862 288.198594 
-L 416.099862 116.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 118.680156 288.198594 
-L 416.099862 288.198594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 118.680156 116.298594 
-L 416.099862 116.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_21">
+    <path d="M 83.705234 310.168828 
+L 418.620234 310.168828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="110.298594" transform="rotate(-0 118.680156 110.298594)">Shendure (piggyBac, oBC reporter)  (+reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="109.918828" transform="rotate(-0 83.705234 109.918828)">Lalanne et al., with reporter</text>
    </g>
   </g>
   <g id="axes_3">
-   <g id="patch_26">
-    <path d="M 118.680156 350.078594 
-L 416.099862 350.078594 
-L 416.099862 315.698594 
-L 118.680156 315.698594 
+   <g id="patch_22">
+    <path d="M 83.705234 368.338828 
+L 418.620234 368.338828 
+L 418.620234 329.488828 
+L 83.705234 329.488828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 118.680156 317.261321 
-L 167.723301 317.261321 
-L 167.723301 330.13084 
-L 118.680156 330.13084 
-z
-" clip-path="url(#p2c13193f54)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 118.680156 335.646348 
-L 187.56258 335.646348 
-L 187.56258 348.515866 
-L 118.680156 348.515866 
-z
-" clip-path="url(#p2c13193f54)" style="fill: #ff7f50; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
-      <path d="M 118.680156 350.078594 
-L 118.680156 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 368.338828 
+L 83.705234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_42">
-      <g>
-       <use xlink:href="#mf22de96625" x="118.680156" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_42"/>
      <g id="text_17">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="118.680156" y="364.677031" transform="rotate(-0 118.680156 364.677031)">0.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="375.277812" transform="rotate(-0 83.705234 375.277812)">0.0</text>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_43">
-      <path d="M 176.997746 350.078594 
-L 176.997746 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 150.688234 368.338828 
+L 150.688234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#mf22de96625" x="176.997746" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_44"/>
      <g id="text_18">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="176.997746" y="364.677031" transform="rotate(-0 176.997746 364.677031)">0.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="150.688234" y="375.277812" transform="rotate(-0 150.688234 375.277812)">0.2</text>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_45">
-      <path d="M 235.315335 350.078594 
-L 235.315335 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 217.671234 368.338828 
+L 217.671234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_46">
-      <g>
-       <use xlink:href="#mf22de96625" x="235.315335" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_46"/>
      <g id="text_19">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="235.315335" y="364.677031" transform="rotate(-0 235.315335 364.677031)">0.4</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="217.671234" y="375.277812" transform="rotate(-0 217.671234 375.277812)">0.4</text>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_47">
-      <path d="M 293.632924 350.078594 
-L 293.632924 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 284.654234 368.338828 
+L 284.654234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_48">
-      <g>
-       <use xlink:href="#mf22de96625" x="293.632924" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_48"/>
      <g id="text_20">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="293.632924" y="364.677031" transform="rotate(-0 293.632924 364.677031)">0.6</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="284.654234" y="375.277812" transform="rotate(-0 284.654234 375.277812)">0.6</text>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_49">
-      <path d="M 351.950514 350.078594 
-L 351.950514 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 351.637234 368.338828 
+L 351.637234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#mf22de96625" x="351.950514" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_50"/>
      <g id="text_21">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.950514" y="364.677031" transform="rotate(-0 351.950514 364.677031)">0.8</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="351.637234" y="375.277812" transform="rotate(-0 351.637234 375.277812)">0.8</text>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_51">
-      <path d="M 410.268103 350.078594 
-L 410.268103 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 418.620234 368.338828 
+L 418.620234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_52">
-      <g>
-       <use xlink:href="#mf22de96625" x="410.268103" y="350.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_52"/>
      <g id="text_22">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="410.268103" y="364.677031" transform="rotate(-0 410.268103 364.677031)">1.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="418.620234" y="375.277812" transform="rotate(-0 418.620234 375.277812)">1.0</text>
      </g>
     </g>
     <g id="text_23">
-     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="267.390009" y="378.355156" transform="rotate(-0 267.390009 378.355156)">Power at FC = 1.5</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="251.162734" y="386.328437" transform="rotate(-0 251.162734 386.328437)">power at 1.5-fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_6">
     <g id="ytick_15">
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="323.69608" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_53"/>
      <g id="text_24">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="327.115377" transform="rotate(-0 111.680156 327.115377)">K562</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="340.99562" transform="rotate(-0 81.705234 340.99562)">K562</text>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_54">
-      <g>
-       <use xlink:href="#mbd02740f92" x="118.680156" y="342.081107" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_54"/>
      <g id="text_25">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="345.500404" transform="rotate(-0 111.680156 345.500404)">HepG2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="361.771021" transform="rotate(-0 81.705234 361.771021)">HepG2</text>
      </g>
     </g>
    </g>
+   <g id="patch_23">
+    <path d="M 83.705234 331.254737 
+L 140.0357 331.254737 
+L 140.0357 345.797518 
+L 83.705234 345.797518 
+z
+" clip-path="url(#p83578693a3)" style="fill: #d55e00"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 83.705234 352.030138 
+L 162.822897 352.030138 
+L 162.822897 366.572919 
+L 83.705234 366.572919 
+z
+" clip-path="url(#p83578693a3)" style="fill: #d55e00"/>
+   </g>
    <g id="line2d_55">
-    <path d="M 351.950514 350.078594 
-L 351.950514 315.698594 
-" clip-path="url(#p2c13193f54)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 351.637234 368.338828 
+L 351.637234 329.488828 
+" clip-path="url(#p83578693a3)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="patch_29">
-    <path d="M 118.680156 350.078594 
-L 118.680156 315.698594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_25">
+    <path d="M 83.705234 368.338828 
+L 83.705234 329.488828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_30">
-    <path d="M 416.099862 350.078594 
-L 416.099862 315.698594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 118.680156 350.078594 
-L 416.099862 350.078594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 118.680156 315.698594 
-L 416.099862 315.698594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_26">
+    <path d="M 83.705234 368.338828 
+L 418.620234 368.338828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_26">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="309.698594" transform="rotate(-0 118.680156 309.698594)">Seelig (episomal, no reporter)  (-reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="323.488828" transform="rotate(-0 83.705234 323.488828)">Yin et al., without reporter</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p35042fd7f6">
-   <rect x="118.680156" y="20.038594" width="297.419706" height="68.76"/>
+  <clipPath id="p569d85fbd7">
+   <rect x="83.705234" y="18.898828" width="334.915" height="77.7"/>
   </clipPath>
-  <clipPath id="p2a019fcfcc">
-   <rect x="118.680156" y="116.298594" width="297.419706" height="171.9"/>
+  <clipPath id="p9bbc121112">
+   <rect x="83.705234" y="115.918828" width="334.915" height="194.25"/>
   </clipPath>
-  <clipPath id="p2c13193f54">
-   <rect x="118.680156" y="315.698594" width="297.419706" height="34.38"/>
+  <clipPath id="p83578693a3">
+   <rect x="83.705234" y="329.488828" width="334.915" height="38.85"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/output/fig_b_slope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_slope.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="640.37125pt" height="250.339219pt" viewBox="0 0 640.37125 250.339219" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="243.36pt" height="240.48pt" viewBox="0 0 243.36 240.48" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:28.762273</dc:date>
+    <dc:date>2026-08-16T17:35:04.589667</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,800 +21,906 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 250.339219 
-L 640.37125 250.339219 
-L 640.37125 0 
+   <path d="M 0 240.48 
+L 243.36 240.48 
+L 243.36 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 43.78125 214.718594 
-L 230.71125 214.718594 
-L 230.71125 20.038594 
-L 43.78125 20.038594 
+    <path d="M 28.8 105.12 
+L 192.96 105.12 
+L 192.96 18.72 
+L 28.8 18.72 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m8d20c1c007" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m8d20c1c007" x="62.47425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_1">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="62.47425" y="228.557187" transform="rotate(-0 62.47425 228.557187)">1.1</text>
-     </g>
+     <g id="line2d_1"/>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="137.24625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_2">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="137.24625" y="228.557187" transform="rotate(-0 137.24625 228.557187)">1.2</text>
-     </g>
+     <g id="line2d_2"/>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="212.01825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="212.01825" y="228.557187" transform="rotate(-0 212.01825 228.557187)">1.3</text>
-     </g>
+     <g id="line2d_3"/>
     </g>
-    <g id="text_4">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="137.24625" y="241.2675" transform="rotate(-0 137.24625 241.2675)">Fold change</text>
+    <g id="xtick_4">
+     <g id="line2d_4"/>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5"/>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6"/>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7"/>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_4">
-      <path d="M 43.78125 214.718594 
-L 230.71125 214.718594 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_8">
+      <path d="M 28.8 105.12 
+L 192.96 105.12 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_5">
-      <defs>
-       <path id="m0362dd7e1a" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="218.517812" transform="rotate(-0 36.78125 218.517812)">0.0</text>
+     <g id="line2d_9"/>
+     <g id="text_1">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="107.589492" transform="rotate(-0 26.8 107.589492)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_6">
-      <path d="M 43.78125 177.636689 
-L 230.71125 177.636689 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_10">
+      <path d="M 28.8 62.767059 
+L 192.96 62.767059 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="181.435908" transform="rotate(-0 36.78125 181.435908)">0.2</text>
+     <g id="line2d_11"/>
+     <g id="text_2">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="65.236551" transform="rotate(-0 26.8 65.236551)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_8">
-      <path d="M 43.78125 140.554784 
-L 230.71125 140.554784 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="144.354003" transform="rotate(-0 36.78125 144.354003)">0.4</text>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_10">
-      <path d="M 43.78125 103.472879 
-L 230.71125 103.472879 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="107.272098" transform="rotate(-0 36.78125 107.272098)">0.6</text>
-     </g>
-    </g>
-    <g id="ytick_5">
      <g id="line2d_12">
-      <path d="M 43.78125 66.390975 
-L 230.71125 66.390975 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 28.8 20.414118 
+L 192.96 20.414118 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="70.190193" transform="rotate(-0 36.78125 70.190193)">0.8</text>
+     <g id="line2d_13"/>
+     <g id="text_3">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="22.88361" transform="rotate(-0 26.8 22.88361)">1</text>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_14">
-      <path d="M 43.78125 29.30907 
-L 230.71125 29.30907 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="43.78125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="36.78125" y="33.108289" transform="rotate(-0 36.78125 33.108289)">1.0</text>
-     </g>
-    </g>
-    <g id="text_11">
-     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="14.798438" y="117.378594" transform="rotate(-90 14.798438 117.378594)">Power</text>
+    <g id="text_4">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.903203" y="61.92" transform="rotate(-90 10.903203 61.92)">power</text>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 62.47425 106.653202 
-L 137.24625 61.936426 
-L 212.01825 47.320281 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <defs>
-     <path id="mc6e4128710" d="M 0 2 
-C 0.530406 2 1.03916 1.789267 1.414214 1.414214 
-C 1.789267 1.03916 2 0.530406 2 0 
-C 2 -0.530406 1.789267 -1.03916 1.414214 -1.414214 
-C 1.03916 -1.789267 0.530406 -2 0 -2 
-C -0.530406 -2 -1.03916 -1.789267 -1.414214 -1.414214 
-C -1.789267 -1.03916 -2 -0.530406 -2 0 
-C -2 0.530406 -1.789267 1.03916 -1.414214 1.414214 
-C -1.03916 1.789267 -0.530406 2 0 2 
-z
-" style="stroke: #4682b4; stroke-opacity: 0.55"/>
-    </defs>
-    <g clip-path="url(#pe91611f49b)">
-     <use xlink:href="#mc6e4128710" x="62.47425" y="106.653202" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="137.24625" y="61.936426" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="212.01825" y="47.320281" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
+   <g id="line2d_14">
+    <path d="M 28.8 37.355294 
+L 192.96 37.355294 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 62.47425 91.480572 
-L 137.24625 50.903654 
-L 212.01825 41.789621 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#pe91611f49b)">
-     <use xlink:href="#mc6e4128710" x="62.47425" y="91.480572" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="137.24625" y="50.903654" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="212.01825" y="41.789621" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 62.47425 106.300334 
-L 137.24625 59.991497 
-L 212.01825 44.639947 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#pe91611f49b)">
-     <use xlink:href="#mc6e4128710" x="62.47425" y="106.300334" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="137.24625" y="59.991497" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="212.01825" y="44.639947" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_19">
-    <path d="M 43.78125 66.390975 
-L 230.71125 66.390975 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+   <g id="line2d_15">
+    <path d="M 165.6 105.12 
+L 165.6 18.72 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="patch_3">
-    <path d="M 43.78125 214.718594 
-L 43.78125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 28.8 105.12 
+L 28.8 18.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 230.71125 214.718594 
-L 230.71125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 28.8 105.12 
+L 192.96 105.12 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_5">
-    <path d="M 43.78125 214.718594 
-L 230.71125 214.718594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_16">
+    <path d="M 32.7672 100.255702 
+L 41.112 95.154602 
+L 49.32 84.129989 
+L 57.528 70.909753 
+L 65.736 59.883454 
+L 73.944 51.933755 
+L 82.152 47.277229 
+L 90.36 42.303193 
+L 98.568 38.900805 
+L 106.776 36.754156 
+L 114.984 33.21657 
+L 123.192 33.080418 
+L 131.4 31.850748 
+L 139.608 31.689349 
+L 147.816 31.333015 
+L 156.024 27.80565 
+L 164.232 28.109619 
+L 172.44 28.191384 
+L 180.648 26.873295 
+L 188.856 26.503295 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="patch_6">
-    <path d="M 43.78125 20.038594 
-L 230.71125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_17">
+    <path d="M 32.7672 100.279664 
+L 41.112 91.457761 
+L 49.32 76.372941 
+L 57.528 64.72181 
+L 65.736 54.296471 
+L 73.944 45.925536 
+L 82.152 43.405714 
+L 90.36 37.461508 
+L 98.568 34.025477 
+L 106.776 33.106382 
+L 114.984 30.447242 
+L 123.192 29.645223 
+L 131.4 28.645724 
+L 139.608 29.136308 
+L 147.816 27.906255 
+L 156.024 26.760336 
+L 164.232 26.429063 
+L 172.44 26.340536 
+L 180.648 25.278416 
+L 188.856 25.538673 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_18">
+    <path d="M 32.7672 101.104721 
+L 41.112 95.556433 
+L 49.32 82.037647 
+L 57.528 70.205973 
+L 65.736 59.094496 
+L 73.944 52.403045 
+L 82.152 46.352006 
+L 90.36 42.719115 
+L 98.568 38.640487 
+L 106.776 36.538196 
+L 114.984 32.914403 
+L 123.192 32.372595 
+L 131.4 31.141759 
+L 139.608 30.75774 
+L 147.816 28.968573 
+L 156.024 27.083025 
+L 164.232 27.201625 
+L 172.44 27.118753 
+L 180.648 24.942947 
+L 188.856 25.960695 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_19">
+    <path d="M 32.7672 97.627863 
+L 41.112 83.694394 
+L 49.32 62.873607 
+L 57.528 51.891917 
+L 65.736 42.942278 
+L 73.944 38.612058 
+L 82.152 35.560902 
+L 90.36 32.030924 
+L 98.568 30.459938 
+L 106.776 29.595142 
+L 114.984 27.422357 
+L 123.192 27.116701 
+L 131.4 25.704895 
+L 139.608 26.533339 
+L 147.816 25.817284 
+L 156.024 24.298719 
+L 164.232 23.95737 
+L 172.44 24.272606 
+L 180.648 23.757025 
+L 188.856 24.152028 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_20">
-    <path d="M 62.47425 38.831417 
-L 137.24625 33.458503 
-L 212.01825 31.605934 
-" clip-path="url(#pe91611f49b)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-    <defs>
-     <path id="m26197fd761" d="M 0 3 
-C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
-C 2.683901 1.55874 3 0.795609 3 0 
-C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
-C 1.55874 -2.683901 0.795609 -3 0 -3 
-C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
-C -2.683901 -1.55874 -3 -0.795609 -3 0 
-C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
-C -1.55874 2.683901 -0.795609 3 0 3 
-z
-" style="stroke: #000000"/>
-    </defs>
-    <g clip-path="url(#pe91611f49b)">
-     <use xlink:href="#m26197fd761" x="62.47425" y="38.831417" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="137.24625" y="33.458503" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="212.01825" y="31.605934" style="stroke: #000000"/>
-    </g>
+    <path d="M 32.7672 99.014576 
+L 41.112 77.139734 
+L 49.32 55.725882 
+L 57.528 43.491041 
+L 65.736 37.355294 
+L 73.944 32.223114 
+L 82.152 29.673891 
+L 90.36 28.751938 
+L 98.568 27.13217 
+L 106.776 26.84196 
+L 114.984 25.62257 
+L 123.192 25.02967 
+L 131.4 24.290939 
+L 139.608 24.551567 
+L 147.816 23.712895 
+L 156.024 23.425882 
+L 164.232 23.669914 
+L 172.44 23.886161 
+L 180.648 23.041957 
+L 188.856 23.609429 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_12">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="137.24625" y="14.038594" transform="rotate(-0 137.24625 14.038594)">Cohen (episomal, CRE-reporter)</text>
+   <g id="line2d_21">
+    <path d="M 32.7672 98.904568 
+L 41.112 84.571992 
+L 49.32 62.82 
+L 57.528 51.255747 
+L 65.736 42.567964 
+L 73.944 37.953218 
+L 82.152 33.988104 
+L 90.36 31.885259 
+L 98.568 29.293631 
+L 106.776 27.931424 
+L 114.984 26.609435 
+L 123.192 26.07866 
+L 131.4 24.82201 
+L 139.608 25.725708 
+L 147.816 24.327921 
+L 156.024 24.286387 
+L 164.232 24.111378 
+L 172.44 23.826298 
+L 180.648 23.265603 
+L 188.856 23.307984 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 178.204687 211.218594 
-L 225.81125 211.218594 
-Q 227.21125 211.218594 227.21125 209.818594 
-L 227.21125 189.969219 
-Q 227.21125 188.569219 225.81125 188.569219 
-L 178.204687 188.569219 
-Q 176.804687 188.569219 176.804687 189.969219 
-L 176.804687 209.818594 
-Q 176.804687 211.218594 178.204687 211.218594 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_13">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="179.604687" y="196.688125" transform="rotate(-0 179.604687 196.688125)">reference CT</text>
-    </g>
-    <g id="line2d_21">
-     <path d="M 185.57 204.512812 
-L 192.57 204.512812 
-L 199.57 204.512812 
-" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m26197fd761" x="192.57" y="204.512812" style="stroke: #000000"/>
-     </g>
-    </g>
-    <g id="text_14">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="205.17" y="206.962812" transform="rotate(-0 205.17 206.962812)">Rod</text>
-    </g>
+   <g id="text_5">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="22.73292" transform="rotate(-0 192.856 22.73292)">Rod</text>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="167.6" y="16.472188" transform="rotate(-0 167.6 16.472188)">1.5x</text>
+   </g>
+   <g id="text_7">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="14.72" transform="rotate(-0 28.8 14.72)">Zhao et al. (episomal, CRE reporter)</text>
+   </g>
+   <g id="line2d_22">
+    <path d="M 32.7672 82.733445 
+L 41.112 43.803871 
+L 49.32 30.684706 
+L 57.528 26.71276 
+L 65.736 24.856734 
+L 73.944 23.254256 
+L 82.152 22.93951 
+L 90.36 23.228796 
+L 98.568 22.809249 
+L 106.776 22.429627 
+L 114.984 22.387847 
+L 123.192 22.0925 
+L 131.4 21.529368 
+L 139.608 21.979639 
+L 147.816 21.25279 
+L 156.024 21.382185 
+L 164.232 21.186679 
+L 172.44 21.192334 
+L 180.648 21.196878 
+L 188.856 21.37874 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_23">
+    <path d="M 32.7672 68.762475 
+L 41.112 32.546186 
+L 49.32 24.490588 
+L 57.528 24.052127 
+L 65.736 23.375862 
+L 73.944 22.457024 
+L 82.152 21.782039 
+L 90.36 22.166653 
+L 98.568 22.108235 
+L 106.776 21.394636 
+L 114.984 21.400982 
+L 123.192 20.991062 
+L 131.4 20.945189 
+L 139.608 21.308701 
+L 147.816 21.085055 
+L 156.024 21.005714 
+L 164.232 20.910765 
+L 172.44 20.833157 
+L 180.648 20.861409 
+L 188.856 21.077295 
+" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="axes_2">
-   <g id="patch_8">
-    <path d="M 245.01125 214.718594 
-L 431.94125 214.718594 
-L 431.94125 20.038594 
-L 245.01125 20.038594 
+   <g id="patch_5">
+    <path d="M 28.8 213.12 
+L 192.96 213.12 
+L 192.96 126.72 
+L 28.8 126.72 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_3">
-    <g id="xtick_4">
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="263.70425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="263.70425" y="228.557187" transform="rotate(-0 263.70425 228.557187)">1.2</text>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="338.47625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="338.47625" y="228.557187" transform="rotate(-0 338.47625 228.557187)">1.5</text>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="413.24825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_17">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="413.24825" y="228.557187" transform="rotate(-0 413.24825 228.557187)">2.0</text>
-     </g>
-    </g>
-    <g id="text_18">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="338.47625" y="241.2675" transform="rotate(-0 338.47625 241.2675)">Fold change</text>
-    </g>
-   </g>
-   <g id="matplotlib.axis_4">
-    <g id="ytick_7">
-     <g id="line2d_25">
-      <path d="M 245.01125 214.718594 
-L 431.94125 214.718594 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_26">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_27">
-      <path d="M 245.01125 177.636689 
-L 431.94125 177.636689 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_28">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_29">
-      <path d="M 245.01125 140.554784 
-L 431.94125 140.554784 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_30">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_31">
-      <path d="M 245.01125 103.472879 
-L 431.94125 103.472879 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_32">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_11">
-     <g id="line2d_33">
-      <path d="M 245.01125 66.390975 
-L 431.94125 66.390975 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_34">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_35">
-      <path d="M 245.01125 29.30907 
-L 431.94125 29.30907 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_36">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="245.01125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="line2d_37">
-    <path d="M 263.70425 189.218701 
-L 338.47625 125.317775 
-L 413.24825 45.65966 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="189.218701" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="125.317775" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="45.65966" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_38">
-    <path d="M 263.70425 169.396266 
-L 338.47625 61.586567 
-L 413.24825 30.787418 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="169.396266" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="61.586567" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="30.787418" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_39">
-    <path d="M 263.70425 152.432217 
-L 338.47625 45.427155 
-L 413.24825 29.51872 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="152.432217" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="45.427155" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="29.51872" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_40">
-    <path d="M 263.70425 161.070513 
-L 338.47625 55.526785 
-L 413.24825 30.648646 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="161.070513" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="55.526785" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="30.648646" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_41">
-    <path d="M 263.70425 183.250005 
-L 338.47625 95.864577 
-L 413.24825 36.21748 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="183.250005" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="95.864577" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="36.21748" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_42">
-    <path d="M 263.70425 123.450258 
-L 338.47625 33.909973 
-L 413.24825 29.362541 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="123.450258" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="33.909973" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="29.362541" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_43">
-    <path d="M 263.70425 118.468242 
-L 338.47625 34.040589 
-L 413.24825 29.360969 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="118.468242" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="34.040589" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="29.360969" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_44">
-    <path d="M 263.70425 159.450587 
-L 338.47625 55.581385 
-L 413.24825 30.666999 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="159.450587" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="55.581385" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="30.666999" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_45">
-    <path d="M 263.70425 126.591845 
-L 338.47625 35.714946 
-L 413.24825 29.644653 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #4682b4; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#mc6e4128710" x="263.70425" y="126.591845" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="338.47625" y="35.714946" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-     <use xlink:href="#mc6e4128710" x="413.24825" y="29.644653" style="fill: #4682b4; fill-opacity: 0.55; stroke: #4682b4; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_46">
-    <path d="M 245.01125 66.390975 
-L 431.94125 66.390975 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 245.01125 214.718594 
-L 245.01125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 431.94125 214.718594 
-L 431.94125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 245.01125 214.718594 
-L 431.94125 214.718594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 245.01125 20.038594 
-L 431.94125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_47">
-    <path d="M 263.70425 131.107914 
-L 338.47625 35.30087 
-L 413.24825 29.489298 
-" clip-path="url(#p20431dfcac)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-    <g clip-path="url(#p20431dfcac)">
-     <use xlink:href="#m26197fd761" x="263.70425" y="131.107914" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="338.47625" y="35.30087" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="413.24825" y="29.489298" style="stroke: #000000"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="338.47625" y="14.038594" transform="rotate(-0 338.47625 14.038594)">Shendure (piggyBac, oBC reporter)</text>
-   </g>
-   <g id="legend_2">
-    <g id="patch_13">
-     <path d="M 366.258281 211.218594 
-L 427.04125 211.218594 
-Q 428.44125 211.218594 428.44125 209.818594 
-L 428.44125 189.969219 
-Q 428.44125 188.569219 427.04125 188.569219 
-L 366.258281 188.569219 
-Q 364.858281 188.569219 364.858281 189.969219 
-L 364.858281 209.818594 
-Q 364.858281 211.218594 366.258281 211.218594 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_20">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="374.246484" y="196.688125" transform="rotate(-0 374.246484 196.688125)">reference CT</text>
-    </g>
-    <g id="line2d_48">
-     <path d="M 367.658281 204.512812 
-L 374.658281 204.512812 
-L 381.658281 204.512812 
-" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m26197fd761" x="374.658281" y="204.512812" style="stroke: #000000"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="387.258281" y="206.962812" transform="rotate(-0 387.258281 206.962812)">Pluripotent</text>
-    </g>
-   </g>
-  </g>
-  <g id="axes_3">
-   <g id="patch_14">
-    <path d="M 446.24125 214.718594 
-L 633.17125 214.718594 
-L 633.17125 20.038594 
-L 446.24125 20.038594 
-z
-" style="fill: #ffffff"/>
-   </g>
-   <g id="matplotlib.axis_5">
-    <g id="xtick_7">
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="464.93425" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_22">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="464.93425" y="228.557187" transform="rotate(-0 464.93425 228.557187)">1.5</text>
-     </g>
-    </g>
     <g id="xtick_8">
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="539.70625" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_23">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="539.70625" y="228.557187" transform="rotate(-0 539.70625 228.557187)">2.0</text>
+     <g id="line2d_24"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="28.8" y="220.058984" transform="rotate(-0 28.8 220.058984)">1.0</text>
      </g>
     </g>
     <g id="xtick_9">
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#m8d20c1c007" x="614.47825" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_24">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="614.47825" y="228.557187" transform="rotate(-0 614.47825 228.557187)">3.0</text>
+     <g id="line2d_25"/>
+     <g id="text_9">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="56.16" y="220.058984" transform="rotate(-0 56.16 220.058984)">1.1</text>
      </g>
     </g>
-    <g id="text_25">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="539.70625" y="241.2675" transform="rotate(-0 539.70625 241.2675)">Fold change</text>
-    </g>
-   </g>
-   <g id="matplotlib.axis_6">
-    <g id="ytick_13">
-     <g id="line2d_52">
-      <path d="M 446.24125 214.718594 
-L 633.17125 214.718594 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="214.718594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+    <g id="xtick_10">
+     <g id="line2d_26"/>
+     <g id="text_10">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.52" y="220.058984" transform="rotate(-0 83.52 220.058984)">1.2</text>
      </g>
     </g>
-    <g id="ytick_14">
-     <g id="line2d_54">
-      <path d="M 446.24125 177.636689 
-L 633.17125 177.636689 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_55">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="177.636689" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+    <g id="xtick_11">
+     <g id="line2d_27"/>
+     <g id="text_11">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="220.058984" transform="rotate(-0 110.88 220.058984)">1.3</text>
      </g>
     </g>
-    <g id="ytick_15">
-     <g id="line2d_56">
-      <path d="M 446.24125 140.554784 
-L 633.17125 140.554784 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_57">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="140.554784" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+    <g id="xtick_12">
+     <g id="line2d_28"/>
+     <g id="text_12">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="138.24" y="220.058984" transform="rotate(-0 138.24 220.058984)">1.4</text>
      </g>
     </g>
-    <g id="ytick_16">
-     <g id="line2d_58">
-      <path d="M 446.24125 103.472879 
-L 633.17125 103.472879 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_59">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="103.472879" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+    <g id="xtick_13">
+     <g id="line2d_29"/>
+     <g id="text_13">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="165.6" y="220.058984" transform="rotate(-0 165.6 220.058984)">1.5</text>
      </g>
     </g>
-    <g id="ytick_17">
-     <g id="line2d_60">
-      <path d="M 446.24125 66.390975 
-L 633.17125 66.390975 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_61">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="66.390975" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+    <g id="xtick_14">
+     <g id="line2d_30"/>
+     <g id="text_14">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="192.96" y="220.058984" transform="rotate(-0 192.96 220.058984)">1.6</text>
      </g>
     </g>
-    <g id="ytick_18">
-     <g id="line2d_62">
-      <path d="M 446.24125 29.30907 
-L 633.17125 29.30907 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_63">
-      <g>
-       <use xlink:href="#m0362dd7e1a" x="446.24125" y="29.30907" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+    <g id="text_15">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="231.109609" transform="rotate(-0 110.88 231.109609)">fold change</text>
     </g>
    </g>
-   <g id="line2d_64">
-    <path d="M 464.93425 183.53395 
-L 539.70625 114.643759 
-L 614.47825 39.232497 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #ff7f50; stroke-opacity: 0.55; stroke-linecap: square"/>
-    <defs>
-     <path id="mcff8c8ac15" d="M 0 2 
-C 0.530406 2 1.03916 1.789267 1.414214 1.414214 
-C 1.789267 1.03916 2 0.530406 2 0 
-C 2 -0.530406 1.789267 -1.03916 1.414214 -1.414214 
-C 1.03916 -1.789267 0.530406 -2 0 -2 
-C -0.530406 -2 -1.03916 -1.789267 -1.414214 -1.414214 
-C -1.789267 -1.03916 -2 -0.530406 -2 0 
-C -2 0.530406 -1.789267 1.03916 -1.414214 1.414214 
-C -1.03916 1.789267 -0.530406 2 0 2 
-z
-" style="stroke: #ff7f50; stroke-opacity: 0.55"/>
-    </defs>
-    <g clip-path="url(#pb3137e9c7f)">
-     <use xlink:href="#mcff8c8ac15" x="464.93425" y="183.53395" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
-     <use xlink:href="#mcff8c8ac15" x="539.70625" y="114.643759" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
-     <use xlink:href="#mcff8c8ac15" x="614.47825" y="39.232497" style="fill: #ff7f50; fill-opacity: 0.55; stroke: #ff7f50; stroke-opacity: 0.55"/>
-    </g>
-   </g>
-   <g id="line2d_65">
-    <path d="M 446.24125 66.390975 
-L 633.17125 66.390975 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 446.24125 214.718594 
-L 446.24125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 633.17125 214.718594 
-L 633.17125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 446.24125 214.718594 
-L 633.17125 214.718594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 446.24125 20.038594 
-L 633.17125 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_66">
-    <path d="M 464.93425 170.918919 
-L 539.70625 90.609074 
-L 614.47825 32.10184 
-" clip-path="url(#pb3137e9c7f)" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-    <g clip-path="url(#pb3137e9c7f)">
-     <use xlink:href="#m26197fd761" x="464.93425" y="170.918919" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="539.70625" y="90.609074" style="stroke: #000000"/>
-     <use xlink:href="#m26197fd761" x="614.47825" y="32.10184" style="stroke: #000000"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="539.70625" y="14.038594" transform="rotate(-0 539.70625 14.038594)">Seelig (episomal, no reporter)</text>
-   </g>
-   <g id="legend_3">
-    <g id="patch_19">
-     <path d="M 580.664687 211.218594 
-L 628.27125 211.218594 
-Q 629.67125 211.218594 629.67125 209.818594 
-L 629.67125 189.969219 
-Q 629.67125 188.569219 628.27125 188.569219 
-L 580.664687 188.569219 
-Q 579.264687 188.569219 579.264687 189.969219 
-L 579.264687 209.818594 
-Q 579.264687 211.218594 580.664687 211.218594 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_27">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.064687" y="196.688125" transform="rotate(-0 582.064687 196.688125)">reference CT</text>
-    </g>
-    <g id="line2d_67">
-     <path d="M 582.721484 204.512812 
-L 589.721484 204.512812 
-L 596.721484 204.512812 
-" style="fill: none; stroke: #000000; stroke-width: 1.8; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m26197fd761" x="589.721484" y="204.512812" style="stroke: #000000"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_4">
+     <g id="line2d_31">
+      <path d="M 28.8 213.12 
+L 192.96 213.12 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32"/>
+     <g id="text_16">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="215.589492" transform="rotate(-0 26.8 215.589492)">0</text>
      </g>
     </g>
-    <g id="text_28">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.321484" y="206.962812" transform="rotate(-0 602.321484 206.962812)">HepG2</text>
+    <g id="ytick_5">
+     <g id="line2d_33">
+      <path d="M 28.8 170.767059 
+L 192.96 170.767059 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34"/>
+     <g id="text_17">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="173.236551" transform="rotate(-0 26.8 173.236551)">0.5</text>
+     </g>
     </g>
+    <g id="ytick_6">
+     <g id="line2d_35">
+      <path d="M 28.8 128.414118 
+L 192.96 128.414118 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36"/>
+     <g id="text_18">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="130.88361" transform="rotate(-0 26.8 130.88361)">1</text>
+     </g>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.903203" y="169.92" transform="rotate(-90 10.903203 169.92)">power</text>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <path d="M 28.8 145.355294 
+L 192.96 145.355294 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+   </g>
+   <g id="line2d_38">
+    <path d="M 165.6 213.12 
+L 165.6 126.72 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 28.8 213.12 
+L 28.8 126.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 28.8 213.12 
+L 192.96 213.12 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_39">
+    <path d="M 32.7672 212.093262 
+L 41.112 211.938057 
+L 49.32 212.111597 
+L 57.528 210.610196 
+L 65.736 212.367059 
+L 73.944 212.178824 
+L 82.152 211.444499 
+L 90.36 212.032035 
+L 98.568 212.228359 
+L 106.776 210.980062 
+L 114.984 209.809655 
+L 123.192 211.367465 
+L 131.4 210.980062 
+L 139.608 209.277671 
+L 147.816 210.513665 
+L 156.024 210.24 
+L 164.232 211.256471 
+L 172.44 209.621279 
+L 180.648 209.693695 
+L 188.856 208.312369 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_40">
+    <path d="M 32.7672 211.727575 
+L 41.112 211.519259 
+L 49.32 211.542482 
+L 57.528 211.358789 
+L 65.736 210.621762 
+L 73.944 210.336239 
+L 82.152 211.0561 
+L 90.36 210.309132 
+L 98.568 210.075272 
+L 106.776 209.36317 
+L 114.984 208.825054 
+L 123.192 207.895849 
+L 131.4 208.037647 
+L 139.608 209.172541 
+L 147.816 206.597647 
+L 156.024 207.708235 
+L 164.232 206.16598 
+L 172.44 205.507665 
+L 180.648 203.632941 
+L 188.856 204.464464 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_41">
+    <path d="M 32.7672 211.467202 
+L 41.112 210.472941 
+L 49.32 211.055739 
+L 57.528 209.606853 
+L 65.736 209.593782 
+L 73.944 210.223322 
+L 82.152 208.339569 
+L 90.36 208.817479 
+L 98.568 208.555939 
+L 106.776 207.174299 
+L 114.984 208.247538 
+L 123.192 206.448863 
+L 131.4 207.316078 
+L 139.608 203.427287 
+L 147.816 203.751607 
+L 156.024 203.303617 
+L 164.232 204.04437 
+L 172.44 200.832194 
+L 180.648 200.691193 
+L 188.856 199.69359 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_42">
+    <path d="M 32.7672 211.849412 
+L 41.112 211.727575 
+L 49.32 211.737047 
+L 57.528 211.916059 
+L 65.736 210.568618 
+L 73.944 210.296471 
+L 82.152 210.626121 
+L 90.36 209.902123 
+L 98.568 209.898058 
+L 106.776 209.061176 
+L 114.984 207.50521 
+L 123.192 206.821357 
+L 131.4 206.45774 
+L 139.608 207.281515 
+L 147.816 206.63634 
+L 156.024 205.169951 
+L 164.232 206.424685 
+L 172.44 203.510093 
+L 180.648 204.240487 
+L 188.856 201.060179 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_43">
+    <path d="M 32.7672 211.841421 
+L 41.112 211.876611 
+L 49.32 212.041925 
+L 57.528 211.838735 
+L 65.736 212.032035 
+L 73.944 211.039505 
+L 82.152 210.610196 
+L 90.36 210.96385 
+L 98.568 210.079276 
+L 106.776 211.018769 
+L 114.984 210.745069 
+L 123.192 210.236395 
+L 131.4 209.423743 
+L 139.608 209.223529 
+L 147.816 208.325327 
+L 156.024 209.078985 
+L 164.232 210.139608 
+L 172.44 209.914913 
+L 180.648 206.767059 
+L 188.856 208.513189 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_44">
+    <path d="M 32.7672 210.159406 
+L 41.112 210.163285 
+L 49.32 209.814405 
+L 57.528 210.218039 
+L 65.736 208.305139 
+L 73.944 208.978824 
+L 82.152 208.907115 
+L 90.36 207.802142 
+L 98.568 206.99395 
+L 106.776 205.547216 
+L 114.984 202.521333 
+L 123.192 204.073741 
+L 131.4 202.714506 
+L 139.608 199.381633 
+L 147.816 197.777048 
+L 156.024 197.71893 
+L 164.232 197.283683 
+L 172.44 194.45181 
+L 180.648 192.046829 
+L 188.856 190.720788 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_45">
+    <path d="M 32.7672 210.991711 
+L 41.112 210.207038 
+L 49.32 210.229562 
+L 57.528 209.502353 
+L 65.736 209.563289 
+L 73.944 208.178824 
+L 82.152 208.820209 
+L 90.36 206.860945 
+L 98.568 205.607623 
+L 106.776 204.734973 
+L 114.984 203.333592 
+L 123.192 200.632842 
+L 131.4 200.617955 
+L 139.608 199.475485 
+L 147.816 199.486387 
+L 156.024 195.392893 
+L 164.232 192.518167 
+L 172.44 193.327338 
+L 180.648 190.559311 
+L 188.856 189.495607 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_46">
+    <path d="M 32.7672 210.861176 
+L 41.112 210.80984 
+L 49.32 211.361953 
+L 57.528 210.80984 
+L 65.736 210.767059 
+L 73.944 207.883636 
+L 82.152 210.210909 
+L 90.36 208.441008 
+L 98.568 208.516419 
+L 106.776 208.582185 
+L 114.984 207.729626 
+L 123.192 207.591827 
+L 131.4 206.343529 
+L 139.608 206.13548 
+L 147.816 206.422326 
+L 156.024 204.714073 
+L 164.232 205.768169 
+L 172.44 205.060605 
+L 180.648 203.270479 
+L 188.856 201.878659 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_47">
+    <path d="M 32.7672 210.42236 
+L 41.112 210.191895 
+L 49.32 210.429343 
+L 57.528 209.202965 
+L 65.736 210.224989 
+L 73.944 209.310741 
+L 82.152 209.071165 
+L 90.36 207.724721 
+L 98.568 207.76503 
+L 106.776 205.475811 
+L 114.984 205.529473 
+L 123.192 205.355294 
+L 131.4 203.674011 
+L 139.608 201.415187 
+L 147.816 201.003842 
+L 156.024 198.024977 
+L 164.232 197.934921 
+L 172.44 195.312513 
+L 180.648 195.69479 
+L 188.856 193.534825 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_48">
+    <path d="M 32.7672 211.066524 
+L 41.112 209.968153 
+L 49.32 208.481345 
+L 57.528 209.355294 
+L 65.736 205.778824 
+L 73.944 204.461176 
+L 82.152 201.205326 
+L 90.36 199.753567 
+L 98.568 197.962105 
+L 106.776 194.395542 
+L 114.984 188.389777 
+L 123.192 184.300527 
+L 131.4 186.72743 
+L 139.608 182.381371 
+L 147.816 180.168481 
+L 156.024 174.324706 
+L 164.232 170.936471 
+L 172.44 172.608491 
+L 180.648 164.771024 
+L 188.856 161.151797 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_49">
+    <path d="M 32.7672 208.633296 
+L 41.112 208.384474 
+L 49.32 207.084277 
+L 57.528 206.159022 
+L 65.736 201.721789 
+L 73.944 199.042121 
+L 82.152 193.082974 
+L 90.36 187.822189 
+L 98.568 184.156053 
+L 106.776 176.827605 
+L 114.984 172.238476 
+L 123.192 162.968147 
+L 131.4 161.086387 
+L 139.608 153.579166 
+L 147.816 150.098824 
+L 156.024 147.786667 
+L 164.232 144.319589 
+L 172.44 139.459466 
+L 180.648 137.825882 
+L 188.856 138.031379 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_50">
+    <path d="M 32.7672 207.583128 
+L 41.112 207.977143 
+L 49.32 206.001859 
+L 57.528 202.112139 
+L 65.736 197.711962 
+L 73.944 192.053252 
+L 82.152 186.450227 
+L 90.36 180.313277 
+L 98.568 174.441515 
+L 106.776 163.92543 
+L 114.984 158.923227 
+L 123.192 154.133106 
+L 131.4 149.12 
+L 139.608 143.332467 
+L 147.816 139.734259 
+L 156.024 137.597185 
+L 164.232 135.847491 
+L 172.44 134.30354 
+L 180.648 133.084816 
+L 188.856 131.507113 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_51">
+    <path d="M 32.7672 210.049412 
+L 41.112 209.058759 
+L 49.32 206.723842 
+L 57.528 204.348426 
+L 65.736 198.730206 
+L 73.944 194.296471 
+L 82.152 192.652995 
+L 90.36 183.023385 
+L 98.568 176.743241 
+L 106.776 173.061176 
+L 114.984 164.232605 
+L 123.192 158.604163 
+L 131.4 157.728063 
+L 139.608 151.57663 
+L 147.816 147.760523 
+L 156.024 144.314216 
+L 164.232 139.775865 
+L 172.44 135.250031 
+L 180.648 137.176795 
+L 188.856 134.348315 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_52">
+    <path d="M 32.7672 209.603907 
+L 41.112 208.612715 
+L 49.32 208.191658 
+L 57.528 205.859496 
+L 65.736 203.794582 
+L 73.944 201.825882 
+L 82.152 200.100392 
+L 90.36 194.176684 
+L 98.568 194.441267 
+L 106.776 188.955841 
+L 114.984 182.72088 
+L 123.192 181.0399 
+L 131.4 175.695401 
+L 139.608 173.647059 
+L 147.816 162.93576 
+L 156.024 161.519352 
+L 164.232 162.923922 
+L 172.44 157.565151 
+L 180.648 152.848507 
+L 188.856 149.219071 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_53">
+    <path d="M 32.7672 209.25478 
+L 41.112 208.565061 
+L 49.32 203.368494 
+L 57.528 195.237647 
+L 65.736 189.313189 
+L 73.944 181.044706 
+L 82.152 173.411317 
+L 90.36 163.891828 
+L 98.568 155.716639 
+L 106.776 148.321952 
+L 114.984 142.100585 
+L 123.192 137.707093 
+L 131.4 134.863804 
+L 139.608 134.482599 
+L 147.816 132.010122 
+L 156.024 131.109305 
+L 164.232 130.25555 
+L 172.44 129.812176 
+L 180.648 129.736356 
+L 188.856 129.335604 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_54">
+    <path d="M 32.7672 208.437765 
+L 41.112 207.140761 
+L 49.32 202.602018 
+L 57.528 196.531765 
+L 65.736 190.843757 
+L 73.944 178.374902 
+L 82.152 171.240036 
+L 90.36 161.211568 
+L 98.568 153.557583 
+L 106.776 144.927487 
+L 114.984 142.805894 
+L 123.192 136.924474 
+L 131.4 135.208707 
+L 139.608 132.260223 
+L 147.816 131.721681 
+L 156.024 130.77191 
+L 164.232 131.393722 
+L 172.44 129.83986 
+L 180.648 129.818996 
+L 188.856 128.9581 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_55">
+    <path d="M 32.7672 209.893109 
+L 41.112 208.692193 
+L 49.32 207.20657 
+L 57.528 204.649412 
+L 65.736 198.531765 
+L 73.944 194.638717 
+L 82.152 189.847273 
+L 90.36 180.528403 
+L 98.568 177.580358 
+L 106.776 173.641008 
+L 114.984 164.991658 
+L 123.192 163.544768 
+L 131.4 156.946625 
+L 139.608 151.745387 
+L 147.816 146.537237 
+L 156.024 143.156821 
+L 164.232 139.12222 
+L 172.44 138.118287 
+L 180.648 136.490725 
+L 188.856 134.588939 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_56">
+    <path d="M 32.7672 209.019588 
+L 41.112 206.218039 
+L 49.32 203.154602 
+L 57.528 197.256008 
+L 65.736 190.924914 
+L 73.944 182.846418 
+L 82.152 174.975716 
+L 90.36 167.583844 
+L 98.568 155.96787 
+L 106.776 150.726887 
+L 114.984 145.575309 
+L 123.192 141.321681 
+L 131.4 139.913583 
+L 139.608 138.065455 
+L 147.816 133.989695 
+L 156.024 132.649412 
+L 164.232 130.996614 
+L 172.44 130.050481 
+L 180.648 129.963025 
+L 188.856 130.176783 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="text_20">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="131.119196" transform="rotate(-0 192.856 131.119196)">Pluripotent</text>
+   </g>
+   <g id="text_21">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="30.8" y="142.107482" transform="rotate(-0 30.8 142.107482)">80%</text>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 159.334101)">with</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 166.280742)">reporter</text>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 206.695494)">without</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 213.642134)">reporter</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="122.72" transform="rotate(-0 28.8 122.72)">Lalanne et al. (piggyBac, oBC reporter)</text>
+   </g>
+   <g id="line2d_57">
+    <path d="M 32.7672 211.13526 
+L 41.112 210.084706 
+L 49.32 211.142431 
+L 57.528 209.460706 
+L 65.736 209.556975 
+L 73.944 209.31824 
+L 82.152 208.796101 
+L 90.36 209.041569 
+L 98.568 207.171765 
+L 106.776 205.32406 
+L 114.984 204.649412 
+L 123.192 202.822422 
+L 131.4 203.795787 
+L 139.608 198.926041 
+L 147.816 200.202353 
+L 156.024 198.589426 
+L 164.232 195.753522 
+L 172.44 194.671346 
+L 180.648 193.412917 
+L 188.856 191.081478 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_58">
+    <path d="M 32.7672 210.142889 
+L 41.112 207.896471 
+L 49.32 204.023182 
+L 57.528 198.821647 
+L 65.736 191.607395 
+L 73.944 183.973173 
+L 82.152 176.614954 
+L 90.36 168.021961 
+L 98.568 159.887059 
+L 106.776 150.902405 
+L 114.984 145.965176 
+L 123.192 141.767751 
+L 131.4 138.263639 
+L 139.608 134.824293 
+L 147.816 133.496471 
+L 156.024 131.829137 
+L 164.232 130.682392 
+L 172.44 130.352303 
+L 180.648 129.797071 
+L 188.856 129.463571 
+" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_59">
+    <path d="M 196.2432 161.151797 
+L 204.4512 161.151797 
+" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_60">
+    <path d="M 196.2432 208.513189 
+L 204.4512 208.513189 
+" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe91611f49b">
-   <rect x="43.78125" y="20.038594" width="186.93" height="194.68"/>
+  <clipPath id="p93484b0ab7">
+   <rect x="28.8" y="18.72" width="164.16" height="86.4"/>
   </clipPath>
-  <clipPath id="p20431dfcac">
-   <rect x="245.01125" y="20.038594" width="186.93" height="194.68"/>
-  </clipPath>
-  <clipPath id="pb3137e9c7f">
-   <rect x="446.24125" y="20.038594" width="186.93" height="194.68"/>
+  <clipPath id="p20b52322a5">
+   <rect x="28.8" y="126.72" width="164.16" height="86.4"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/output/fig_b_slope_discrete.svg
+++ b/analyses/simulation/activity_power/output/fig_b_slope_discrete.svg
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="243.36pt" height="136.8pt" viewBox="0 0 243.36 136.8" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T17:35:04.760458</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 136.8 
+L 243.36 136.8 
+L 243.36 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 29.2032 103.968 
+L 105.835711 103.968 
+L 105.835711 21.888 
+L 29.2032 21.888 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="36.298803" y="110.906984" transform="rotate(-0 36.298803 110.906984)">1.1</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="64.681214" y="110.906984" transform="rotate(-0 64.681214 110.906984)">1.2</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3"/>
+     <g id="text_3">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="93.063626" y="110.906984" transform="rotate(-0 93.063626 110.906984)">1.3</text>
+     </g>
+    </g>
+    <g id="text_4">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="67.519455" y="121.957609" transform="rotate(-0 67.519455 121.957609)">fold change</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <path d="M 29.2032 103.968 
+L 105.835711 103.968 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5"/>
+     <g id="text_5">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="106.437492" transform="rotate(-0 27.2032 106.437492)">0</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <path d="M 29.2032 63.732706 
+L 105.835711 63.732706 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="66.202198" transform="rotate(-0 27.2032 66.202198)">0.5</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <path d="M 29.2032 23.497412 
+L 105.835711 23.497412 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="25.966904" transform="rotate(-0 27.2032 25.966904)">1</text>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="11.306403" y="62.928" transform="rotate(-90 11.306403 62.928)">power</text>
+    </g>
+   </g>
+   <g id="line2d_10">
+    <path d="M 29.2032 39.591529 
+L 105.835711 39.591529 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 29.2032 103.968 
+L 29.2032 21.888 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 29.2032 103.968 
+L 105.835711 103.968 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_11">
+    <path d="M 36.298803 57.065956 
+L 64.681214 37.658187 
+L 93.063626 31.314555 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <defs>
+     <path id="maa2de6941a" d="M 0 1.25 
+C 0.331504 1.25 0.649475 1.118292 0.883883 0.883883 
+C 1.118292 0.649475 1.25 0.331504 1.25 0 
+C 1.25 -0.331504 1.118292 -0.649475 0.883883 -0.883883 
+C 0.649475 -1.118292 0.331504 -1.25 0 -1.25 
+C -0.331504 -1.25 -0.649475 -1.118292 -0.883883 -0.883883 
+C -1.118292 -0.649475 -1.25 -0.331504 -1.25 0 
+C -1.25 0.331504 -1.118292 0.649475 -0.883883 0.883883 
+C -0.649475 1.118292 -0.331504 1.25 0 1.25 
+z
+" style="stroke: #0072b2; stroke-opacity: 0.45"/>
+    </defs>
+    <g clip-path="url(#paac861e7da)">
+     <use xlink:href="#maa2de6941a" x="36.298803" y="57.065956" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="64.681214" y="37.658187" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="93.063626" y="31.314555" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_12">
+    <path d="M 36.298803 50.480801 
+L 64.681214 32.869794 
+L 93.063626 28.914163 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#paac861e7da)">
+     <use xlink:href="#maa2de6941a" x="36.298803" y="50.480801" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="64.681214" y="32.869794" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="93.063626" y="28.914163" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_13">
+    <path d="M 36.298803 56.912806 
+L 64.681214 36.814058 
+L 93.063626 30.151248 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#paac861e7da)">
+     <use xlink:href="#maa2de6941a" x="36.298803" y="56.912806" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="64.681214" y="36.814058" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="93.063626" y="30.151248" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="96.063626" y="26.149911" transform="rotate(-0 96.063626 26.149911)">Rod</text>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="29.2032" y="17.888" transform="rotate(-0 29.2032 17.888)">Zhao et al.</text>
+   </g>
+   <g id="line2d_14">
+    <path d="M 36.298803 27.630257 
+L 64.681214 25.29833 
+L 93.063626 24.494286 
+" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="maf6df414e7" d="M 0 1.75 
+C 0.464105 1.75 0.909265 1.565609 1.237437 1.237437 
+C 1.565609 0.909265 1.75 0.464105 1.75 0 
+C 1.75 -0.464105 1.565609 -0.909265 1.237437 -1.237437 
+C 0.909265 -1.565609 0.464105 -1.75 0 -1.75 
+C -0.464105 -1.75 -0.909265 -1.565609 -1.237437 -1.237437 
+C -1.565609 -0.909265 -1.75 -0.464105 -1.75 0 
+C -1.75 0.464105 -1.565609 0.909265 -1.237437 1.237437 
+C -0.909265 1.565609 -0.464105 1.75 0 1.75 
+z
+" style="stroke: #0072b2"/>
+    </defs>
+    <g clip-path="url(#paac861e7da)">
+     <use xlink:href="#maf6df414e7" x="36.298803" y="27.630257" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#maf6df414e7" x="64.681214" y="25.29833" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#maf6df414e7" x="93.063626" y="24.494286" style="fill: #0072b2; stroke: #0072b2"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 132.657089 103.968 
+L 209.2896 103.968 
+L 209.2896 21.888 
+L 132.657089 21.888 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_4">
+     <g id="line2d_15"/>
+     <g id="text_11">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="139.752692" y="110.906984" transform="rotate(-0 139.752692 110.906984)">1.2</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_16"/>
+     <g id="text_12">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="168.135104" y="110.906984" transform="rotate(-0 168.135104 110.906984)">1.5</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_17"/>
+     <g id="text_13">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="196.517515" y="110.906984" transform="rotate(-0 196.517515 110.906984)">2</text>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="170.973345" y="121.957609" transform="rotate(-0 170.973345 121.957609)">fold change</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_4">
+     <g id="line2d_18">
+      <path d="M 132.657089 103.968 
+L 209.2896 103.968 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19"/>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_20">
+      <path d="M 132.657089 63.732706 
+L 209.2896 63.732706 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21"/>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_22">
+      <path d="M 132.657089 23.497412 
+L 209.2896 23.497412 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23"/>
+    </g>
+   </g>
+   <g id="line2d_24">
+    <path d="M 132.657089 39.591529 
+L 209.2896 39.591529 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 132.657089 103.968 
+L 132.657089 21.888 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 132.657089 103.968 
+L 209.2896 103.968 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_25">
+    <path d="M 139.752692 92.900654 
+L 168.135104 65.166668 
+L 196.517515 30.59382 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="92.900654" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="65.166668" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="30.59382" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_26">
+    <path d="M 139.752692 84.297412 
+L 168.135104 37.506343 
+L 196.517515 24.139038 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="84.297412" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="37.506343" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="24.139038" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_27">
+    <path d="M 139.752692 76.934753 
+L 168.135104 30.492909 
+L 196.517515 23.588403 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="76.934753" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="30.492909" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="23.588403" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_28">
+    <path d="M 139.752692 80.683907 
+L 168.135104 34.876304 
+L 196.517515 24.078808 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="80.683907" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="34.876304" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="24.078808" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_29">
+    <path d="M 139.752692 90.310148 
+L 168.135104 52.383527 
+L 196.517515 26.495768 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="90.310148" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="52.383527" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="26.495768" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_30">
+    <path d="M 139.752692 64.356137 
+L 168.135104 25.494275 
+L 196.517515 23.520619 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="64.356137" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="25.494275" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="23.520619" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_31">
+    <path d="M 139.752692 62.193865 
+L 168.135104 25.550964 
+L 196.517515 23.519937 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="62.193865" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="25.550964" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="23.519937" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_32">
+    <path d="M 139.752692 79.980834 
+L 168.135104 34.900001 
+L 196.517515 24.086774 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="79.980834" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="34.900001" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="24.086774" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path d="M 139.752692 65.719634 
+L 168.135104 26.277661 
+L 196.517515 23.64306 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maa2de6941a" x="139.752692" y="65.719634" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="168.135104" y="26.277661" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#maa2de6941a" x="196.517515" y="23.64306" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="199.517515" y="25.231258" transform="rotate(-0 199.517515 25.231258)">Pluripotent</text>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="132.657089" y="17.888" transform="rotate(-0 132.657089 17.888)">Lalanne et al.</text>
+   </g>
+   <g id="line2d_34">
+    <path d="M 139.752692 67.679678 
+L 168.135104 26.097945 
+L 196.517515 23.575633 
+" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
+    <g clip-path="url(#p8fe9f60d45)">
+     <use xlink:href="#maf6df414e7" x="139.752692" y="67.679678" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#maf6df414e7" x="168.135104" y="26.097945" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#maf6df414e7" x="196.517515" y="23.575633" style="fill: #0072b2; stroke: #0072b2"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="paac861e7da">
+   <rect x="29.2032" y="21.888" width="76.632511" height="82.08"/>
+  </clipPath>
+  <clipPath id="p8fe9f60d45">
+   <rect x="132.657089" y="21.888" width="76.632511" height="82.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/analyses/simulation/activity_power/output/fig_b_telescope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_telescope.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="461.250116pt" height="423.634844pt" viewBox="0 0 461.250116 423.634844" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="466.98875pt" height="431.088203pt" viewBox="0 0 466.98875 431.088203" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:28.688235</dc:date>
+    <dc:date>2026-08-16T17:35:04.890827</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,1084 +21,869 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 423.634844 
-L 461.250116 423.634844 
-L 461.250116 0 
+   <path d="M 0 431.088203 
+L 466.98875 431.088203 
+L 466.98875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 118.680156 97.798594 
-L 452.646921 97.798594 
-L 452.646921 20.038594 
-L 118.680156 20.038594 
+    <path d="M 83.705234 105.598828 
+L 454.620234 105.598828 
+L 454.620234 18.898828 
+L 83.705234 18.898828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 118.680156 23.573139 
-L 414.292194 23.573139 
-L 414.292194 37.711321 
-L 118.680156 37.711321 
-z
-" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 118.680156 42.424048 
-L 419.02545 42.424048 
-L 419.02545 56.56223 
-L 118.680156 56.56223 
-z
-" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 118.680156 61.274957 
-L 424.058897 61.274957 
-L 424.058897 75.413139 
-L 118.680156 75.413139 
-z
-" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 118.680156 80.125866 
-L 442.042474 80.125866 
-L 442.042474 94.264048 
-L 118.680156 94.264048 
-z
-" clip-path="url(#p11524b9682)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 118.680156 23.573139 
-L 388.48125 23.573139 
-L 388.48125 37.711321 
-L 118.680156 37.711321 
-z
-" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 118.680156 42.424048 
-L 391.91584 42.424048 
-L 391.91584 56.56223 
-L 118.680156 56.56223 
-z
-" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 118.680156 61.274957 
-L 407.964243 61.274957 
-L 407.964243 75.413139 
-L 118.680156 75.413139 
-z
-" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 118.680156 80.125866 
-L 438.770986 80.125866 
-L 438.770986 94.264048 
-L 118.680156 94.264048 
-z
-" clip-path="url(#p11524b9682)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 118.680156 23.573139 
-L 309.514999 23.573139 
-L 309.514999 37.711321 
-L 118.680156 37.711321 
-z
-" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 118.680156 42.424048 
-L 310.138136 42.424048 
-L 310.138136 56.56223 
-L 118.680156 56.56223 
-z
-" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 118.680156 61.274957 
-L 336.308651 61.274957 
-L 336.308651 75.413139 
-L 118.680156 75.413139 
-z
-" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 118.680156 80.125866 
-L 429.282849 80.125866 
-L 429.282849 94.264048 
-L 118.680156 94.264048 
-z
-" clip-path="url(#p11524b9682)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 118.680156 97.798594 
-L 118.680156 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 105.598828 
+L 83.705234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_2">
-      <defs>
-       <path id="m9c34bc6eda" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="118.680156" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 184.163836 97.798594 
-L 184.163836 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 157.888234 105.598828 
+L 157.888234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="184.163836" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 249.647515 97.798594 
-L 249.647515 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 232.071234 105.598828 
+L 232.071234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="249.647515" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_6"/>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 315.131194 97.798594 
-L 315.131194 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 306.254234 105.598828 
+L 306.254234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="315.131194" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_8"/>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 380.614874 97.798594 
-L 380.614874 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 380.437234 105.598828 
+L 380.437234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="380.614874" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_10"/>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 446.098553 97.798594 
-L 446.098553 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 454.620234 105.598828 
+L 454.620234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="446.098553" y="97.798594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_12"/>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_13">
-      <defs>
-       <path id="mda24468226" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="30.64223" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_13"/>
      <g id="text_1">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="34.061527" transform="rotate(-0 111.680156 34.061527)">Bipolar</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="33.191048" transform="rotate(-0 81.705234 33.191048)">Bipolar</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="49.493139" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_14"/>
      <g id="text_2">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="52.912436" transform="rotate(-0 111.680156 52.912436)">Mueller Glia</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="54.209229" transform="rotate(-0 81.705234 54.209229)">Mueller glia</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="68.344048" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_15"/>
      <g id="text_3">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="71.763345" transform="rotate(-0 111.680156 71.763345)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="75.227411" transform="rotate(-0 81.705234 75.227411)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="87.194957" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_16"/>
      <g id="text_4">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="90.614254" transform="rotate(-0 111.680156 90.614254)">Rod</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="96.245593" transform="rotate(-0 81.705234 96.245593)">Rod</text>
      </g>
     </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 83.705234 22.839737 
+L 418.588492 22.839737 
+L 418.588492 38.603374 
+L 83.705234 38.603374 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 83.705234 43.857919 
+L 423.950546 43.857919 
+L 423.950546 59.621555 
+L 83.705234 59.621555 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 83.705234 64.876101 
+L 429.652672 64.876101 
+L 429.652672 80.639737 
+L 83.705234 80.639737 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 83.705234 85.894283 
+L 450.025317 85.894283 
+L 450.025317 101.657919 
+L 83.705234 101.657919 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 83.705234 22.839737 
+L 389.348637 22.839737 
+L 389.348637 38.603374 
+L 83.705234 38.603374 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 83.705234 43.857919 
+L 393.239502 43.857919 
+L 393.239502 59.621555 
+L 83.705234 59.621555 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 83.705234 64.876101 
+L 411.41989 64.876101 
+L 411.41989 80.639737 
+L 83.705234 80.639737 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 83.705234 85.894283 
+L 446.319221 85.894283 
+L 446.319221 101.657919 
+L 83.705234 101.657919 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 83.705234 22.839737 
+L 299.891943 22.839737 
+L 299.891943 38.603374 
+L 83.705234 38.603374 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 83.705234 43.857919 
+L 300.597862 43.857919 
+L 300.597862 59.621555 
+L 83.705234 59.621555 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 83.705234 64.876101 
+L 330.245056 64.876101 
+L 330.245056 80.639737 
+L 83.705234 80.639737 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 83.705234 85.894283 
+L 435.570612 85.894283 
+L 435.570612 101.657919 
+L 83.705234 101.657919 
+z
+" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
    </g>
    <g id="line2d_17">
-    <path d="M 380.614874 97.798594 
-L 380.614874 20.038594 
-" clip-path="url(#p11524b9682)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 380.437234 105.598828 
+L 380.437234 18.898828 
+" clip-path="url(#ped2729ea74)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_15">
-    <path d="M 118.680156 97.798594 
-L 118.680156 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 83.705234 105.598828 
+L 83.705234 18.898828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_16">
-    <path d="M 452.646921 97.798594 
-L 452.646921 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 118.680156 97.798594 
-L 452.646921 97.798594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 118.680156 20.038594 
-L 452.646921 20.038594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 83.705234 105.598828 
+L 454.620234 105.598828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_5">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="14.038594" transform="rotate(-0 118.680156 14.038594)">Cohen (episomal, CRE-reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="12.898828" transform="rotate(-0 83.705234 12.898828)">Zhao et al. (episomal, CRE reporter)</text>
    </g>
    <g id="legend_1">
-    <g id="patch_19">
-     <path d="M 322.410827 94.298594 
-L 447.746921 94.298594 
-Q 449.146921 94.298594 449.146921 92.898594 
-L 449.146921 83.323906 
-Q 449.146921 81.923906 447.746921 81.923906 
-L 322.410827 81.923906 
-Q 321.010827 81.923906 321.010827 83.323906 
-L 321.010827 92.898594 
-Q 321.010827 94.298594 322.410827 94.298594 
+    <g id="patch_17">
+     <path d="M 334.986719 98.397031 
+L 342.786719 98.397031 
+L 342.786719 93.847031 
+L 334.986719 93.847031 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="patch_20">
-     <path d="M 323.810827 90.042813 
-L 332.210827 90.042813 
-L 332.210827 85.142813 
-L 323.810827 85.142813 
-z
-" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #b2d5e8"/>
     </g>
     <g id="text_6">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="335.010827" y="90.042813" transform="rotate(-0 335.010827 90.042813)">FC=1.3</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="98.397031" transform="rotate(-0 345.386719 98.397031)">FC=1.3</text>
     </g>
-    <g id="patch_21">
-     <path d="M 366.522858 90.042813 
-L 374.922858 90.042813 
-L 374.922858 85.142813 
-L 366.522858 85.142813 
+    <g id="patch_18">
+     <path d="M 374.647891 98.397031 
+L 382.447891 98.397031 
+L 382.447891 93.847031 
+L 374.647891 93.847031 
 z
-" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #66aad1"/>
     </g>
     <g id="text_7">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="377.722858" y="90.042813" transform="rotate(-0 377.722858 90.042813)">FC=1.2</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="98.397031" transform="rotate(-0 385.047891 98.397031)">FC=1.2</text>
     </g>
-    <g id="patch_22">
-     <path d="M 409.23489 90.042813 
-L 417.63489 90.042813 
-L 417.63489 85.142813 
-L 409.23489 85.142813 
+    <g id="patch_19">
+     <path d="M 414.309063 98.397031 
+L 422.109063 98.397031 
+L 422.109063 93.847031 
+L 414.309063 93.847031 
 z
-" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #1980ba"/>
     </g>
     <g id="text_8">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.43489" y="90.042813" transform="rotate(-0 420.43489 90.042813)">FC=1.1</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="98.397031" transform="rotate(-0 424.709063 98.397031)">FC=1.1</text>
     </g>
    </g>
   </g>
   <g id="axes_2">
-   <g id="patch_23">
-    <path d="M 118.680156 319.698594 
-L 452.646921 319.698594 
-L 452.646921 125.298594 
-L 118.680156 125.298594 
+   <g id="patch_20">
+    <path d="M 83.705234 341.668828 
+L 454.620234 341.668828 
+L 454.620234 124.918828 
+L 83.705234 124.918828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 118.680156 134.134957 
-L 417.224718 134.134957 
-L 417.224718 147.729363 
-L 118.680156 147.729363 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 118.680156 152.260832 
-L 433.898854 152.260832 
-L 433.898854 165.855237 
-L 118.680156 165.855237 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 118.680156 170.386706 
-L 443.487908 170.386706 
-L 443.487908 183.981111 
-L 118.680156 183.981111 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 118.680156 188.51258 
-L 443.700559 188.51258 
-L 443.700559 202.106985 
-L 118.680156 202.106985 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 118.680156 206.638454 
-L 443.732969 206.638454 
-L 443.732969 220.232859 
-L 118.680156 220.232859 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 118.680156 224.764328 
-L 445.505941 224.764328 
-L 445.505941 238.358734 
-L 118.680156 238.358734 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 118.680156 242.890202 
-L 445.728327 242.890202 
-L 445.728327 256.484608 
-L 118.680156 256.484608 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 118.680156 261.016076 
-L 445.780285 261.016076 
-L 445.780285 274.610482 
-L 118.680156 274.610482 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 118.680156 279.14195 
-L 446.004128 279.14195 
-L 446.004128 292.736356 
-L 118.680156 292.736356 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 118.680156 297.267825 
-L 446.006903 297.267825 
-L 446.006903 310.86223 
-L 118.680156 310.86223 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 118.680156 134.134957 
-L 276.554855 134.134957 
-L 276.554855 147.729363 
-L 118.680156 147.729363 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 118.680156 152.260832 
-L 328.566848 152.260832 
-L 328.566848 165.855237 
-L 118.680156 165.855237 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 118.680156 170.386706 
-L 389.099073 170.386706 
-L 389.099073 183.981111 
-L 118.680156 183.981111 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_37">
-    <path d="M 118.680156 188.51258 
-L 399.703745 188.51258 
-L 399.703745 202.106985 
-L 118.680156 202.106985 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_38">
-    <path d="M 118.680156 206.638454 
-L 399.800165 206.638454 
-L 399.800165 220.232859 
-L 118.680156 220.232859 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_39">
-    <path d="M 118.680156 224.764328 
-L 434.786287 224.764328 
-L 434.786287 238.358734 
-L 118.680156 238.358734 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_40">
-    <path d="M 118.680156 242.890202 
-L 417.635304 242.890202 
-L 417.635304 256.484608 
-L 118.680156 256.484608 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_41">
-    <path d="M 118.680156 261.016076 
-L 435.517513 261.016076 
-L 435.517513 274.610482 
-L 118.680156 274.610482 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_42">
-    <path d="M 118.680156 279.14195 
-L 437.973726 279.14195 
-L 437.973726 292.736356 
-L 118.680156 292.736356 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_43">
-    <path d="M 118.680156 297.267825 
-L 437.743069 297.267825 
-L 437.743069 310.86223 
-L 118.680156 310.86223 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_44">
-    <path d="M 118.680156 134.134957 
-L 163.710928 134.134957 
-L 163.710928 147.729363 
-L 118.680156 147.729363 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_45">
-    <path d="M 118.680156 152.260832 
-L 174.251169 152.260832 
-L 174.251169 165.855237 
-L 118.680156 165.855237 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_46">
-    <path d="M 118.680156 170.386706 
-L 198.715764 170.386706 
-L 198.715764 183.981111 
-L 118.680156 183.981111 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_47">
-    <path d="M 118.680156 188.51258 
-L 216.279037 188.51258 
-L 216.279037 202.106985 
-L 118.680156 202.106985 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_48">
-    <path d="M 118.680156 206.638454 
-L 213.418379 206.638454 
-L 213.418379 220.232859 
-L 118.680156 220.232859 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_49">
-    <path d="M 118.680156 224.764328 
-L 274.30495 224.764328 
-L 274.30495 238.358734 
-L 118.680156 238.358734 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_50">
-    <path d="M 118.680156 242.890202 
-L 228.672919 242.890202 
-L 228.672919 256.484608 
-L 118.680156 256.484608 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_51">
-    <path d="M 118.680156 261.016076 
-L 266.329932 261.016076 
-L 266.329932 274.610482 
-L 118.680156 274.610482 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_52">
-    <path d="M 118.680156 279.14195 
-L 279.85274 279.14195 
-L 279.85274 292.736356 
-L 118.680156 292.736356 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_53">
-    <path d="M 118.680156 297.267825 
-L 288.650583 297.267825 
-L 288.650583 310.86223 
-L 118.680156 310.86223 
-z
-" clip-path="url(#p0ccffbd026)" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
-      <path d="M 118.680156 319.698594 
-L 118.680156 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 341.668828 
+L 83.705234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="118.680156" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_19"/>
     </g>
     <g id="xtick_8">
      <g id="line2d_20">
-      <path d="M 184.163836 319.698594 
-L 184.163836 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 157.888234 341.668828 
+L 157.888234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="184.163836" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_21"/>
     </g>
     <g id="xtick_9">
      <g id="line2d_22">
-      <path d="M 249.647515 319.698594 
-L 249.647515 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 232.071234 341.668828 
+L 232.071234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="249.647515" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_23"/>
     </g>
     <g id="xtick_10">
      <g id="line2d_24">
-      <path d="M 315.131194 319.698594 
-L 315.131194 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 306.254234 341.668828 
+L 306.254234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="315.131194" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_25"/>
     </g>
     <g id="xtick_11">
      <g id="line2d_26">
-      <path d="M 380.614874 319.698594 
-L 380.614874 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 380.437234 341.668828 
+L 380.437234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="380.614874" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_27"/>
     </g>
     <g id="xtick_12">
      <g id="line2d_28">
-      <path d="M 446.098553 319.698594 
-L 446.098553 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 454.620234 341.668828 
+L 454.620234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="446.098553" y="319.698594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_29"/>
     </g>
    </g>
    <g id="matplotlib.axis_4">
     <g id="ytick_5">
-     <g id="line2d_30">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="140.93216" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_30"/>
      <g id="text_9">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="144.351457" transform="rotate(-0 111.680156 144.351457)">Cardiomyocytes</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="144.819264" transform="rotate(-0 81.705234 144.819264)">Cardiomyocytes</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="159.058034" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_31"/>
      <g id="text_10">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="162.477331" transform="rotate(-0 111.680156 162.477331)">Haematoendothelial</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="165.029055" transform="rotate(-0 81.705234 165.029055)">Haematoendothelial</text>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_32">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="177.183908" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_32"/>
      <g id="text_11">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="180.603205" transform="rotate(-0 111.680156 180.603205)">EpiblastPrimitiveStreak</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="185.238845" transform="rotate(-0 81.705234 185.238845)">Epiblast/prim. streak</text>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="195.309783" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_33"/>
      <g id="text_12">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="198.729079" transform="rotate(-0 111.680156 198.729079)">NeuroectodermRostral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="205.448635" transform="rotate(-0 81.705234 205.448635)">Neuroectoderm rostral</text>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_34">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="213.435657" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_34"/>
      <g id="text_13">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="216.854954" transform="rotate(-0 111.680156 216.854954)">ExEndodermVisceral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="225.658425" transform="rotate(-0 81.705234 225.658425)">ExE endoderm visceral</text>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="231.561531" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_35"/>
      <g id="text_14">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="234.980828" transform="rotate(-0 111.680156 234.980828)">SurfaceEctoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="245.868215" transform="rotate(-0 81.705234 245.868215)">Surface ectoderm</text>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_36">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="249.687405" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_36"/>
      <g id="text_15">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="253.106702" transform="rotate(-0 111.680156 253.106702)">ExEndodermParietal</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="266.078006" transform="rotate(-0 81.705234 266.078006)">ExE endoderm parietal</text>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="267.813279" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_37"/>
      <g id="text_16">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="271.232576" transform="rotate(-0 111.680156 271.232576)">Pluripotent</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="286.287796" transform="rotate(-0 81.705234 286.287796)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_38">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="285.939153" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_38"/>
      <g id="text_17">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="289.35845" transform="rotate(-0 111.680156 289.35845)">Mesoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="306.497586" transform="rotate(-0 81.705234 306.497586)">Mesoderm</text>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="304.065027" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_39"/>
      <g id="text_18">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="307.484324" transform="rotate(-0 111.680156 307.484324)">NeuroectodermBrain</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="326.707376" transform="rotate(-0 81.705234 326.707376)">Neuroectoderm brain</text>
      </g>
     </g>
+   </g>
+   <g id="patch_21">
+    <path d="M 83.705234 134.771101 
+L 421.910592 134.771101 
+L 421.910592 149.928444 
+L 83.705234 149.928444 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 83.705234 154.980891 
+L 440.79984 154.980891 
+L 440.79984 170.138234 
+L 83.705234 170.138234 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 83.705234 175.190681 
+L 451.662773 175.190681 
+L 451.662773 190.348024 
+L 83.705234 190.348024 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 83.705234 195.400471 
+L 451.903674 195.400471 
+L 451.903674 210.557814 
+L 83.705234 210.557814 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 83.705234 215.610262 
+L 451.940389 215.610262 
+L 451.940389 230.767604 
+L 83.705234 230.767604 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 83.705234 235.820052 
+L 453.948895 235.820052 
+L 453.948895 250.977395 
+L 83.705234 250.977395 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 83.705234 256.029842 
+L 454.200825 256.029842 
+L 454.200825 271.187185 
+L 83.705234 271.187185 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 83.705234 276.239632 
+L 454.259685 276.239632 
+L 454.259685 291.396975 
+L 83.705234 291.396975 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 83.705234 296.449423 
+L 454.513265 296.449423 
+L 454.513265 311.606765 
+L 83.705234 311.606765 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 83.705234 316.659213 
+L 454.516409 316.659213 
+L 454.516409 331.816555 
+L 83.705234 331.816555 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 83.705234 134.771101 
+L 262.553138 134.771101 
+L 262.553138 149.928444 
+L 83.705234 149.928444 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 83.705234 154.980891 
+L 321.474776 154.980891 
+L 321.474776 170.138234 
+L 83.705234 170.138234 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 83.705234 175.190681 
+L 390.048535 175.190681 
+L 390.048535 190.348024 
+L 83.705234 190.348024 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 83.705234 195.400471 
+L 402.062009 195.400471 
+L 402.062009 210.557814 
+L 83.705234 210.557814 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 83.705234 215.610262 
+L 402.171237 215.610262 
+L 402.171237 230.767604 
+L 83.705234 230.767604 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 83.705234 235.820052 
+L 441.805166 235.820052 
+L 441.805166 250.977395 
+L 83.705234 250.977395 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 83.705234 256.029842 
+L 422.375724 256.029842 
+L 422.375724 271.187185 
+L 83.705234 271.187185 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 83.705234 276.239632 
+L 442.633534 276.239632 
+L 442.633534 291.396975 
+L 83.705234 291.396975 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 83.705234 296.449423 
+L 445.416047 296.449423 
+L 445.416047 311.606765 
+L 83.705234 311.606765 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 83.705234 316.659213 
+L 445.154748 316.659213 
+L 445.154748 331.816555 
+L 83.705234 331.816555 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 83.705234 134.771101 
+L 134.718216 134.771101 
+L 134.718216 149.928444 
+L 83.705234 149.928444 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 83.705234 154.980891 
+L 146.658698 154.980891 
+L 146.658698 170.138234 
+L 83.705234 170.138234 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 83.705234 175.190681 
+L 174.373345 175.190681 
+L 174.373345 190.348024 
+L 83.705234 190.348024 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 83.705234 195.400471 
+L 194.269849 195.400471 
+L 194.269849 210.557814 
+L 83.705234 210.557814 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 83.705234 215.610262 
+L 191.02916 215.610262 
+L 191.02916 230.767604 
+L 83.705234 230.767604 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 83.705234 235.820052 
+L 260.004339 235.820052 
+L 260.004339 250.977395 
+L 83.705234 250.977395 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 83.705234 256.029842 
+L 208.310223 256.029842 
+L 208.310223 271.187185 
+L 83.705234 271.187185 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 83.705234 276.239632 
+L 250.969863 276.239632 
+L 250.969863 291.396975 
+L 83.705234 291.396975 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 83.705234 296.449423 
+L 266.289138 296.449423 
+L 266.289138 311.606765 
+L 83.705234 311.606765 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 83.705234 316.659213 
+L 276.25575 316.659213 
+L 276.25575 331.816555 
+L 83.705234 331.816555 
+z
+" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
    </g>
    <g id="line2d_40">
-    <path d="M 380.614874 319.698594 
-L 380.614874 125.298594 
-" clip-path="url(#p0ccffbd026)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 380.437234 341.668828 
+L 380.437234 124.918828 
+" clip-path="url(#p5620c45f01)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="patch_54">
-    <path d="M 118.680156 319.698594 
-L 118.680156 125.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_51">
+    <path d="M 83.705234 341.668828 
+L 83.705234 124.918828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_55">
-    <path d="M 452.646921 319.698594 
-L 452.646921 125.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_56">
-    <path d="M 118.680156 319.698594 
-L 452.646921 319.698594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_57">
-    <path d="M 118.680156 125.298594 
-L 452.646921 125.298594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_52">
+    <path d="M 83.705234 341.668828 
+L 454.620234 341.668828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="119.298594" transform="rotate(-0 118.680156 119.298594)">Shendure (piggyBac, oBC reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="118.918828" transform="rotate(-0 83.705234 118.918828)">Lalanne et al. (piggyBac, oBC reporter)</text>
    </g>
    <g id="legend_2">
-    <g id="patch_58">
-     <path d="M 322.410827 316.198594 
-L 447.746921 316.198594 
-Q 449.146921 316.198594 449.146921 314.798594 
-L 449.146921 305.223906 
-Q 449.146921 303.823906 447.746921 303.823906 
-L 322.410827 303.823906 
-Q 321.010827 303.823906 321.010827 305.223906 
-L 321.010827 314.798594 
-Q 321.010827 316.198594 322.410827 316.198594 
+    <g id="patch_53">
+     <path d="M 334.986719 334.467031 
+L 342.786719 334.467031 
+L 342.786719 329.917031 
+L 334.986719 329.917031 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="patch_59">
-     <path d="M 323.810827 311.942812 
-L 332.210827 311.942812 
-L 332.210827 307.042812 
-L 323.810827 307.042812 
-z
-" style="fill: #c8dae8; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #b2d5e8"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="335.010827" y="311.942812" transform="rotate(-0 335.010827 311.942812)">FC=2.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="334.467031" transform="rotate(-0 345.386719 334.467031)">FC=2.0</text>
     </g>
-    <g id="patch_60">
-     <path d="M 366.522858 311.942812 
-L 374.922858 311.942812 
-L 374.922858 307.042812 
-L 366.522858 307.042812 
+    <g id="patch_54">
+     <path d="M 374.647891 334.467031 
+L 382.447891 334.467031 
+L 382.447891 329.917031 
+L 374.647891 329.917031 
 z
-" style="fill: #90b4d2; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #66aad1"/>
     </g>
     <g id="text_21">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="377.722858" y="311.942812" transform="rotate(-0 377.722858 311.942812)">FC=1.5</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="334.467031" transform="rotate(-0 385.047891 334.467031)">FC=1.5</text>
     </g>
-    <g id="patch_61">
-     <path d="M 409.23489 311.942812 
-L 417.63489 311.942812 
-L 417.63489 307.042812 
-L 409.23489 307.042812 
+    <g id="patch_55">
+     <path d="M 414.309063 334.467031 
+L 422.109063 334.467031 
+L 422.109063 329.917031 
+L 414.309063 329.917031 
 z
-" style="fill: #588ebc; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #1980ba"/>
     </g>
     <g id="text_22">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.43489" y="311.942812" transform="rotate(-0 420.43489 311.942812)">FC=1.2</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="334.467031" transform="rotate(-0 424.709063 334.467031)">FC=1.2</text>
     </g>
    </g>
   </g>
   <g id="axes_3">
-   <g id="patch_62">
-    <path d="M 118.680156 386.078594 
-L 452.646921 386.078594 
-L 452.646921 347.198594 
-L 118.680156 347.198594 
+   <g id="patch_56">
+    <path d="M 83.705234 404.338828 
+L 454.620234 404.338828 
+L 454.620234 360.988828 
+L 83.705234 360.988828 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_63">
-    <path d="M 118.680156 348.965866 
-L 428.574574 348.965866 
-L 428.574574 364.113918 
-L 118.680156 364.113918 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_64">
-    <path d="M 118.680156 369.163269 
-L 441.166745 369.163269 
-L 441.166745 384.311321 
-L 118.680156 384.311321 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_65">
-    <path d="M 118.680156 348.965866 
-L 295.404315 348.965866 
-L 295.404315 364.113918 
-L 118.680156 364.113918 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_66">
-    <path d="M 118.680156 369.163269 
-L 337.847646 369.163269 
-L 337.847646 384.311321 
-L 118.680156 384.311321 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_67">
-    <path d="M 118.680156 348.965866 
-L 173.749743 348.965866 
-L 173.749743 364.113918 
-L 118.680156 364.113918 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_68">
-    <path d="M 118.680156 369.163269 
-L 196.026881 369.163269 
-L 196.026881 384.311321 
-L 118.680156 384.311321 
-z
-" clip-path="url(#pa5ae2cb02e)" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
-      <path d="M 118.680156 386.078594 
-L 118.680156 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 83.705234 404.338828 
+L 83.705234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_42">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="118.680156" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_42"/>
      <g id="text_23">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="118.680156" y="400.677031" transform="rotate(-0 118.680156 400.677031)">0.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="411.277812" transform="rotate(-0 83.705234 411.277812)">0.0</text>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_43">
-      <path d="M 184.163836 386.078594 
-L 184.163836 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 157.888234 404.338828 
+L 157.888234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="184.163836" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_44"/>
      <g id="text_24">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="184.163836" y="400.677031" transform="rotate(-0 184.163836 400.677031)">0.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="157.888234" y="411.277812" transform="rotate(-0 157.888234 411.277812)">0.2</text>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_45">
-      <path d="M 249.647515 386.078594 
-L 249.647515 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 232.071234 404.338828 
+L 232.071234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_46">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="249.647515" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_46"/>
      <g id="text_25">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="249.647515" y="400.677031" transform="rotate(-0 249.647515 400.677031)">0.4</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="232.071234" y="411.277812" transform="rotate(-0 232.071234 411.277812)">0.4</text>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_47">
-      <path d="M 315.131194 386.078594 
-L 315.131194 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 306.254234 404.338828 
+L 306.254234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_48">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="315.131194" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_48"/>
      <g id="text_26">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="315.131194" y="400.677031" transform="rotate(-0 315.131194 400.677031)">0.6</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="306.254234" y="411.277812" transform="rotate(-0 306.254234 411.277812)">0.6</text>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_49">
-      <path d="M 380.614874 386.078594 
-L 380.614874 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 380.437234 404.338828 
+L 380.437234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="380.614874" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_50"/>
      <g id="text_27">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="380.614874" y="400.677031" transform="rotate(-0 380.614874 400.677031)">0.8</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="380.437234" y="411.277812" transform="rotate(-0 380.437234 411.277812)">0.8</text>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_51">
-      <path d="M 446.098553 386.078594 
-L 446.098553 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 454.620234 404.338828 
+L 454.620234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_52">
-      <g>
-       <use xlink:href="#m9c34bc6eda" x="446.098553" y="386.078594" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_52"/>
      <g id="text_28">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="446.098553" y="400.677031" transform="rotate(-0 446.098553 400.677031)">1.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="454.620234" y="411.277812" transform="rotate(-0 454.620234 411.277812)">1.0</text>
      </g>
     </g>
     <g id="text_29">
-     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="285.663539" y="414.355156" transform="rotate(-0 285.663539 414.355156)">Power</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="269.162734" y="422.328438" transform="rotate(-0 269.162734 422.328438)">power</text>
     </g>
    </g>
    <g id="matplotlib.axis_6">
     <g id="ytick_15">
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="356.539892" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_53"/>
      <g id="text_30">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="359.959189" transform="rotate(-0 111.680156 359.959189)">K562</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="373.87358" transform="rotate(-0 81.705234 373.87358)">K562</text>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_54">
-      <g>
-       <use xlink:href="#mda24468226" x="118.680156" y="376.737295" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_54"/>
      <g id="text_31">
-      <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="111.680156" y="380.156592" transform="rotate(-0 111.680156 380.156592)">HepG2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="396.393061" transform="rotate(-0 81.705234 396.393061)">HepG2</text>
      </g>
     </g>
+   </g>
+   <g id="patch_57">
+    <path d="M 83.705234 362.959283 
+L 434.768244 362.959283 
+L 434.768244 379.848893 
+L 83.705234 379.848893 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #f2cfb2"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 83.705234 385.478763 
+L 449.03325 385.478763 
+L 449.03325 402.368374 
+L 83.705234 402.368374 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #f2cfb2"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 83.705234 362.959283 
+L 283.906695 362.959283 
+L 283.906695 379.848893 
+L 83.705234 379.848893 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #e69e66"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 83.705234 385.478763 
+L 331.988502 385.478763 
+L 331.988502 402.368374 
+L 83.705234 402.368374 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #e69e66"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 83.705234 362.959283 
+L 146.09066 362.959283 
+L 146.09066 379.848893 
+L 83.705234 379.848893 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #d96e19"/>
+   </g>
+   <g id="patch_62">
+    <path d="M 83.705234 385.478763 
+L 171.327252 385.478763 
+L 171.327252 402.368374 
+L 83.705234 402.368374 
+z
+" clip-path="url(#p1ecbf345b6)" style="fill: #d96e19"/>
    </g>
    <g id="line2d_55">
-    <path d="M 380.614874 386.078594 
-L 380.614874 347.198594 
-" clip-path="url(#pa5ae2cb02e)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4; stroke-width: 0.6"/>
+    <path d="M 380.437234 404.338828 
+L 380.437234 360.988828 
+" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
-   <g id="patch_69">
-    <path d="M 118.680156 386.078594 
-L 118.680156 347.198594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_63">
+    <path d="M 83.705234 404.338828 
+L 83.705234 360.988828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_70">
-    <path d="M 452.646921 386.078594 
-L 452.646921 347.198594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_71">
-    <path d="M 118.680156 386.078594 
-L 452.646921 386.078594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_72">
-    <path d="M 118.680156 347.198594 
-L 452.646921 347.198594 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="patch_64">
+    <path d="M 83.705234 404.338828 
+L 454.620234 404.338828 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_32">
-    <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="118.680156" y="341.198594" transform="rotate(-0 118.680156 341.198594)">Seelig (episomal, no reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="354.988828" transform="rotate(-0 83.705234 354.988828)">Yin et al. (episomal, no reporter)</text>
    </g>
    <g id="legend_3">
-    <g id="patch_73">
-     <path d="M 322.410827 382.578594 
-L 447.746921 382.578594 
-Q 449.146921 382.578594 449.146921 381.178594 
-L 449.146921 371.603906 
-Q 449.146921 370.203906 447.746921 370.203906 
-L 322.410827 370.203906 
-Q 321.010827 370.203906 321.010827 371.603906 
-L 321.010827 381.178594 
-Q 321.010827 382.578594 322.410827 382.578594 
+    <g id="patch_65">
+     <path d="M 334.986719 397.137031 
+L 342.786719 397.137031 
+L 342.786719 392.587031 
+L 334.986719 392.587031 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="patch_74">
-     <path d="M 323.810827 378.322812 
-L 332.210827 378.322812 
-L 332.210827 373.422812 
-L 323.810827 373.422812 
-z
-" style="fill: #ffd9cb; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #f2cfb2"/>
     </g>
     <g id="text_33">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="335.010827" y="378.322812" transform="rotate(-0 335.010827 378.322812)">FC=3.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="397.137031" transform="rotate(-0 345.386719 397.137031)">FC=3.0</text>
     </g>
-    <g id="patch_75">
-     <path d="M 366.522858 378.322812 
-L 374.922858 378.322812 
-L 374.922858 373.422812 
-L 366.522858 373.422812 
+    <g id="patch_66">
+     <path d="M 374.647891 397.137031 
+L 382.447891 397.137031 
+L 382.447891 392.587031 
+L 374.647891 392.587031 
 z
-" style="fill: #ffb296; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #e69e66"/>
     </g>
     <g id="text_34">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="377.722858" y="378.322812" transform="rotate(-0 377.722858 378.322812)">FC=2.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="397.137031" transform="rotate(-0 385.047891 397.137031)">FC=2.0</text>
     </g>
-    <g id="patch_76">
-     <path d="M 409.23489 378.322812 
-L 417.63489 378.322812 
-L 417.63489 373.422812 
-L 409.23489 373.422812 
+    <g id="patch_67">
+     <path d="M 414.309063 397.137031 
+L 422.109063 397.137031 
+L 422.109063 392.587031 
+L 414.309063 392.587031 
 z
-" style="fill: #ff8c62; stroke: #ffffff; stroke-width: 0.4; stroke-linejoin: miter"/>
+" style="fill: #d96e19"/>
     </g>
     <g id="text_35">
-     <text style="font-size: 7px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.43489" y="378.322812" transform="rotate(-0 420.43489 378.322812)">FC=1.5</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="397.137031" transform="rotate(-0 424.709063 397.137031)">FC=1.5</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p11524b9682">
-   <rect x="118.680156" y="20.038594" width="333.966765" height="77.76"/>
+  <clipPath id="ped2729ea74">
+   <rect x="83.705234" y="18.898828" width="370.915" height="86.7"/>
   </clipPath>
-  <clipPath id="p0ccffbd026">
-   <rect x="118.680156" y="125.298594" width="333.966765" height="194.4"/>
+  <clipPath id="p5620c45f01">
+   <rect x="83.705234" y="124.918828" width="370.915" height="216.75"/>
   </clipPath>
-  <clipPath id="pa5ae2cb02e">
-   <rect x="118.680156" y="347.198594" width="333.966765" height="38.88"/>
+  <clipPath id="p1ecbf345b6">
+   <rect x="83.705234" y="360.988828" width="370.915" height="43.35"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
Re-plots panels A and B of manuscript Figure 4 ("Transfection reporters provide a quantifiable power benefit for activity hypotheses"). Builds on #102, which repointed these panels at the MWU arms.

## Yin et al. dropped from panel B

Panel A already plotted Zhao and Lalanne only; panel B plotted all three. Figure 4 is a **paired +/- transfection reporter contrast**, and Yin et al. ran no transfection reporter, so it has no empirical "+reporter" arm and cannot participate in the pairing -- only a guess from fit parameters could supply one.

The old code betrayed this: `best_mode` mapped seelig to `"deflated"` while cohen and shendure got `"reporter"`, so Yin's panel was silently plotting a different condition from its neighbours while reading as the same measurement.

`seelig` stays in the `DATASETS` dict -- it is dropped at the panel level only, because `fig_b_dataset_bars` and `fig_b_telescope` still iterate over all three. All four outputs still generate.

## Panel B is now continuous

Power vs fold change over a common window of fc 1.0-1.6, binned at fixed width 0.03 (20 bins in both datasets, so a bin is the same fold-change interval in each; thinnest bin 1,405 draws for Zhao and 370 for Lalanne, asserted >= 30). Both arms are drawn per panel, reference cell type solid/heavy/on top and directly labelled.

`FC_TRIPLET` was a presentation choice, not a data limit -- there are 226,512 distinct fc values in the Lalanne parquet and 11,400 in Zhao's. The binning follows `pow_curve_data()` in `replot_overlay_ct.py`, which is what draws Figure 3A, so the two figures now agree on curve treatment.

The discrete version is kept as `fig_b_slope_discrete.svg`. Beyond looking worse, it had a real defect: it plotted each dataset's own FC triplet as equally spaced categories, but Zhao's triplet spans 0.2 in fold change and Lalanne's spans 0.8, so an identical drawn slope meant a 4x different thing per panel.

Dropping Yin is what made the continuous form affordable -- each panel is a full-width 3.38 in strip instead of a 1.1 in sliver.

## Appearance

Both panels drawn at 3.38 in wide, which is the `0.49\textwidth` they are included at; the sync pipeline applies no font scaling, so point sizes only mean what they say at final width. Shared type scale (7 pt base, 7.5 pt titles, 6.5 pt ticks, 6 pt annotations), `svg.fonttype: "none"` for editable text.

Okabe-Ito `#0072b2` / `#d55e00` replacing steelblue/coral, matching `activity_calibration/fpr_dumbbell.py` so neighbouring figures share a colour convention. Palette validated: worst CVD dE 21.9, normal-vision separation 31.2, both >= 3:1 on white.

Dataset titles are written as "Zhao et al." / "Lalanne et al." directly rather than relying on the downstream `dataset_names` SVG transform. Cell-type identifiers are spelled for a reader ("EpiblastPrimitiveStreak" -> "Epiblast/prim. streak"). Legends that restated a single direct label are gone; panel B is direct-labelled instead. A grey rule at 1.5x in panel B marks the slice panel A shows.

## Numbers, for the caption

Power at fc 1.5 +/- 5%, MWU. Mean gap +0.030 for Zhao (four cell types, 0.967 vs 0.937) and +0.716 for Lalanne (ten cell types, 0.846 vs 0.131).

## Known, not addressed here

- **fc 1.5 is a poor slice for Zhao in panel A.** Both arms are near-saturated, so all eight dots pile into the right 10% of the axis. `TARGET_FC` is a one-constant change and fc 1.2 would give Zhao a mean gap of ~0.109 spread across 0.69-0.98, but the manuscript prose cites 1.5, so this needs a coordinated decision.
- Zhao's reference row (Rod) is 0.994 vs 0.991 -- the two dots overlap, and the per-cell-type claim rests on the other three.
- Lalanne's -reporter arm has almost no power anywhere in the window (0.03-0.23 at fc 1.5). That is the MWU arm, so it is not t-test miscalibration, but it is a large claim resting on one arm.
