### PR TITLE
Fig 3A replot: editable text, shared log2 axis, direct labels

### DIFF
--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:22.889526</dc:date>
+    <dc:date>2026-08-16T20:37:59.404709</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,2072 +21,220 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
+   <g id="patch_3">
+    <path d="M 99.6 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 99.6 25.92 
+z
+" clip-path="url(#pc69d595cd2)" style="fill: #c9c9c9; opacity: 0.22"/>
+   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m1723208b96" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m1723208b96" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.6 -->
-      <g transform="translate(95.409082 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m1723208b96" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.8 -->
-      <g transform="translate(169.736756 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m1723208b96" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(244.064429 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m1723208b96" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.2 -->
-      <g transform="translate(318.392102 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m1723208b96" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 1.4 -->
-      <g transform="translate(392.719775 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m1723208b96" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 1.6 -->
-      <g transform="translate(467.047449 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_7">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
-     </g>
+    <g id="text_5">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="91.44" y="123.918828" transform="rotate(-0 91.44 123.918828)">fold change vs minP</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_7">
-      <defs>
-       <path id="mcf1628fae4" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_8">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="111.189238" transform="rotate(-0 28.24 111.189238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_9">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_8"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="70.601003" transform="rotate(-0 28.24 70.601003)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_10">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_10"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="30.012768" transform="rotate(-0 28.24 30.012768)">1</text>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#mcf1628fae4" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+    <g id="text_9">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="14.101211" y="67.32" transform="rotate(-90 14.101211 67.32)">power</text>
     </g>
    </g>
-   <g id="line2d_13">
-    <path d="M 68.055 46.76972 
-L 72.328841 48.552941 
-L 76.416863 55.726667 
-L 80.504885 58.113667 
-L 84.592907 54.43156 
-L 88.680929 59.951795 
-L 92.768951 60.355294 
-L 96.856973 55.241852 
-L 100.944995 55.643871 
-L 105.033017 57.36 
-L 109.121039 64.637358 
-L 113.209061 65.272941 
-L 117.297084 62.148 
-L 121.385106 65.2336 
-L 125.473128 64.789655 
-L 129.56115 70.729391 
-L 133.649172 70.324272 
-L 137.737194 68.223529 
-L 141.825216 75.6 
-L 145.913238 78.683607 
-L 150.00126 75.524685 
-L 154.089282 81.119223 
-L 158.177304 84.533725 
-L 162.265326 98.048148 
-L 166.353348 101.563577 
-L 170.44137 96.793333 
-L 174.529392 106.746549 
-L 178.617414 110.023529 
-L 182.705436 120.97265 
-L 186.793458 126.196174 
-L 190.88148 139.913333 
-L 194.969502 148.922569 
-L 199.057524 163.134118 
-L 203.145546 159.933333 
-L 207.233568 169.852258 
-L 211.32159 196.498462 
-L 215.409612 205.536434 
-L 219.497634 222.881391 
-L 223.585656 249.867216 
-L 227.673678 258.15907 
-L 231.7617 266.770265 
-L 235.849722 278.628571 
-L 239.937744 288.54592 
-L 244.025766 300.336471 
-L 248.113788 305.804 
-L 252.20181 305.769677 
-L 256.289832 305.949091 
-L 260.377855 295.577778 
-L 264.465877 295.032137 
-L 268.553899 282.928 
-L 272.641921 274.568 
-L 276.729943 253.614312 
-L 280.817965 249.430345 
-L 284.905987 224.788618 
-L 288.994009 208.8375 
-L 293.082031 186.242783 
-L 297.170053 174.449259 
-L 301.258075 153.95451 
-L 305.346097 164.7176 
-L 309.434119 146.981538 
-L 313.522141 135.284918 
-L 317.610163 125.295556 
-L 321.698185 127.713271 
-L 325.786207 111.757 
-L 329.874229 104.09088 
-L 333.962251 106.967863 
-L 338.050273 103.091538 
-L 342.138295 90.286486 
-L 346.226317 90.876 
-L 350.314339 85.107451 
-L 354.402361 84.826963 
-L 358.490383 78.357021 
-L 362.578405 76.645 
-L 366.666427 75.669667 
-L 370.754449 63.101386 
-L 374.842471 64.637358 
-L 378.930493 71.822519 
-L 383.018515 71.724 
-L 387.106537 66.970323 
-L 391.194559 64.285172 
-L 395.282581 63.762832 
-L 399.370603 65.48 
-L 403.458626 64.114087 
-L 407.546648 61.801942 
-L 411.63467 65.753778 
-L 415.722692 60.745455 
-L 419.810714 57.652844 
-L 423.898736 51.821967 
-L 427.986758 49.566667 
-L 432.07478 50.976 
-L 436.162802 51.342295 
-L 440.250824 56.989913 
-L 444.338846 49.675556 
-L 448.426868 53.879626 
-L 452.51489 45.348866 
-L 456.602912 50.745946 
-L 460.690934 44.268174 
-L 464.778956 46.418868 
-L 468.866978 51.519565 
-L 472.955 45.488519 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="m01ead28dd5" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#p35cf3a6bba)">
-     <use xlink:href="#m01ead28dd5" x="68.055" y="46.76972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="72.328841" y="48.552941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="76.416863" y="55.726667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="80.504885" y="58.113667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="84.592907" y="54.43156" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="88.680929" y="59.951795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="92.768951" y="60.355294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="96.856973" y="55.241852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="100.944995" y="55.643871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="105.033017" y="57.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="109.121039" y="64.637358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="113.209061" y="65.272941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="117.297084" y="62.148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="121.385106" y="65.2336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="125.473128" y="64.789655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="129.56115" y="70.729391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="133.649172" y="70.324272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="137.737194" y="68.223529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="141.825216" y="75.6" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="145.913238" y="78.683607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="150.00126" y="75.524685" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="154.089282" y="81.119223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="158.177304" y="84.533725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="162.265326" y="98.048148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="166.353348" y="101.563577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="170.44137" y="96.793333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="174.529392" y="106.746549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="178.617414" y="110.023529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="182.705436" y="120.97265" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="186.793458" y="126.196174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="190.88148" y="139.913333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="194.969502" y="148.922569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="199.057524" y="163.134118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="203.145546" y="159.933333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="207.233568" y="169.852258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="211.32159" y="196.498462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="215.409612" y="205.536434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="219.497634" y="222.881391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="223.585656" y="249.867216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="227.673678" y="258.15907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="231.7617" y="266.770265" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="235.849722" y="278.628571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="239.937744" y="288.54592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="244.025766" y="300.336471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="248.113788" y="305.804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="252.20181" y="305.769677" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="256.289832" y="305.949091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="260.377855" y="295.577778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="264.465877" y="295.032137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="268.553899" y="282.928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="272.641921" y="274.568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="276.729943" y="253.614312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="280.817965" y="249.430345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="284.905987" y="224.788618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="288.994009" y="208.8375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="293.082031" y="186.242783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="297.170053" y="174.449259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="301.258075" y="153.95451" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="305.346097" y="164.7176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="309.434119" y="146.981538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="313.522141" y="135.284918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="317.610163" y="125.295556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="321.698185" y="127.713271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="325.786207" y="111.757" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="329.874229" y="104.09088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="333.962251" y="106.967863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="338.050273" y="103.091538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="342.138295" y="90.286486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="346.226317" y="90.876" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="350.314339" y="85.107451" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="354.402361" y="84.826963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="358.490383" y="78.357021" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="362.578405" y="76.645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="366.666427" y="75.669667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="370.754449" y="63.101386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="374.842471" y="64.637358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="378.930493" y="71.822519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="383.018515" y="71.724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="387.106537" y="66.970323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="391.194559" y="64.285172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="395.282581" y="63.762832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="399.370603" y="65.48" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="403.458626" y="64.114087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="407.546648" y="61.801942" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="411.63467" y="65.753778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="415.722692" y="60.745455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="419.810714" y="57.652844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="423.898736" y="51.821967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="427.986758" y="49.566667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="432.07478" y="50.976" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="436.162802" y="51.342295" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="440.250824" y="56.989913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="444.338846" y="49.675556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="448.426868" y="53.879626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="452.51489" y="45.348866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="456.602912" y="50.745946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="460.690934" y="44.268174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="464.778956" y="46.418868" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="468.866978" y="51.519565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m01ead28dd5" x="472.955" y="45.488519" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="text_10">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #666666" transform="translate(121.207031 66.295671)">not</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #666666" transform="translate(111.301875 74.26864)">simulated</text>
    </g>
-   <g id="line2d_14">
-    <path d="M 68.055 36.714495 
-L 72.328841 43.334545 
-L 76.416863 43.406667 
-L 80.504885 50.798667 
-L 84.592907 44.419459 
-L 88.680929 49.740678 
-L 92.768951 50.798667 
-L 96.856973 45.841468 
-L 100.944995 49.351398 
-L 105.033017 49.228618 
-L 109.121039 54.7 
-L 113.209061 53.962353 
-L 117.297084 48.637117 
-L 121.385106 49.78432 
-L 125.473128 57.726897 
-L 129.56115 56.717931 
-L 133.649172 60.097476 
-L 137.737194 59.089 
-L 141.825216 64.637358 
-L 145.913238 68.754016 
-L 150.00126 67.616577 
-L 154.089282 68.204615 
-L 158.177304 70.324272 
-L 162.265326 80.167037 
-L 166.353348 90.620813 
-L 170.44137 85.486609 
-L 174.529392 88.539826 
-L 178.617414 97.501818 
-L 182.705436 106.967863 
-L 186.793458 107.368 
-L 190.88148 111.438957 
-L 194.969502 123.689174 
-L 199.057524 141.029091 
-L 203.145546 132.390345 
-L 207.233568 153.162222 
-L 211.32159 157.985299 
-L 215.409612 171.516641 
-L 219.497634 186.874483 
-L 223.585656 230.561649 
-L 227.673678 232.510769 
-L 231.7617 249.851478 
-L 235.849722 268.386667 
-L 239.937744 283.39616 
-L 244.025766 296.454754 
-L 248.113788 301.8425 
-L 252.20181 303.177778 
-L 256.289832 299.812459 
-L 260.377855 301.975686 
-L 264.465877 292.251525 
-L 268.553899 272.636552 
-L 272.641921 248.034766 
-L 276.729943 241.432 
-L 280.817965 215.004786 
-L 284.905987 195.290732 
-L 288.994009 184.8025 
-L 293.082031 172.490256 
-L 297.170053 152.143853 
-L 301.258075 139.666538 
-L 305.346097 143.638812 
-L 309.434119 122.673231 
-L 313.522141 113.457886 
-L 317.610163 104.990625 
-L 321.698185 111.594444 
-L 325.786207 102.491333 
-L 329.874229 89.57792 
-L 333.962251 87.345455 
-L 338.050273 85.085385 
-L 342.138295 77.69 
-L 346.226317 73.084602 
-L 350.314339 68.619806 
-L 354.402361 75.723852 
-L 358.490383 66.528511 
-L 362.578405 60.137699 
-L 366.666427 64.773115 
-L 370.754449 59.045545 
-L 374.842471 51.939623 
-L 378.930493 61.154412 
-L 383.018515 58.654054 
-L 387.106537 55.171935 
-L 391.194559 49.655172 
-L 395.282581 53.936696 
-L 399.370603 58.231379 
-L 403.458626 53.691034 
-L 407.546648 54.421333 
-L 411.63467 50.52 
-L 415.722692 50.105455 
-L 419.810714 54.96844 
-L 423.898736 49.228618 
-L 427.986758 41.866667 
-L 432.07478 42.310631 
-L 436.162802 47.98459 
-L 440.250824 47.830261 
-L 444.338846 49.4332 
-L 448.426868 44.03514 
-L 452.51489 41.663366 
-L 456.602912 43.365045 
-L 460.690934 39.179478 
-L 464.778956 42.394393 
-L 468.866978 47.703043 
-L 472.955 42.779259 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m0a4af889ee" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#p35cf3a6bba)">
-     <use xlink:href="#m0a4af889ee" x="68.055" y="36.714495" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="72.328841" y="43.334545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="76.416863" y="43.406667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="80.504885" y="50.798667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="84.592907" y="44.419459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="88.680929" y="49.740678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="92.768951" y="50.798667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="96.856973" y="45.841468" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="100.944995" y="49.351398" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="105.033017" y="49.228618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="109.121039" y="54.7" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="113.209061" y="53.962353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="117.297084" y="48.637117" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="121.385106" y="49.78432" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="125.473128" y="57.726897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="129.56115" y="56.717931" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="133.649172" y="60.097476" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="137.737194" y="59.089" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="141.825216" y="64.637358" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="145.913238" y="68.754016" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="150.00126" y="67.616577" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="154.089282" y="68.204615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="158.177304" y="70.324272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="162.265326" y="80.167037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="166.353348" y="90.620813" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="170.44137" y="85.486609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="174.529392" y="88.539826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="178.617414" y="97.501818" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="182.705436" y="106.967863" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="186.793458" y="107.368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="190.88148" y="111.438957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="194.969502" y="123.689174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="199.057524" y="141.029091" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="203.145546" y="132.390345" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="207.233568" y="153.162222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="211.32159" y="157.985299" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="215.409612" y="171.516641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="219.497634" y="186.874483" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="223.585656" y="230.561649" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="227.673678" y="232.510769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="231.7617" y="249.851478" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="235.849722" y="268.386667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="239.937744" y="283.39616" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="244.025766" y="296.454754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="248.113788" y="301.8425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="252.20181" y="303.177778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="256.289832" y="299.812459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="260.377855" y="301.975686" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="264.465877" y="292.251525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="268.553899" y="272.636552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="272.641921" y="248.034766" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="276.729943" y="241.432" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="280.817965" y="215.004786" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="284.905987" y="195.290732" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="288.994009" y="184.8025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="293.082031" y="172.490256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="297.170053" y="152.143853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="301.258075" y="139.666538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="305.346097" y="143.638812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="309.434119" y="122.673231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="313.522141" y="113.457886" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="317.610163" y="104.990625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="321.698185" y="111.594444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="325.786207" y="102.491333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="329.874229" y="89.57792" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="333.962251" y="87.345455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="338.050273" y="85.085385" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="342.138295" y="77.69" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="346.226317" y="73.084602" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="350.314339" y="68.619806" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="354.402361" y="75.723852" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="358.490383" y="66.528511" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="362.578405" y="60.137699" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="366.666427" y="64.773115" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="370.754449" y="59.045545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="374.842471" y="51.939623" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="378.930493" y="61.154412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="383.018515" y="58.654054" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="387.106537" y="55.171935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="391.194559" y="49.655172" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="395.282581" y="53.936696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="399.370603" y="58.231379" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="403.458626" y="53.691034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="407.546648" y="54.421333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="411.63467" y="50.52" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="415.722692" y="50.105455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="419.810714" y="54.96844" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="423.898736" y="49.228618" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="427.986758" y="41.866667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="432.07478" y="42.310631" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="436.162802" y="47.98459" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="440.250824" y="47.830261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="444.338846" y="49.4332" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="448.426868" y="44.03514" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="452.51489" y="41.663366" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="456.602912" y="43.365045" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="460.690934" y="39.179478" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="464.778956" y="42.394393" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="468.866978" y="47.703043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m0a4af889ee" x="472.955" y="42.779259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_15">
-    <path d="M 68.055 45.304587 
-L 72.328841 47.203636 
-L 76.416863 52.133333 
-L 80.504885 55.675333 
-L 84.592907 52.327568 
-L 88.680929 59.16339 
-L 92.768951 54.212333 
-L 96.856973 55.505321 
-L 100.944995 58.790108 
-L 105.033017 53.986341 
-L 109.121039 65.537037 
-L 113.209061 63.797647 
-L 117.297084 55.490811 
-L 121.385106 57.74304 
-L 125.473128 64.285172 
-L 129.56115 69.834483 
-L 133.649172 66.91534 
-L 137.737194 69.817667 
-L 141.825216 72.366415 
-L 145.913238 76.126614 
-L 150.00126 74.997477 
-L 154.089282 77.770385 
-L 158.177304 81.119223 
-L 162.265326 94.797037 
-L 166.353348 96.330081 
-L 170.44137 95.15513 
-L 174.529392 96.681739 
-L 178.617414 106.207273 
-L 182.705436 116.471111 
-L 186.793458 125.687304 
-L 190.88148 124.669565 
-L 194.969502 134.426789 
-L 199.057524 143.930909 
-L 203.145546 156.605517 
-L 207.233568 165.237778 
-L 211.32159 186.995214 
-L 215.409612 207.254046 
-L 219.497634 221.17931 
-L 223.585656 233.578144 
-L 227.673678 247.365846 
-L 231.7617 265.626435 
-L 235.849722 283.755556 
-L 239.937744 296.9728 
-L 244.025766 299.812459 
-L 248.113788 309.68 
-L 252.20181 305.964444 
-L 256.289832 306.527869 
-L 260.377855 301.401961 
-L 264.465877 298.202712 
-L 268.553899 288.78 
-L 272.641921 267.176822 
-L 276.729943 252.604 
-L 280.817965 234.011282 
-L 284.905987 223.837073 
-L 288.994009 210.405 
-L 293.082031 185.994872 
-L 297.170053 168.250275 
-L 301.258075 152.045769 
-L 305.346097 166.235644 
-L 309.434119 142.029846 
-L 313.522141 137.246504 
-L 317.610163 127.392812 
-L 321.698185 122.431481 
-L 325.786207 108.343333 
-L 329.874229 105.96352 
-L 333.962251 108.141818 
-L 338.050273 99.152692 
-L 342.138295 97.0225 
-L 346.226317 89.656637 
-L 350.314339 79.982913 
-L 354.402361 85.260444 
-L 358.490383 80.847234 
-L 362.578405 72.566726 
-L 366.666427 67.171475 
-L 370.754449 67.736634 
-L 374.842471 67.397736 
-L 378.930493 68.899706 
-L 383.018515 68.143784 
-L 387.106537 63.194839 
-L 391.194559 61.762759 
-L 395.282581 62.587478 
-L 399.370603 63.78069 
-L 403.458626 59.744828 
-L 407.546648 57.208 
-L 411.63467 54.378462 
-L 415.722692 52.523636 
-L 419.810714 59.263486 
-L 423.898736 51.60748 
-L 427.986758 41.353333 
-L 432.07478 43.892252 
-L 436.162802 51.821967 
-L 440.250824 51.901217 
-L 444.338846 50.0184 
-L 448.426868 46.222804 
-L 452.51489 43.401584 
-L 456.602912 41.256216 
-L 460.690934 39.179478 
-L 464.778956 42.394393 
-L 468.866978 48.33913 
-L 472.955 44.404815 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="m709140e92d" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#p35cf3a6bba)">
-     <use xlink:href="#m709140e92d" x="68.055" y="45.304587" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="72.328841" y="47.203636" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="76.416863" y="52.133333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="80.504885" y="55.675333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="84.592907" y="52.327568" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="88.680929" y="59.16339" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="92.768951" y="54.212333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="96.856973" y="55.505321" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="100.944995" y="58.790108" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="105.033017" y="53.986341" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="109.121039" y="65.537037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="113.209061" y="63.797647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="117.297084" y="55.490811" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="121.385106" y="57.74304" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="125.473128" y="64.285172" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="129.56115" y="69.834483" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="133.649172" y="66.91534" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="137.737194" y="69.817667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="141.825216" y="72.366415" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="145.913238" y="76.126614" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="150.00126" y="74.997477" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="154.089282" y="77.770385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="158.177304" y="81.119223" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="162.265326" y="94.797037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="166.353348" y="96.330081" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="170.44137" y="95.15513" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="174.529392" y="96.681739" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="178.617414" y="106.207273" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="182.705436" y="116.471111" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="186.793458" y="125.687304" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="190.88148" y="124.669565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="194.969502" y="134.426789" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="199.057524" y="143.930909" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="203.145546" y="156.605517" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="207.233568" y="165.237778" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="211.32159" y="186.995214" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="215.409612" y="207.254046" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="219.497634" y="221.17931" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="223.585656" y="233.578144" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="227.673678" y="247.365846" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="231.7617" y="265.626435" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="235.849722" y="283.755556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="239.937744" y="296.9728" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="244.025766" y="299.812459" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="248.113788" y="309.68" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="252.20181" y="305.964444" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="256.289832" y="306.527869" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="260.377855" y="301.401961" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="264.465877" y="298.202712" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="268.553899" y="288.78" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="272.641921" y="267.176822" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="276.729943" y="252.604" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="280.817965" y="234.011282" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="284.905987" y="223.837073" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="288.994009" y="210.405" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="293.082031" y="185.994872" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="297.170053" y="168.250275" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="301.258075" y="152.045769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="305.346097" y="166.235644" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="309.434119" y="142.029846" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="313.522141" y="137.246504" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="317.610163" y="127.392812" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="321.698185" y="122.431481" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="325.786207" y="108.343333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="329.874229" y="105.96352" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="333.962251" y="108.141818" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="338.050273" y="99.152692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="342.138295" y="97.0225" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="346.226317" y="89.656637" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="350.314339" y="79.982913" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="354.402361" y="85.260444" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="358.490383" y="80.847234" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="362.578405" y="72.566726" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="366.666427" y="67.171475" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="370.754449" y="67.736634" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="374.842471" y="67.397736" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="378.930493" y="68.899706" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="383.018515" y="68.143784" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="387.106537" y="63.194839" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="391.194559" y="61.762759" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="395.282581" y="62.587478" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="399.370603" y="63.78069" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="403.458626" y="59.744828" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="407.546648" y="57.208" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="411.63467" y="54.378462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="415.722692" y="52.523636" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="419.810714" y="59.263486" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="423.898736" y="51.60748" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="427.986758" y="41.353333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="432.07478" y="43.892252" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="436.162802" y="51.821967" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="440.250824" y="51.901217" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="444.338846" y="50.0184" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="448.426868" y="46.222804" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="452.51489" y="43.401584" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="456.602912" y="41.256216" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="460.690934" y="39.179478" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="464.778956" y="42.394393" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="468.866978" y="48.33913" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m709140e92d" x="472.955" y="44.404815" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_16">
-    <path d="M 68.055 27.587523 
-L 72.328841 28.825455 
-L 76.416863 29.546667 
-L 80.504885 27.390667 
-L 84.592907 30.184865 
-L 88.680929 28.415593 
-L 92.768951 30.316667 
-L 96.856973 29.198165 
-L 100.944995 30.473978 
-L 105.033017 32.576585 
-L 109.121039 32.484074 
-L 113.209061 32.324706 
-L 117.297084 32.293694 
-L 121.385106 28.71712 
-L 125.473128 30.484828 
-L 129.56115 30.484828 
-L 133.649172 33.96233 
-L 137.737194 32.755 
-L 141.825216 30.960755 
-L 145.913238 31.430236 
-L 150.00126 37.038559 
-L 154.089282 33.317692 
-L 158.177304 34.530485 
-L 162.265326 38.986296 
-L 166.353348 31.625041 
-L 170.44137 32.564174 
-L 174.529392 34.599652 
-L 178.617414 38.014545 
-L 182.705436 39.444786 
-L 186.793458 40.706087 
-L 190.88148 43.250435 
-L 194.969502 35.640734 
-L 199.057524 40.432727 
-L 203.145546 43.601379 
-L 207.233568 41.695556 
-L 211.32159 48.447863 
-L 215.409612 49.116031 
-L 219.497634 58.735862 
-L 223.585656 67.670928 
-L 227.673678 70.455385 
-L 231.7617 78.871304 
-L 235.849722 108.195556 
-L 239.937744 132.64864 
-L 244.025766 198.121967 
-L 248.113788 280.9425 
-L 252.20181 309.215556 
-L 256.289832 267.194754 
-L 260.377855 186.083137 
-L 264.465877 139.504407 
-L 268.553899 97.581034 
-L 272.641921 88.335327 
-L 276.729943 65.872 
-L 280.817965 58.451282 
-L 284.905987 52.559024 
-L 288.994009 47.9075 
-L 293.082031 45.446838 
-L 297.170053 44.767706 
-L 301.258075 38.381923 
-L 305.346097 43.401584 
-L 309.434119 37.144 
-L 313.522141 36.382764 
-L 317.610163 31.840625 
-L 321.698185 35.193333 
-L 325.786207 34.705667 
-L 329.874229 31.52608 
-L 333.962251 36.08 
-L 338.050273 35.568462 
-L 342.138295 33.8 
-L 346.226317 33.726018 
-L 350.314339 34.530485 
-L 354.402361 31.075259 
-L 358.490383 31.665532 
-L 362.578405 34.243894 
-L 366.666427 33.594426 
-L 370.754449 32.392871 
-L 374.842471 29.856604 
-L 378.930493 31.033824 
-L 383.018515 32.293694 
-L 387.106537 29.215484 
-L 391.194559 30.98931 
-L 395.282581 27.984348 
-L 399.370603 29.980345 
-L 403.458626 30.98931 
-L 407.546648 31.570667 
-L 411.63467 28.655385 
-L 415.722692 25.923636 
-L 419.810714 31.345688 
-L 423.898736 28.294634 
-L 427.986758 28.006667 
-L 432.07478 27.548829 
-L 436.162802 28.797705 
-L 440.250824 28.493217 
-L 444.338846 28.9512 
-L 448.426868 26.533832 
-L 452.51489 28.916436 
-L 456.602912 27.548829 
-L 460.690934 27.475478 
-L 464.778956 27.627664 
-L 468.866978 29.256522 
-L 472.955 30.316667 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-    <defs>
-     <path id="mf85e2c9af9" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#p35cf3a6bba)">
-     <use xlink:href="#mf85e2c9af9" x="68.055" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="72.328841" y="28.825455" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="76.416863" y="29.546667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="80.504885" y="27.390667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="84.592907" y="30.184865" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="88.680929" y="28.415593" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="92.768951" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="96.856973" y="29.198165" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="100.944995" y="30.473978" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="105.033017" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="109.121039" y="32.484074" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="113.209061" y="32.324706" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="117.297084" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="121.385106" y="28.71712" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="125.473128" y="30.484828" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="129.56115" y="30.484828" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="133.649172" y="33.96233" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="137.737194" y="32.755" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="141.825216" y="30.960755" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="145.913238" y="31.430236" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="150.00126" y="37.038559" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="154.089282" y="33.317692" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="158.177304" y="34.530485" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="162.265326" y="38.986296" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="166.353348" y="31.625041" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="170.44137" y="32.564174" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="174.529392" y="34.599652" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="178.617414" y="38.014545" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="182.705436" y="39.444786" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="186.793458" y="40.706087" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="190.88148" y="43.250435" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="194.969502" y="35.640734" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="199.057524" y="40.432727" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="203.145546" y="43.601379" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="207.233568" y="41.695556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="211.32159" y="48.447863" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="215.409612" y="49.116031" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="219.497634" y="58.735862" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="223.585656" y="67.670928" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="227.673678" y="70.455385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="231.7617" y="78.871304" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="235.849722" y="108.195556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="239.937744" y="132.64864" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="244.025766" y="198.121967" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="248.113788" y="280.9425" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="252.20181" y="309.215556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="256.289832" y="267.194754" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="260.377855" y="186.083137" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="264.465877" y="139.504407" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="268.553899" y="97.581034" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="272.641921" y="88.335327" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="276.729943" y="65.872" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="280.817965" y="58.451282" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="284.905987" y="52.559024" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="288.994009" y="47.9075" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="293.082031" y="45.446838" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="297.170053" y="44.767706" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="301.258075" y="38.381923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="305.346097" y="43.401584" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="309.434119" y="37.144" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="313.522141" y="36.382764" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="317.610163" y="31.840625" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="321.698185" y="35.193333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="325.786207" y="34.705667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="329.874229" y="31.52608" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="333.962251" y="36.08" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="338.050273" y="35.568462" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="342.138295" y="33.8" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="346.226317" y="33.726018" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="350.314339" y="34.530485" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="354.402361" y="31.075259" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="358.490383" y="31.665532" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="362.578405" y="34.243894" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="366.666427" y="33.594426" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="370.754449" y="32.392871" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="374.842471" y="29.856604" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="378.930493" y="31.033824" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="383.018515" y="32.293694" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="387.106537" y="29.215484" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="391.194559" y="30.98931" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="395.282581" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="399.370603" y="29.980345" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="403.458626" y="30.98931" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="407.546648" y="31.570667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="411.63467" y="28.655385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="415.722692" y="25.923636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="419.810714" y="31.345688" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="423.898736" y="28.294634" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="427.986758" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="432.07478" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="436.162802" y="28.797705" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="440.250824" y="28.493217" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="444.338846" y="28.9512" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="448.426868" y="26.533832" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="452.51489" y="28.916436" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="456.602912" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="460.690934" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="464.778956" y="27.627664" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="468.866978" y="29.256522" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mf85e2c9af9" x="472.955" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_17">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_18">
-    <path d="M 252.015991 318.04 
-L 252.015991 25.44 
-" clip-path="url(#p35cf3a6bba)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_13">
+    <path d="M 32.2596 34.53252 
+L 36.36 36.919412 
+L 40.44 36.417232 
+L 44.52 38.20654 
+L 48.6 40.324506 
+L 52.68 43.072941 
+L 56.76 49.134508 
+L 60.84 60.435814 
+L 64.92 78.610909 
+L 69 100.232318 
+L 73.08 100.040189 
+L 77.16 75.146244 
+L 81.24 54.253207 
+L 85.32 43.5609 
+L 89.4 38.859037 
+L 93.48 35.978893 
+L 97.56 33.868445 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_15">
-    <!-- Cohen - - deflated (minP power) -->
-    <g transform="translate(176.42125 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-43"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(69.824219 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(131.005859 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(194.384766 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(255.908203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(319.287109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(351.074219 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(387.158203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(423.242188 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(455.029297 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(518.505859 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(580.029297 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(615.234375 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(643.017578 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(704.296875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(743.505859 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(805.029297 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(868.505859 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(900.292969 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(939.306641 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1036.71875 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1064.501953 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1127.880859 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1188.183594 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1219.970703 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1283.447266 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1344.628906 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1426.416016 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1487.939453 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1529.052734 0)"/>
-    </g>
+   <g id="line2d_14">
+    <path d="M 32.2596 32.182185 
+L 36.36 34.174281 
+L 40.44 34.061348 
+L 44.52 34.823777 
+L 48.6 37.222923 
+L 52.68 39.664616 
+L 56.76 45.641434 
+L 60.84 53.818039 
+L 64.92 70.731853 
+L 69 97.615241 
+L 73.08 97.91865 
+L 77.16 68.678442 
+L 81.24 49.292022 
+L 85.32 39.872993 
+L 89.4 35.872658 
+L 93.48 33.952198 
+L 97.56 32.562075 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 53.41 314.04 
-L 126.65 314.04 
-Q 128.25 314.04 128.25 312.44 
-L 128.25 252.591875 
-Q 128.25 250.991875 126.65 250.991875 
-L 53.41 250.991875 
-Q 51.81 250.991875 51.81 252.591875 
-L 51.81 312.44 
-Q 51.81 314.04 53.41 314.04 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_16">
-     <!-- Cell type -->
-     <g transform="translate(67.924531 261.790313) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_19">
-     <path d="M 55.01 271.14875 
-L 63.01 271.14875 
-L 71.01 271.14875 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m01ead28dd5" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Bipolar -->
-     <g transform="translate(77.41 273.94875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-42"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(68.603516 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(96.386719 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(159.863281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(221.044922 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(248.828125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(310.107422 0)"/>
-     </g>
-    </g>
-    <g id="line2d_20">
-     <path d="M 55.01 282.89125 
-L 63.01 282.89125 
-L 71.01 282.89125 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m0a4af889ee" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_18">
-     <!-- Interneuron -->
-     <g transform="translate(77.41 285.69125) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-49" d="M 628 4666 
-L 1259 4666 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-49"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(29.492188 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(92.871094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(132.080078 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(193.603516 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(232.966797 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(296.345703 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(357.869141 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(421.248047 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(460.111328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(521.292969 0)"/>
-     </g>
-    </g>
-    <g id="line2d_21">
-     <path d="M 55.01 294.63375 
-L 63.01 294.63375 
-L 71.01 294.63375 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m709140e92d" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_19">
-     <!-- Mueller Glia -->
-     <g transform="translate(77.41 297.43375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(149.658203 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(211.181641 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(238.964844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(266.748047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(328.271484 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(369.384766 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(401.171875 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(478.662109 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(506.445312 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(534.228516 0)"/>
-     </g>
-    </g>
-    <g id="line2d_22">
-     <path d="M 55.01 306.37625 
-L 63.01 306.37625 
-L 71.01 306.37625 
-" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mf85e2c9af9" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- Rod -->
-     <g transform="translate(77.41 309.17625) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-52"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(64.982422 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(126.164062 0)"/>
-     </g>
-    </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 33.900205 
+L 36.36 36.103227 
+L 40.44 36.273456 
+L 44.52 37.045449 
+L 48.6 40.003174 
+L 52.68 42.291379 
+L 56.76 47.865447 
+L 60.84 57.818039 
+L 64.92 76.786519 
+L 69 100.716365 
+L 73.08 100.380559 
+L 77.16 74.165848 
+L 81.24 53.94602 
+L 85.32 43.256846 
+L 89.4 38.361636 
+L 93.48 34.680096 
+L 97.56 32.722028 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
+   <g id="text_11">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="97.6" y="49.337417" transform="rotate(-0 97.6 49.337417)">80%</text>
+   </g>
+   <g id="line2d_16">
+    <path d="M 32.2596 28.359589 
+L 36.36 28.628561 
+L 40.44 29.123607 
+L 44.52 29.115789 
+L 48.6 29.328382 
+L 52.68 29.980406 
+L 56.76 30.128944 
+L 60.84 31.857255 
+L 64.92 35.209518 
+L 69 66.216365 
+L 73.08 64.006403 
+L 77.16 33.732333 
+L 81.24 30.139028 
+L 85.32 29.685436 
+L 89.4 28.942563 
+L 93.48 28.44549 
+L 97.56 28.303309 
+" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+  </g>
+  <g id="line2d_17">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_12">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Zhao et al.</text>
+  </g>
+  <g id="text_13">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter withheld</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p35cf3a6bba">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="pc69d595cd2">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:22.831861</dc:date>
+    <dc:date>2026-08-16T20:37:59.370159</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,2055 +21,248 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
+   <g id="patch_3">
+    <path d="M 99.6 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 99.6 25.92 
+z
+" clip-path="url(#p0b1cd83206)" style="fill: #c9c9c9; opacity: 0.22"/>
+   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="mcde95ff51b" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mcde95ff51b" x="103.360645" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.6 -->
-      <g transform="translate(95.409082 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#mcde95ff51b" x="177.688318" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.8 -->
-      <g transform="translate(169.736756 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#mcde95ff51b" x="252.015991" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(244.064429 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#mcde95ff51b" x="326.343665" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.2 -->
-      <g transform="translate(318.392102 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#mcde95ff51b" x="400.671338" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 1.4 -->
-      <g transform="translate(392.719775 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#mcde95ff51b" x="474.999011" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 1.6 -->
-      <g transform="translate(467.047449 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_7">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
-     </g>
+    <g id="text_5">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="91.44" y="123.918828" transform="rotate(-0 91.44 123.918828)">fold change vs minP</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_7">
-      <defs>
-       <path id="m9ade53a94b" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_8">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
+     <g id="line2d_6"/>
     </g>
     <g id="ytick_2">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_9">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
+     <g id="line2d_8"/>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_10">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#m9ade53a94b" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+     <g id="line2d_10"/>
     </g>
    </g>
-   <g id="line2d_13">
-    <path d="M 68.055 30.362243 
-L 72.328841 34.783529 
-L 76.416863 36.733333 
-L 80.504885 39.094667 
-L 84.592907 37.251376 
-L 88.680929 36.443761 
-L 92.768951 40.684706 
-L 96.856973 35.735185 
-L 100.944995 36.137204 
-L 105.033017 39.949091 
-L 109.121039 40.898113 
-L 113.209061 40.192941 
-L 117.297084 40.336 
-L 121.385106 38.08032 
-L 125.473128 41.583448 
-L 129.56115 44.268174 
-L 133.649172 46.461748 
-L 137.737194 49.536471 
-L 141.825216 42.717333 
-L 145.913238 48.943934 
-L 150.00126 52.327568 
-L 154.089282 51.575146 
-L 158.177304 54.126275 
-L 162.265326 62.285926 
-L 166.353348 61.122927 
-L 170.44137 65.48 
-L 174.529392 62.209204 
-L 178.617414 64.781176 
-L 182.705436 73.956581 
-L 186.793458 74.800348 
-L 190.88148 80.88 
-L 194.969502 85.570642 
-L 199.057524 97.729412 
-L 203.145546 99.873333 
-L 207.233568 108.500645 
-L 211.32159 116.471111 
-L 215.409612 130.685271 
-L 219.497634 149.604174 
-L 223.585656 184.107629 
-L 227.673678 188.297984 
-L 231.7617 218.089912 
-L 235.849722 245.785714 
-L 239.937744 263.73344 
-L 244.025766 293.943529 
-L 248.113788 305.804 
-L 252.20181 299.162581 
-L 256.289832 302.08 
-L 260.377855 282.573333 
-L 264.465877 269.523419 
-L 268.553899 242.218435 
-L 272.641921 219.392 
-L 276.729943 189.188624 
-L 280.817965 173.757931 
-L 284.905987 147.237724 
-L 288.994009 135.165 
-L 293.082031 127.722783 
-L 297.170053 116.471111 
-L 301.258075 99.450588 
-L 305.346097 106.7828 
-L 309.434119 91.162462 
-L 313.522141 88.756721 
-L 317.610163 85.353333 
-L 321.698185 82.866168 
-L 325.786207 76.157333 
-L 329.874229 62.8928 
-L 333.962251 68.454701 
-L 338.050273 68.204615 
-L 342.138295 62.344505 
-L 346.226317 61.084 
-L 350.314339 58.142353 
-L 354.402361 57.084148 
-L 358.490383 64.038298 
-L 362.578405 47.385 
-L 366.666427 53.724667 
-L 370.754449 48.036832 
-L 374.842471 44.210566 
-L 378.930493 52.749333 
-L 383.018515 50.444 
-L 387.106537 44.789355 
-L 391.194559 43.601379 
-L 395.282581 39.940531 
-L 399.370603 48.54 
-L 403.458626 44.777043 
-L 407.546648 45.893592 
-L 411.63467 44.946667 
-L 415.722692 43.818182 
-L 419.810714 42.620183 
-L 423.898736 39.830164 
-L 427.986758 35.706667 
-L 432.07478 36.08 
-L 436.162802 39.350492 
-L 440.250824 40.197217 
-L 444.338846 38.444444 
-L 448.426868 36.925234 
-L 452.51489 37.505979 
-L 456.602912 39.674595 
-L 460.690934 33.581913 
-L 464.778956 37.58566 
-L 468.866978 41.342174 
-L 472.955 37.902593 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="m5a2f7c6181" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#pd0e5ecd757)">
-     <use xlink:href="#m5a2f7c6181" x="68.055" y="30.362243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="72.328841" y="34.783529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="76.416863" y="36.733333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="80.504885" y="39.094667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="84.592907" y="37.251376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="88.680929" y="36.443761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="92.768951" y="40.684706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="96.856973" y="35.735185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="100.944995" y="36.137204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="105.033017" y="39.949091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="109.121039" y="40.898113" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="113.209061" y="40.192941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="117.297084" y="40.336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="121.385106" y="38.08032" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="125.473128" y="41.583448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="129.56115" y="44.268174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="133.649172" y="46.461748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="137.737194" y="49.536471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="141.825216" y="42.717333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="145.913238" y="48.943934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="150.00126" y="52.327568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="154.089282" y="51.575146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="158.177304" y="54.126275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="162.265326" y="62.285926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="166.353348" y="61.122927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="170.44137" y="65.48" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="174.529392" y="62.209204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="178.617414" y="64.781176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="182.705436" y="73.956581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="186.793458" y="74.800348" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="190.88148" y="80.88" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="194.969502" y="85.570642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="199.057524" y="97.729412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="203.145546" y="99.873333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="207.233568" y="108.500645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="211.32159" y="116.471111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="215.409612" y="130.685271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="219.497634" y="149.604174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="223.585656" y="184.107629" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="227.673678" y="188.297984" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="231.7617" y="218.089912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="235.849722" y="245.785714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="239.937744" y="263.73344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="244.025766" y="293.943529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="248.113788" y="305.804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="252.20181" y="299.162581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="256.289832" y="302.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="260.377855" y="282.573333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="264.465877" y="269.523419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="268.553899" y="242.218435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="272.641921" y="219.392" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="276.729943" y="189.188624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="280.817965" y="173.757931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="284.905987" y="147.237724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="288.994009" y="135.165" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="293.082031" y="127.722783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="297.170053" y="116.471111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="301.258075" y="99.450588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="305.346097" y="106.7828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="309.434119" y="91.162462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="313.522141" y="88.756721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="317.610163" y="85.353333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="321.698185" y="82.866168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="325.786207" y="76.157333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="329.874229" y="62.8928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="333.962251" y="68.454701" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="338.050273" y="68.204615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="342.138295" y="62.344505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="346.226317" y="61.084" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="350.314339" y="58.142353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="354.402361" y="57.084148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="358.490383" y="64.038298" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="362.578405" y="47.385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="366.666427" y="53.724667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="370.754449" y="48.036832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="374.842471" y="44.210566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="378.930493" y="52.749333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="383.018515" y="50.444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="387.106537" y="44.789355" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="391.194559" y="43.601379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="395.282581" y="39.940531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="399.370603" y="48.54" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="403.458626" y="44.777043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="407.546648" y="45.893592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="411.63467" y="44.946667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="415.722692" y="43.818182" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="419.810714" y="42.620183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="423.898736" y="39.830164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="427.986758" y="35.706667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="432.07478" y="36.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="436.162802" y="39.350492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="440.250824" y="40.197217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="444.338846" y="38.444444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="448.426868" y="36.925234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="452.51489" y="37.505979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="456.602912" y="39.674595" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="460.690934" y="33.581913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="464.778956" y="37.58566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="468.866978" y="41.342174" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5a2f7c6181" x="472.955" y="37.902593" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="text_6">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #666666" transform="translate(121.207031 66.295671)">not</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #666666" transform="translate(111.301875 74.26864)">simulated</text>
    </g>
-   <g id="line2d_14">
-    <path d="M 68.055 29.735046 
-L 72.328841 33.178182 
-L 76.416863 34.166667 
-L 80.504885 34.705667 
-L 84.592907 34.92973 
-L 88.680929 36.350508 
-L 92.768951 37.144 
-L 96.856973 32.95633 
-L 100.944995 35.507957 
-L 105.033017 36.382764 
-L 109.121039 38.444444 
-L 113.209061 37.734118 
-L 117.297084 37.565766 
-L 121.385106 35.27136 
-L 125.473128 38.556552 
-L 129.56115 38.052069 
-L 133.649172 45.325437 
-L 137.737194 38.119333 
-L 141.825216 39.241887 
-L 145.913238 45.253858 
-L 150.00126 46.528288 
-L 154.089282 44.008846 
-L 158.177304 52.143301 
-L 162.265326 54.158148 
-L 166.353348 55.889431 
-L 170.44137 57.498783 
-L 174.529392 58.007652 
-L 178.617414 55.909091 
-L 182.705436 59.951795 
-L 186.793458 66.149565 
-L 190.88148 71.74713 
-L 194.969502 66.779817 
-L 199.057524 80.574545 
-L 203.145546 82.951034 
-L 207.233568 97.893333 
-L 211.32159 96.964444 
-L 215.409612 112.996641 
-L 219.497634 127.345517 
-L 223.585656 146.703093 
-L 227.673678 163.637231 
-L 231.7617 185.225043 
-L 235.849722 227.6 
-L 239.937744 253.43392 
-L 244.025766 281.105246 
-L 248.113788 295.05 
-L 252.20181 307.357778 
-L 256.289832 303.649836 
-L 260.377855 284.190196 
-L 264.465877 257.536271 
-L 268.553899 224.206207 
-L 272.641921 188.420935 
-L 276.729943 168.548 
-L 280.817965 140.979487 
-L 284.905987 123.449106 
-L 288.994009 113.7425 
-L 293.082031 94.963761 
-L 297.170053 94.697615 
-L 301.258075 76.082308 
-L 305.346097 87.436436 
-L 309.434119 71.805846 
-L 313.522141 66.356423 
-L 317.610163 61.100625 
-L 321.698185 56.867407 
-L 325.786207 56.650667 
-L 329.874229 54.46592 
-L 333.962251 55.425455 
-L 338.050273 56.950769 
-L 342.138295 47.9075 
-L 346.226317 48.744425 
-L 350.314339 47.598058 
-L 354.402361 49.714963 
-L 358.490383 47.851915 
-L 362.578405 42.012035 
-L 366.666427 46.065902 
-L 370.754449 43.401584 
-L 374.842471 39.241887 
-L 378.930493 40.500294 
-L 383.018515 45.473874 
-L 387.106537 40.541935 
-L 391.194559 39.565517 
-L 395.282581 35.617391 
-L 399.370603 42.592414 
-L 403.458626 38.556552 
-L 407.546648 37.144 
-L 411.63467 38.944615 
-L 415.722692 34.145455 
-L 419.810714 39.398899 
-L 423.898736 37.334309 
-L 427.986758 31.6 
-L 432.07478 33.875315 
-L 436.162802 39.350492 
-L 440.250824 38.670609 
-L 444.338846 38.3144 
-L 448.426868 34.73757 
-L 452.51489 36.448713 
-L 456.602912 33.875315 
-L 460.690934 33.073043 
-L 464.778956 36.378318 
-L 468.866978 38.161739 
-L 472.955 36.818889 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m729b46263b" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#pd0e5ecd757)">
-     <use xlink:href="#m729b46263b" x="68.055" y="29.735046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="72.328841" y="33.178182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="76.416863" y="34.166667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="80.504885" y="34.705667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="84.592907" y="34.92973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="88.680929" y="36.350508" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="92.768951" y="37.144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="96.856973" y="32.95633" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="100.944995" y="35.507957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="105.033017" y="36.382764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="109.121039" y="38.444444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="113.209061" y="37.734118" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="117.297084" y="37.565766" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="121.385106" y="35.27136" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="125.473128" y="38.556552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="129.56115" y="38.052069" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="133.649172" y="45.325437" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="137.737194" y="38.119333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="141.825216" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="145.913238" y="45.253858" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="150.00126" y="46.528288" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="154.089282" y="44.008846" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="158.177304" y="52.143301" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="162.265326" y="54.158148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="166.353348" y="55.889431" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="170.44137" y="57.498783" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="174.529392" y="58.007652" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="178.617414" y="55.909091" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="182.705436" y="59.951795" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="186.793458" y="66.149565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="190.88148" y="71.74713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="194.969502" y="66.779817" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="199.057524" y="80.574545" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="203.145546" y="82.951034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="207.233568" y="97.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="211.32159" y="96.964444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="215.409612" y="112.996641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="219.497634" y="127.345517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="223.585656" y="146.703093" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="227.673678" y="163.637231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="231.7617" y="185.225043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="235.849722" y="227.6" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="239.937744" y="253.43392" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="244.025766" y="281.105246" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="248.113788" y="295.05" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="252.20181" y="307.357778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="256.289832" y="303.649836" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="260.377855" y="284.190196" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="264.465877" y="257.536271" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="268.553899" y="224.206207" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="272.641921" y="188.420935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="276.729943" y="168.548" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="280.817965" y="140.979487" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="284.905987" y="123.449106" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="288.994009" y="113.7425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="293.082031" y="94.963761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="297.170053" y="94.697615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="301.258075" y="76.082308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="305.346097" y="87.436436" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="309.434119" y="71.805846" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="313.522141" y="66.356423" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="317.610163" y="61.100625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="321.698185" y="56.867407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="325.786207" y="56.650667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="329.874229" y="54.46592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="333.962251" y="55.425455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="338.050273" y="56.950769" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="342.138295" y="47.9075" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="346.226317" y="48.744425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="350.314339" y="47.598058" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="354.402361" y="49.714963" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="358.490383" y="47.851915" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="362.578405" y="42.012035" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="366.666427" y="46.065902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="370.754449" y="43.401584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="374.842471" y="39.241887" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="378.930493" y="40.500294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="383.018515" y="45.473874" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="387.106537" y="40.541935" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="391.194559" y="39.565517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="395.282581" y="35.617391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="399.370603" y="42.592414" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="403.458626" y="38.556552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="407.546648" y="37.144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="411.63467" y="38.944615" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="415.722692" y="34.145455" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="419.810714" y="39.398899" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="423.898736" y="37.334309" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="427.986758" y="31.6" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="432.07478" y="33.875315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="436.162802" y="39.350492" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="440.250824" y="38.670609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="444.338846" y="38.3144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="448.426868" y="34.73757" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="452.51489" y="36.448713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="456.602912" y="33.875315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="460.690934" y="33.073043" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="464.778956" y="36.378318" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="468.866978" y="38.161739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m729b46263b" x="472.955" y="36.818889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_15">
-    <path d="M 68.055 32.41945 
-L 72.328841 33.661818 
-L 76.416863 39.3 
-L 80.504885 37.631667 
-L 84.592907 36.511351 
-L 88.680929 38.334237 
-L 92.768951 39.094667 
-L 96.856973 39.398899 
-L 100.944995 40.541935 
-L 105.033017 39.713171 
-L 109.121039 42.779259 
-L 113.209061 42.651765 
-L 117.297084 40.201802 
-L 121.385106 40.42112 
-L 125.473128 44.105862 
-L 129.56115 42.592414 
-L 133.649172 45.893592 
-L 137.737194 42.508333 
-L 141.825216 48.075094 
-L 145.913238 51.704882 
-L 150.00126 50.218739 
-L 154.089282 49.073077 
-L 158.177304 53.847767 
-L 162.265326 55.241852 
-L 166.353348 60.171382 
-L 170.44137 60.04313 
-L 174.529392 62.587478 
-L 178.617414 65.098182 
-L 182.705436 70.955556 
-L 186.793458 71.238261 
-L 190.88148 78.362435 
-L 194.969502 82.886239 
-L 199.057524 86.861818 
-L 203.145546 92.536207 
-L 207.233568 101.608889 
-L 211.32159 110.46906 
-L 215.409612 124.611298 
-L 219.497634 143.993448 
-L 223.585656 172.644948 
-L 227.673678 182.543692 
-L 231.7617 205.070957 
-L 235.849722 230.555556 
-L 239.937744 261.39264 
-L 244.025766 285.422295 
-L 248.113788 300.7975 
-L 252.20181 303.177778 
-L 256.289832 302.21082 
-L 260.377855 287.058824 
-L 264.465877 274.397966 
-L 268.553899 248.925862 
-L 272.641921 221.782804 
-L 276.729943 190.892 
-L 280.817965 165.487863 
-L 284.905987 146.761951 
-L 288.994009 140.39 
-L 293.082031 129.475556 
-L 297.170053 108.119633 
-L 301.258075 99.715385 
-L 305.346097 106.556832 
-L 309.434119 87.561231 
-L 313.522141 90.145041 
-L 317.610163 76.645 
-L 321.698185 80.708889 
-L 325.786207 67.867 
-L 329.874229 65.2336 
-L 333.962251 68 
-L 338.050273 67.079231 
-L 342.138295 56.79 
-L 346.226317 55.99469 
-L 350.314339 53.847767 
-L 354.402361 50.581926 
-L 358.490383 54.7 
-L 362.578405 47.708673 
-L 366.666427 52.781311 
-L 370.754449 43.98099 
-L 374.842471 42.002264 
-L 378.930493 42.651765 
-L 383.018515 49.164324 
-L 387.106537 42.429677 
-L 391.194559 41.078966 
-L 395.282581 38.161739 
-L 399.370603 45.114828 
-L 403.458626 43.096897 
-L 407.546648 42.16 
-L 411.63467 38.301538 
-L 415.722692 36.563636 
-L 419.810714 45.304587 
-L 423.898736 39.237398 
-L 427.986758 35.193333 
-L 432.07478 34.92973 
-L 436.162802 42.228525 
-L 440.250824 37.65287 
-L 444.338846 37.7292 
-L 448.426868 36.378318 
-L 452.51489 34.710495 
-L 456.602912 37.565766 
-L 460.690934 32.055304 
-L 464.778956 34.190654 
-L 468.866978 37.525652 
-L 472.955 36.818889 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="m8f8606c64b" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#pd0e5ecd757)">
-     <use xlink:href="#m8f8606c64b" x="68.055" y="32.41945" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="72.328841" y="33.661818" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="76.416863" y="39.3" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="80.504885" y="37.631667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="84.592907" y="36.511351" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="88.680929" y="38.334237" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="92.768951" y="39.094667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="96.856973" y="39.398899" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="100.944995" y="40.541935" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="105.033017" y="39.713171" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="109.121039" y="42.779259" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="113.209061" y="42.651765" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="117.297084" y="40.201802" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="121.385106" y="40.42112" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="125.473128" y="44.105862" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="129.56115" y="42.592414" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="133.649172" y="45.893592" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="137.737194" y="42.508333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="141.825216" y="48.075094" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="145.913238" y="51.704882" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="150.00126" y="50.218739" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="154.089282" y="49.073077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="158.177304" y="53.847767" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="162.265326" y="55.241852" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="166.353348" y="60.171382" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="170.44137" y="60.04313" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="174.529392" y="62.587478" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="178.617414" y="65.098182" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="182.705436" y="70.955556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="186.793458" y="71.238261" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="190.88148" y="78.362435" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="194.969502" y="82.886239" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="199.057524" y="86.861818" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="203.145546" y="92.536207" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="207.233568" y="101.608889" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="211.32159" y="110.46906" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="215.409612" y="124.611298" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="219.497634" y="143.993448" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="223.585656" y="172.644948" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="227.673678" y="182.543692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="231.7617" y="205.070957" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="235.849722" y="230.555556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="239.937744" y="261.39264" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="244.025766" y="285.422295" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="248.113788" y="300.7975" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="252.20181" y="303.177778" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="256.289832" y="302.21082" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="260.377855" y="287.058824" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="264.465877" y="274.397966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="268.553899" y="248.925862" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="272.641921" y="221.782804" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="276.729943" y="190.892" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="280.817965" y="165.487863" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="284.905987" y="146.761951" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="288.994009" y="140.39" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="293.082031" y="129.475556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="297.170053" y="108.119633" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="301.258075" y="99.715385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="305.346097" y="106.556832" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="309.434119" y="87.561231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="313.522141" y="90.145041" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="317.610163" y="76.645" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="321.698185" y="80.708889" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="325.786207" y="67.867" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="329.874229" y="65.2336" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="333.962251" y="68" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="338.050273" y="67.079231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="342.138295" y="56.79" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="346.226317" y="55.99469" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="350.314339" y="53.847767" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="354.402361" y="50.581926" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="358.490383" y="54.7" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="362.578405" y="47.708673" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="366.666427" y="52.781311" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="370.754449" y="43.98099" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="374.842471" y="42.002264" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="378.930493" y="42.651765" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="383.018515" y="49.164324" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="387.106537" y="42.429677" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="391.194559" y="41.078966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="395.282581" y="38.161739" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="399.370603" y="45.114828" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="403.458626" y="43.096897" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="407.546648" y="42.16" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="411.63467" y="38.301538" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="415.722692" y="36.563636" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="419.810714" y="45.304587" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="423.898736" y="39.237398" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="427.986758" y="35.193333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="432.07478" y="34.92973" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="436.162802" y="42.228525" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="440.250824" y="37.65287" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="444.338846" y="37.7292" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="448.426868" y="36.378318" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="452.51489" y="34.710495" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="456.602912" y="37.565766" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="460.690934" y="32.055304" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="464.778956" y="34.190654" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="468.866978" y="37.525652" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m8f8606c64b" x="472.955" y="36.818889" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_16">
-    <path d="M 68.055 27.587523 
-L 72.328841 28.341818 
-L 76.416863 28.006667 
-L 80.504885 26.415333 
-L 84.592907 27.548829 
-L 88.680929 26.927797 
-L 92.768951 28.853667 
-L 96.856973 28.124404 
-L 100.944995 27.956989 
-L 105.033017 30.197724 
-L 109.121039 28.691111 
-L 113.209061 28.882353 
-L 117.297084 28.076036 
-L 121.385106 27.7808 
-L 125.473128 28.466897 
-L 129.56115 28.466897 
-L 133.649172 28.848932 
-L 137.737194 27.878333 
-L 141.825216 27.648302 
-L 145.913238 29.126299 
-L 150.00126 31.239279 
-L 154.089282 28.253462 
-L 158.177304 33.394175 
-L 162.265326 32.484074 
-L 166.353348 27.343089 
-L 170.44137 29.002087 
-L 174.529392 29.510957 
-L 178.617414 33.178182 
-L 182.705436 31.442051 
-L 186.793458 31.546435 
-L 190.88148 36.126261 
-L 194.969502 33.493211 
-L 199.057524 31.243636 
-L 203.145546 35.025172 
-L 207.233568 34.264444 
-L 211.32159 36.943932 
-L 215.409612 37.948092 
-L 219.497634 38.556552 
-L 223.585656 43.538969 
-L 227.673678 46.597231 
-L 231.7617 54.445565 
-L 235.849722 65.635556 
-L 239.937744 76.9376 
-L 244.025766 134.325574 
-L 248.113788 229.215 
-L 252.20181 297.14 
-L 256.289832 225.942951 
-L 260.377855 112.646275 
-L 264.465877 82.472203 
-L 268.553899 60.24931 
-L 272.641921 60.989533 
-L 276.729943 39.804 
-L 280.817965 40.445128 
-L 284.905987 36.858537 
-L 288.994009 36.935 
-L 293.082031 37.444103 
-L 297.170053 36.177615 
-L 301.258075 33.880385 
-L 305.346097 39.345743 
-L 309.434119 33.992923 
-L 313.522141 32.576585 
-L 317.610163 30.011875 
-L 321.698185 31.40037 
-L 325.786207 30.316667 
-L 329.874229 29.18528 
-L 333.962251 31.727273 
-L 338.050273 31.629615 
-L 342.138295 32.2325 
-L 346.226317 32.172389 
-L 350.314339 29.985243 
-L 354.402361 28.907852 
-L 358.490383 27.930213 
-L 362.578405 28.547257 
-L 366.666427 30.236721 
-L 370.754449 28.33703 
-L 374.842471 27.648302 
-L 378.930493 28.021765 
-L 383.018515 27.548829 
-L 387.106537 26.855806 
-L 391.194559 27.962414 
-L 395.282581 26.966609 
-L 399.370603 27.962414 
-L 403.458626 28.971379 
-L 407.546648 29.341333 
-L 411.63467 28.012308 
-L 415.722692 25.923636 
-L 419.810714 28.124404 
-L 423.898736 28.294634 
-L 427.986758 26.466667 
-L 432.07478 27.021622 
-L 436.162802 27.358689 
-L 440.250824 27.475478 
-L 444.338846 26.6104 
-L 448.426868 25.986916 
-L 452.51489 27.757624 
-L 456.602912 27.021622 
-L 460.690934 26.966609 
-L 464.778956 25.986916 
-L 468.866978 27.984348 
-L 472.955 29.232963 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-    <defs>
-     <path id="m765811db94" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#pd0e5ecd757)">
-     <use xlink:href="#m765811db94" x="68.055" y="27.587523" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="72.328841" y="28.341818" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="76.416863" y="28.006667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="80.504885" y="26.415333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="84.592907" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="88.680929" y="26.927797" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="92.768951" y="28.853667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="96.856973" y="28.124404" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="100.944995" y="27.956989" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="105.033017" y="30.197724" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="109.121039" y="28.691111" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="113.209061" y="28.882353" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="117.297084" y="28.076036" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="121.385106" y="27.7808" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="125.473128" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="129.56115" y="28.466897" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="133.649172" y="28.848932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="137.737194" y="27.878333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="141.825216" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="145.913238" y="29.126299" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="150.00126" y="31.239279" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="154.089282" y="28.253462" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="158.177304" y="33.394175" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="162.265326" y="32.484074" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="166.353348" y="27.343089" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="170.44137" y="29.002087" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="174.529392" y="29.510957" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="178.617414" y="33.178182" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="182.705436" y="31.442051" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="186.793458" y="31.546435" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="190.88148" y="36.126261" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="194.969502" y="33.493211" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="199.057524" y="31.243636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="203.145546" y="35.025172" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="207.233568" y="34.264444" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="211.32159" y="36.943932" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="215.409612" y="37.948092" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="219.497634" y="38.556552" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="223.585656" y="43.538969" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="227.673678" y="46.597231" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="231.7617" y="54.445565" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="235.849722" y="65.635556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="239.937744" y="76.9376" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="244.025766" y="134.325574" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="248.113788" y="229.215" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="252.20181" y="297.14" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="256.289832" y="225.942951" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="260.377855" y="112.646275" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="264.465877" y="82.472203" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="268.553899" y="60.24931" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="272.641921" y="60.989533" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="276.729943" y="39.804" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="280.817965" y="40.445128" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="284.905987" y="36.858537" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="288.994009" y="36.935" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="293.082031" y="37.444103" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="297.170053" y="36.177615" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="301.258075" y="33.880385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="305.346097" y="39.345743" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="309.434119" y="33.992923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="313.522141" y="32.576585" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="317.610163" y="30.011875" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="321.698185" y="31.40037" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="325.786207" y="30.316667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="329.874229" y="29.18528" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="333.962251" y="31.727273" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="338.050273" y="31.629615" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="342.138295" y="32.2325" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="346.226317" y="32.172389" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="350.314339" y="29.985243" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="354.402361" y="28.907852" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="358.490383" y="27.930213" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="362.578405" y="28.547257" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="366.666427" y="30.236721" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="370.754449" y="28.33703" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="374.842471" y="27.648302" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="378.930493" y="28.021765" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="383.018515" y="27.548829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="387.106537" y="26.855806" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="391.194559" y="27.962414" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="395.282581" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="399.370603" y="27.962414" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="403.458626" y="28.971379" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="407.546648" y="29.341333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="411.63467" y="28.012308" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="415.722692" y="25.923636" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="419.810714" y="28.124404" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="423.898736" y="28.294634" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="427.986758" y="26.466667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="432.07478" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="436.162802" y="27.358689" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="440.250824" y="27.475478" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="444.338846" y="26.6104" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="448.426868" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="452.51489" y="27.757624" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="456.602912" y="27.021622" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="460.690934" y="26.966609" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="464.778956" y="25.986916" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="468.866978" y="27.984348" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m765811db94" x="472.955" y="29.232963" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_17">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_18">
-    <path d="M 252.015991 318.04 
-L 252.015991 25.44 
-" clip-path="url(#pd0e5ecd757)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_13">
+    <path d="M 32.2596 29.974483 
+L 36.36 31.155882 
+L 40.44 31.124844 
+L 44.52 31.602353 
+L 48.6 33.139524 
+L 52.68 34.98738 
+L 56.76 38.114697 
+L 60.84 44.305943 
+L 64.92 58.857968 
+L 69 93.10914 
+L 73.08 91.382865 
+L 77.16 56.975204 
+L 81.24 42.297962 
+L 85.32 36.53287 
+L 89.4 33.332478 
+L 93.48 31.769154 
+L 97.56 30.927561 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_14">
+    <path d="M 32.2596 29.476303 
+L 36.36 30.517321 
+L 40.44 30.308665 
+L 44.52 30.824768 
+L 48.6 31.628096 
+L 52.68 33.588249 
+L 56.76 36.105979 
+L 60.84 40.380131 
+L 64.92 53.104962 
+L 69 88.699511 
+L 73.08 88.558959 
+L 77.16 49.885109 
+L 81.24 37.245326 
+L 85.32 33.663263 
+L 89.4 31.675558 
+L 93.48 30.676656 
+L 97.56 30.382706 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 30.206461 
+L 36.36 31.120116 
+L 40.44 31.612228 
+L 44.52 32.055232 
+L 48.6 32.863763 
+L 52.68 34.664272 
+L 56.76 37.662788 
+L 60.84 42.916078 
+L 64.92 56.767059 
+L 69 91.207773 
+L 73.08 92.529065 
+L 77.16 56.445241 
+L 81.24 41.612924 
+L 85.32 35.301192 
+L 89.4 32.375075 
+L 93.48 31.293787 
+L 97.56 30.382706 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_16">
+    <path d="M 32.2596 28.187787 
+L 36.36 28.106139 
+L 40.44 28.452074 
+L 44.52 28.363839 
+L 48.6 28.367308 
+L 52.68 28.93603 
+L 56.76 28.794537 
+L 60.84 29.739608 
+L 64.92 31.278868 
+L 69 54.29072 
+L 73.08 52.650569 
+L 77.16 30.864854 
+L 81.24 29.208229 
+L 85.32 28.767476 
+L 89.4 28.21051 
+L 93.48 28.113189 
+L 97.56 28.02339 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 57.863412 62.025522 
+Q 65.454632 53.81874 73.045852 45.611957 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
    </g>
-   <g id="text_15">
-    <!-- Cohen - - reporter (minP power) -->
-    <g transform="translate(176.750313 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
+   <g id="text_7">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="57.905334" y="69.690593" transform="rotate(-0 57.905334 69.690593)">Rod</text>
+   </g>
+   <g id="line2d_17">
+    <path d="M 74.741489 43.778824 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m528ccd0fbb" d="M 0 1.6 
+C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
+C 1.431414 0.831328 1.6 0.424325 1.6 0 
+C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
+C 0.831328 -1.431414 0.424325 -1.6 0 -1.6 
+C -0.424325 -1.6 -0.831328 -1.431414 -1.131371 -1.131371 
+C -1.431414 -0.831328 -1.6 -0.424325 -1.6 0 
+C -1.6 0.424325 -1.431414 0.831328 -1.131371 1.131371 
+C -0.831328 1.431414 -0.424325 1.6 0 1.6 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-43"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(69.824219 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(131.005859 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(194.384766 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(255.908203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(319.287109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(351.074219 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(387.158203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(423.242188 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(455.029297 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(493.892578 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(555.416016 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(618.892578 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(680.074219 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(721.1875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(760.396484 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(821.919922 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(863.033203 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(894.820312 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(933.833984 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1031.246094 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1059.029297 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1122.408203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1182.710938 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1214.498047 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1277.974609 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1339.15625 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1420.943359 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1482.466797 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1523.580078 0)"/>
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+    </defs>
+    <g clip-path="url(#p0b1cd83206)">
+     <use xlink:href="#m528ccd0fbb" x="74.741489" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 53.41 314.04 
-L 126.65 314.04 
-Q 128.25 314.04 128.25 312.44 
-L 128.25 252.591875 
-Q 128.25 250.991875 126.65 250.991875 
-L 53.41 250.991875 
-Q 51.81 250.991875 51.81 252.591875 
-L 51.81 312.44 
-Q 51.81 314.04 53.41 314.04 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_16">
-     <!-- Cell type -->
-     <g transform="translate(67.924531 261.790313) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_19">
-     <path d="M 55.01 271.14875 
-L 63.01 271.14875 
-L 71.01 271.14875 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m5a2f7c6181" x="63.01" y="271.14875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Bipolar -->
-     <g transform="translate(77.41 273.94875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-42"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(68.603516 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(96.386719 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(159.863281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(221.044922 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(248.828125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(310.107422 0)"/>
-     </g>
-    </g>
-    <g id="line2d_20">
-     <path d="M 55.01 282.89125 
-L 63.01 282.89125 
-L 71.01 282.89125 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m729b46263b" x="63.01" y="282.89125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_18">
-     <!-- Interneuron -->
-     <g transform="translate(77.41 285.69125) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-49" d="M 628 4666 
-L 1259 4666 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-49"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(29.492188 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(92.871094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(132.080078 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(193.603516 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(232.966797 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(296.345703 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(357.869141 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(421.248047 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(460.111328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(521.292969 0)"/>
-     </g>
-    </g>
-    <g id="line2d_21">
-     <path d="M 55.01 294.63375 
-L 63.01 294.63375 
-L 71.01 294.63375 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m8f8606c64b" x="63.01" y="294.63375" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_19">
-     <!-- Mueller Glia -->
-     <g transform="translate(77.41 297.43375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(149.658203 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(211.181641 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(238.964844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(266.748047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(328.271484 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(369.384766 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(401.171875 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(478.662109 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(506.445312 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(534.228516 0)"/>
-     </g>
-    </g>
-    <g id="line2d_22">
-     <path d="M 55.01 306.37625 
-L 63.01 306.37625 
-L 71.01 306.37625 
-" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m765811db94" x="63.01" y="306.37625" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- Rod -->
-     <g transform="translate(77.41 309.17625) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-52"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(64.982422 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(126.164062 0)"/>
-     </g>
+   <g id="patch_7">
+    <path d="M 86.330493 76.264323 
+Q 83.787967 61.252866 81.245442 46.241408 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
+   </g>
+   <g id="text_8">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="97.964922" y="84.302358" transform="rotate(-0 97.964922 84.302358)">Bipolar</text>
+   </g>
+   <g id="line2d_18">
+    <path d="M 80.828348 43.778824 
+" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#p0b1cd83206)">
+     <use xlink:href="#m528ccd0fbb" x="80.828348" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
   </g>
+  <g id="line2d_19">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_9">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Zhao et al.</text>
+  </g>
+  <g id="text_10">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter used</text>
+  </g>
  </g>
  <defs>
-  <clipPath id="pd0e5ecd757">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="p0b1cd83206">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/replot_overlay_ct.py
+++ b/analyses/simulation/activity_power/replot_overlay_ct.py
@@ -1,20 +1,37 @@
-"""Replot activity-power 'minP vs CRE' as a single axis with cell types
-overlaid as colored curves. One SVG per (dataset, condition).
+#!/usr/bin/env python
+"""CRE-vs-minP activity power against fold change, one curve per cell type.
+
+One SVG per (dataset, condition). Three of them are manuscript Fig 3A, placed
+side by side in one row at 0.32\\textwidth each:
+
+    shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
+    cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
+    seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
+
+Those three are drawn as small multiples of a single panel: identical figure
+size, identical margins in inches, one shared pair of axes. Axis furniture is
+therefore labelled once on the outer edges -- y ticks and the y label on the
+left-hand panel, the x label under the middle one -- exactly as a shared-axis
+row would be if LaTeX could see all three at once. Every other output is
+standalone and carries its full furniture.
+
+Sibling figure: main_figs_power_at_fc.py::fig_b_power_curves (Fig 4B). Same
+type scale, same Okabe-Ito pair for the reporter arms, same treatment of the
+reference cell type and the 80% rule.
+
+    python replot_overlay_ct.py
 """
 from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+from matplotlib.ticker import FixedFormatter, FixedLocator, NullLocator
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 
-BASE = Path(__file__).parent
-
-REFERENCE_NAMES = {
-    "cohen": "Rod",
-    "shendure": "Pluripotent",
-    "seelig": "HepG2",
-    "takeshi": "HepG2",
-}
+BASE = Path(__file__).resolve().parent
 
 # The reporter/deflated pair is MWU. Measuring the reporter's power benefit
 # with the t-test confounds it: the t-test over-rejects in exactly the deflated
@@ -40,86 +57,382 @@ DATASETS = {
     ],
 }
 
+# Author-citation form, written here rather than left to the manuscript's
+# dataset_names SVG transform: that transform rewrites <text> nodes, so it is a
+# silent no-op on any figure whose text is baked to paths, and the panel would
+# print lab nicknames next to a panel that prints citations.
+DISPLAY_NAME = {
+    "shendure": "Lalanne et al.",
+    "cohen": "Zhao et al.",
+    "seelig": "Yin et al.",
+    "takeshi": "Takeshi (unpublished)",
+}
 
-def pow_curve_data(df, n_bins=100):
-    df = df.copy()
-    df["fc_bin"] = pd.cut(df["fc"], bins=n_bins)
-    binned = (
-        df.groupby("fc_bin", observed=True)["reject_null"]
-        .mean()
-        .reset_index(name="reject_frac")
-    )
-    binned["bin_center"] = binned["fc_bin"].apply(lambda x: x.mid).astype(float)
-    return binned
+# The reference cell type is a real cell type, renamed at fit time.
+REFERENCE_NAMES = {
+    "cohen": "Rod",
+    "shendure": "Pluripotent",
+    "seelig": "HepG2",
+    "takeshi": "HepG2",
+}
+
+N_CELL_TYPES = {"shendure": 10, "cohen": 4, "seelig": 2, "takeshi": 3}
+
+# Cell-type identifiers as they come out of the fits, and what a reader sees.
+# Shared with main_figs_power_at_fc.py so a cell type is spelled the same way
+# in Fig 3 and Fig 4.
+CT_DISPLAY = {
+    "EpiblastPrimitiveStreak": "Epiblast/prim. streak",
+    "ExEndodermParietal": "ExE endoderm parietal",
+    "ExEndodermVisceral": "ExE endoderm visceral",
+    "NeuroectodermBrain": "Neuroectoderm brain",
+    "NeuroectodermRostral": "Neuroectoderm rostral",
+    "SurfaceEctoderm": "Surface ectoderm",
+    "Mueller Glia": "Mueller glia",
+    "SKNSH": "SK-N-SH",
+}
+
+# What the panel says about the test's access to a transfection reporter. Yin
+# et al. ran none, so its "deflated" arm is not a withholding experiment.
+CONDITION_LABEL = {
+    ("seelig", "deflated"): "no transfection reporter",
+    ("*", "reporter"): "reporter used",
+    ("*", "deflated"): "reporter withheld",
+}
+
+# Okabe-Ito, the palette scripts/figure_styling.py remaps everything else to,
+# and the same two hues Fig 4B and activity_calibration/fpr_dumbbell.py already
+# use for these two arms. The pair passes every categorical check outright
+# (worst CVD dE 21.9, normal-vision 31.2, both above 3:1 on white).
+CONDITION_COLOR = {"reporter": "#0072b2", "deflated": "#d55e00"}
+INK, MUTED, HAIR = "#1a1a1a", "#666666", "#c9c9c9"
+
+POWER_TARGET = 0.8
+
+# Fold change is a ratio, so the axis is log2: a 2x activation and a 2x
+# repression are the same size of effect and sit the same distance from 1x.
+# The window is shared by all three manuscript panels -- a per-panel range
+# would draw Zhao et al.'s 1.2x threshold at the same width as Yin et al.'s
+# 2.4x one, which is the opposite of what the figure is claiming. It runs to
+# 4x because that is where Yin et al.'s curves finally clear 80%; Zhao et al.'s
+# simulation stops at 1.6x and the rest of its panel is marked as unsimulated
+# rather than left as ambiguous white space.
+LOG2_WINDOW = (-1.0, 2.0)
+# Bin *width* in log2, not bin count, so a bin is the same multiplicative step
+# in every dataset even though their raw fc ranges differ by orders of
+# magnitude.
+LOG2_BIN_WIDTH = 0.1
+MIN_BIN_N = 200  # a bin thinner than this is too noisy to draw
+
+# Sized for a 0.32\textwidth inclusion in a 6.90 in text block: 2.21 in on the
+# page, and the manuscript sync applies no font scaling, so a point size here
+# is the point size a reader gets.
+FIG_W, FIG_H = 2.21, 1.85
+LEFT_IN, RIGHT_IN, TOP_IN, BOTTOM_IN = 0.42, 0.09, 0.36, 0.34
+
+# The three panels of manuscript Fig 3A, in the order the tabular places them.
+ROW_ROLE = {
+    ("shendure", "reporter"): "left",
+    ("cohen", "reporter"): "middle",
+    ("seelig", "deflated"): "right",
+}
+
+# Direct labels, hand-placed. A V-shaped curve family leaves only the inside of
+# the V free, so there is no rule that puts a label in clear space on its own.
+# Each entry is (cell type key, text x in fold change, text y in power,
+# horizontal alignment); the marker end of the leader is the curve's ascending
+# 80% crossing, computed from the data.
+ANNOTATIONS = {
+    ("shendure", "reporter"): [
+        ("reference", 0.98, 0.93, "center"),
+        ("Cardiomyocytes", 1.62, 0.28, "left"),
+    ],
+    ("cohen", "reporter"): [
+        ("reference", 0.80, 0.50, "right"),
+        ("Bipolar", 1.58, 0.32, "right"),
+    ],
+    ("seelig", "deflated"): [
+        ("reference", 1.35, 0.93, "center"),
+        ("K562", 3.15, 0.38, "center"),
+    ],
+}
+
+plt.rcParams.update({
+    "svg.fonttype": "none",       # keep text editable downstream
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+    "font.size": 7,
+    "axes.labelsize": 7.5,
+    "axes.titlesize": 7.5,
+    "xtick.labelsize": 6.5,
+    "ytick.labelsize": 6.5,
+    "legend.fontsize": 6.5,
+    "axes.unicode_minus": False,  # the repo is plain ASCII
+})
 
 
-def load_parquet(path, condition):
+# ----- data -----
+
+def display_ct(ct, dataset):
+    """Reader-facing name for a cell type in a given dataset."""
+    if ct == "reference":
+        return REFERENCE_NAMES[dataset]
+    return CT_DISPLAY.get(ct, ct)
+
+
+def condition_label(dataset, condition):
+    return CONDITION_LABEL.get((dataset, condition),
+                               CONDITION_LABEL[("*", condition)])
+
+
+def load_power(path, dataset):
+    """Fold change, cell type and rejection flag for one simulation arm."""
     df = pd.read_parquet(path)
     if "fc" not in df.columns and "log2_fc" in df.columns:
-        df = df.copy()
-        df["fc"] = 2.0 ** df["log2_fc"].astype(float)
+        df = df.assign(fc=2.0 ** df["log2_fc"].astype(float))
+    missing = {"cell_type", "reject_null", "fc"} - set(df.columns)
+    assert not missing, f"{path.name}: missing columns {sorted(missing)}"
+    assert (df["fc"] > 0).all(), \
+        f"{path.name}: fold change must be positive, min {df['fc'].min()}"
+    assert df["cell_type"].nunique() == N_CELL_TYPES[dataset], \
+        (f"{dataset}: expected {N_CELL_TYPES[dataset]} cell types, got "
+         f"{df['cell_type'].nunique()}: {sorted(df['cell_type'].unique())}")
     return df
 
 
-def display_ct(ct, dataset):
-    if ct == "reference":
-        return REFERENCE_NAMES[dataset]
-    return ct
+def pow_curve_data(df, lo=LOG2_WINDOW[0], hi=LOG2_WINDOW[1],
+                   width=LOG2_BIN_WIDTH):
+    """Power per cell type in fixed-width log2 fold-change bins.
+
+    Bins whose centre falls outside the arm's own simulated range are dropped
+    rather than drawn from a handful of edge draws, so a curve ends where the
+    simulation ended.
+    """
+    edges = np.arange(lo, hi + width / 2, width)
+    assert len(edges) - 1 >= 10, \
+        f"only {len(edges) - 1} bins over log2 [{lo}, {hi}] at width {width}"
+
+    log2_fc = np.log2(df["fc"].to_numpy())
+    sub = df.assign(log2_fc=log2_fc)
+    sub = sub[(sub["log2_fc"] >= edges[0]) & (sub["log2_fc"] <= edges[-1])]
+    assert len(sub), \
+        (f"log2 window [{lo}, {hi}] is empty; data spans "
+         f"[{log2_fc.min():.3f}, {log2_fc.max():.3f}]")
+
+    binned = pd.cut(sub["log2_fc"], bins=edges, include_lowest=True)
+    out = (
+        sub.groupby(["cell_type", binned], observed=True)["reject_null"]
+        .agg(["mean", "size"])
+        .rename(columns={"mean": "power", "size": "n"})
+        .reset_index()
+    )
+    out["log2_fc"] = out["log2_fc"].apply(lambda iv: iv.mid).astype(float)
+    out["fc"] = 2.0 ** out["log2_fc"]
+
+    # Keep only bins the arm actually simulated, then require those to be well
+    # populated -- an underfilled bin is a noise spike on a smooth curve.
+    covered = out[(out["log2_fc"] >= log2_fc.min())
+                  & (out["log2_fc"] <= log2_fc.max())]
+    assert len(covered), "every bin centre falls outside the simulated range"
+    assert covered["n"].min() >= MIN_BIN_N, \
+        (f"thinnest kept bin has {covered['n'].min()} draws (floor "
+         f"{MIN_BIN_N}) at fold change "
+         f"{covered.loc[covered['n'].idxmin(), 'fc']:.2f}")
+    assert covered["power"].between(0.0, 1.0).all(), \
+        (f"power outside [0, 1]: {covered['power'].min()} to "
+         f"{covered['power'].max()}")
+
+    n_cts = covered["cell_type"].nunique()
+    n_bins = covered.groupby("cell_type", observed=True).size()
+    assert n_bins.nunique() == 1, \
+        f"cell types disagree on bin count: {n_bins.to_dict()}"
+    assert len(covered) == n_cts * int(n_bins.iloc[0]), \
+        (f"expected {n_cts} cell types x {int(n_bins.iloc[0])} bins = "
+         f"{n_cts * int(n_bins.iloc[0])} curve points, got {len(covered)}")
+    return covered.sort_values(["cell_type", "log2_fc"]).reset_index(drop=True)
 
 
-def plot_overlay(df, dataset, condition, out_path):
-    cell_types = sorted(df["cell_type"].unique().tolist())
-    palette = sns.color_palette("tab10", n_colors=len(cell_types))
+def crossing_fc(curve, level=POWER_TARGET):
+    """Fold change where an ascending curve first reaches `level`.
 
-    fig, ax = plt.subplots(figsize=(7, 5))
-    for color, ct in zip(palette, cell_types):
-        sub = df[df["cell_type"] == ct]
-        binned = pow_curve_data(sub)
-        ax.plot(
-            binned["bin_center"], binned["reject_frac"],
-            color=color, marker="o", markersize=2, linewidth=1,
-            label=display_ct(ct, dataset),
+    Interpolated in log2 between the two straddling bins. None if the curve
+    never gets there within the window.
+    """
+    up = curve[curve["log2_fc"] > 0]
+    x, y = up["log2_fc"].to_numpy(), up["power"].to_numpy()
+    for i in range(1, len(y)):
+        if y[i - 1] < level <= y[i]:
+            t = (level - y[i - 1]) / (y[i] - y[i - 1])
+            return float(2.0 ** (x[i - 1] + t * (x[i] - x[i - 1])))
+    return None
+
+
+# ----- drawing -----
+
+def style_axes(ax):
+    """Hairline y grid, no box, ticks without tick marks."""
+    ax.grid(axis="y", color=HAIR, lw=0.5, zorder=0)
+    ax.set_axisbelow(True)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_color(HAIR)
+        ax.spines[side].set_linewidth(0.8)
+    ax.tick_params(length=0, colors=INK, pad=2)
+
+
+def draw_unsimulated(ax, curve):
+    """Mark the part of the shared window this arm never simulated.
+
+    Returns the fold change the arm reaches. Zhao et al.'s simulation stops at
+    1.6x, well short of the 4x the other two datasets need. Saying so in the
+    panel is the price of a shared axis; the alternative is a curve that
+    appears to stop for no reason.
+    """
+    span = LOG2_WINDOW[1] - LOG2_WINDOW[0]
+    edge = min(curve["log2_fc"].max() + LOG2_BIN_WIDTH / 2, LOG2_WINDOW[1])
+    if LOG2_WINDOW[1] - edge < 0.08 * span:
+        return 2.0 ** LOG2_WINDOW[1]
+    ax.axvspan(2.0 ** edge, 2.0 ** LOG2_WINDOW[1],
+               color=HAIR, alpha=0.22, lw=0, zorder=0)
+    ax.text(2.0 ** ((edge + LOG2_WINDOW[1]) / 2), 0.5, "not\nsimulated",
+            ha="center", va="center", fontsize=6, color=MUTED,
+            linespacing=1.3, zorder=1)
+    return 2.0 ** edge
+
+
+def draw_curves(ax, curve, dataset, color):
+    """One line per cell type; the reference cell type carries the panel."""
+    for ct, sub in curve.groupby("cell_type", observed=True):
+        is_ref = ct == "reference"
+        # The reference cell type is the one every other cell type is measured
+        # against, and the one Fig 3B's heatmap shows, so it is drawn solid and
+        # on top while the rest of the dataset reads as a band around it.
+        ax.plot(sub["fc"], sub["power"], color=color,
+                lw=1.6 if is_ref else 0.8,
+                alpha=1.0 if is_ref else 0.45,
+                solid_capstyle="round",
+                zorder=4 if is_ref else 3)
+
+
+def draw_annotations(ax, curve, dataset, condition, color):
+    """Name a couple of cell types by pointing at their 80% crossing."""
+    for ct, text_fc, text_power, ha in ANNOTATIONS.get((dataset, condition), []):
+        sub = curve[curve["cell_type"] == ct]
+        assert len(sub), f"{dataset}: no curve for annotated cell type {ct!r}"
+        fc = crossing_fc(sub)
+        assert fc is not None, \
+            f"{dataset}: {ct} never reaches {POWER_TARGET:.0%} in the window"
+        ax.annotate(
+            display_ct(ct, dataset),
+            xy=(fc, POWER_TARGET), xytext=(text_fc, text_power),
+            fontsize=6, color=INK, ha=ha, va="center",
+            arrowprops=dict(arrowstyle="-", color=MUTED, lw=0.5,
+                            shrinkA=1.5, shrinkB=2.5),
+            annotation_clip=False, zorder=6,
         )
+        ax.plot([fc], [POWER_TARGET], marker="o", markersize=3.2, color=color,
+                markeredgecolor="white", markeredgewidth=0.8, zorder=6)
 
-    ax.axhline(0.8, color="black", linestyle="--", lw=0.8)
-    ax.axvline(1.0, color="grey", linestyle=":", lw=0.8)
-    ax.set_ylim(0, 1)
-    ax.set_xlabel("FC (activity / minP)")
-    ax.set_ylabel("Power (TPR)")
-    ax.set_title(f"{dataset.capitalize()} -- {condition} (minP power)")
-    ax.legend(title="Cell type", loc="best", fontsize=8)
-    fig.tight_layout()
+
+def draw_title(fig, dataset, condition, color):
+    """Dataset above, condition below, with a key stub for the curve colour.
+
+    Indented to the left edge of the axes rather than the figure: the
+    manuscript overlays a bold panel letter on the top-left corner of the row
+    via \\panel{}, and a flush-left title lands under it.
+    """
+    x = LEFT_IN / FIG_W
+    fig.text(x, 1 - 0.11 / FIG_H, DISPLAY_NAME[dataset],
+             ha="left", va="center", fontsize=7.5, color=INK)
+    fig.add_artist(Line2D(
+        [x, x + 0.085 / FIG_W], [1 - 0.245 / FIG_H] * 2,
+        color=color, lw=1.6, solid_capstyle="round",
+    ))
+    fig.text(x + 0.115 / FIG_W, 1 - 0.245 / FIG_H,
+             condition_label(dataset, condition),
+             ha="left", va="center", fontsize=6.5, color=MUTED)
+
+
+def plot_overlay(curve, dataset, condition, out_path):
+    role = ROW_ROLE.get((dataset, condition))
+    color = CONDITION_COLOR[condition]
+
+    fig, ax = plt.subplots(figsize=(FIG_W, FIG_H))
+    right_edge = draw_unsimulated(ax, curve)
+
+    # Fold change 1 is the null: no difference between the CRE and minP, so
+    # power falls to alpha there and the curve family is V-shaped by
+    # construction. The hairline says the dip is the axis, not the data.
+    ax.axvline(1.0, color=HAIR, lw=0.8, zorder=1)
+    ax.axhline(POWER_TARGET, color=MUTED, ls="--", lw=0.7, zorder=2)
+
+    draw_curves(ax, curve, dataset, color)
+    draw_annotations(ax, curve, dataset, condition, color)
+
+    ax.set_xscale("log", base=2)
+    ax.set_xlim(2.0 ** LOG2_WINDOW[0], 2.0 ** LOG2_WINDOW[1])
+    ax.xaxis.set_major_locator(FixedLocator([0.5, 1, 2, 4]))
+    ax.xaxis.set_major_formatter(FixedFormatter(["0.5x", "1x", "2x", "4x"]))
+    ax.xaxis.set_minor_locator(NullLocator())
+    ax.set_ylim(0, 1.02)
+    ax.set_yticks([0, 0.5, 1.0], ["0", "0.5", "1"])
+    style_axes(ax)
+
+    # Outer-edge labelling for the manuscript row; everything else stands alone.
+    if role in (None, "left"):
+        ax.set_ylabel("power", color=INK, labelpad=2)
+        # 80% is the conventional target and the reason the dashed rule is
+        # there. Naming it once beats a legend entry for a line that is not
+        # data. It sits under the right-hand end of the simulated range, the
+        # one stretch of the rule that every curve has already climbed past.
+        ax.annotate(f"{POWER_TARGET:.0%}", xy=(right_edge, POWER_TARGET),
+                    xytext=(-2, -1), textcoords="offset points",
+                    fontsize=6, color=MUTED, ha="right", va="top")
+    else:
+        ax.set_yticklabels([])
+    if role in (None, "middle"):
+        ax.set_xlabel("fold change vs minP", color=INK, labelpad=1)
+
+    draw_title(fig, dataset, condition, color)
+    fig.subplots_adjust(
+        left=LEFT_IN / FIG_W, right=1 - RIGHT_IN / FIG_W,
+        top=1 - TOP_IN / FIG_H, bottom=BOTTOM_IN / FIG_H,
+    )
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    # No bbox_inches="tight". The three manuscript panels sit in one row with
+    # their plot areas in line, and cropping each to its own contents would
+    # undo that: the left panel carries tick labels the others do not.
     fig.savefig(out_path, format="svg")
     plt.close(fig)
 
 
+def report(curve, dataset, condition):
+    print(f"  {DISPLAY_NAME[dataset]} ({condition}): "
+          f"{curve['cell_type'].nunique()} cell types, "
+          f"{curve['log2_fc'].nunique()} bins, thinnest {curve['n'].min()} draws")
+    for ct, sub in curve.groupby("cell_type", observed=True):
+        fc = crossing_fc(sub)
+        where = f"{fc:.2f}x" if fc is not None else "never in window"
+        print(f"      {display_ct(ct, dataset):<24} {POWER_TARGET:.0%} at {where}")
+
+
 def main():
-    produced = []
-    skipped = []
+    produced, skipped = [], []
     for dataset, items in DATASETS.items():
         for condition, rel in items:
             path = BASE / rel
             if not path.exists():
                 skipped.append((str(path), "missing"))
                 continue
-            try:
-                df = load_parquet(path, condition)
-            except Exception as e:
-                skipped.append((str(path), f"load error: {e}"))
-                continue
-            required = {"reject_null", "cell_type"}
-            if not required.issubset(df.columns) or "fc" not in df.columns:
-                skipped.append((str(path), f"schema: cols={list(df.columns)}"))
-                continue
-            out_path = (
-                BASE / dataset / "output" / "overlay_ct" /
-                f"{dataset}_power_{condition}_overlay_ct.svg"
-            )
-            plot_overlay(df, dataset, condition, out_path)
+            curve = pow_curve_data(load_power(path, dataset))
+            report(curve, dataset, condition)
+            out_path = (BASE / dataset / "output" / "overlay_ct" /
+                        f"{dataset}_power_{condition}_overlay_ct.svg")
+            plot_overlay(curve, dataset, condition, out_path)
             produced.append(str(out_path))
 
-    print("PRODUCED:")
+    print(f"\nPRODUCED ({FIG_W:.2f} x {FIG_H:.2f} in each):")
     for p in produced:
         print(" ", p)
     print(f"Total: {len(produced)}")

--- a/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:23.310488</dc:date>
+    <dc:date>2026-08-16T20:37:59.681475</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,1689 +21,219 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m816f56c484" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m816f56c484" x="66.196481" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.0 -->
-      <g transform="translate(58.244919 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m816f56c484" x="117.296798" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.5 -->
-      <g transform="translate(109.345235 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m816f56c484" x="168.397114" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(160.445552 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m816f56c484" x="219.497431" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.5 -->
-      <g transform="translate(211.545868 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m816f56c484" x="270.597747" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 2.0 -->
-      <g transform="translate(262.646185 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m816f56c484" x="321.698063" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 2.5 -->
-      <g transform="translate(313.746501 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m816f56c484" x="372.79838" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 3.0 -->
-      <g transform="translate(364.846817 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m816f56c484" x="423.898696" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 3.5 -->
-      <g transform="translate(415.947134 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m816f56c484" x="474.999013" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 4.0 -->
-      <g transform="translate(467.04745 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_10">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_10">
-      <defs>
-       <path id="mea4e0467f6" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_11">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
+     <g id="line2d_6"/>
     </g>
     <g id="ytick_2">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_12">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
+     <g id="line2d_8"/>
     </g>
     <g id="ytick_3">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_9">
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_13">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#mea4e0467f6" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+     <g id="line2d_10"/>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 68.055 180.32733 
-L 72.34896 75.113288 
-L 76.426765 88.848305 
-L 80.50457 111.464105 
-L 84.592595 136.454628 
-L 88.680621 159.609766 
-L 92.768646 174.513797 
-L 96.856671 192.813125 
-L 100.944697 206.813965 
-L 105.032722 217.435646 
-L 109.120747 229.536459 
-L 113.208773 243.597892 
-L 117.296798 253.390654 
-L 121.384823 262.331855 
-L 125.472849 270.762759 
-L 129.560874 279.706815 
-L 133.648899 285.831749 
-L 137.736924 292.624792 
-L 141.82495 296.261947 
-L 145.912975 300.191124 
-L 150.001 303.815224 
-L 154.089026 306.448 
-L 158.177051 308.076819 
-L 162.265076 309.238325 
-L 166.353102 308.974312 
-L 170.441127 309.495758 
-L 174.529152 308.391337 
-L 178.617178 306.982694 
-L 182.705203 306.205411 
-L 186.793228 304.102823 
-L 190.881253 301.461565 
-L 194.969279 298.928132 
-L 199.057304 293.307335 
-L 203.145329 290.045989 
-L 207.233355 285.489278 
-L 211.32138 281.475596 
-L 215.409405 277.404202 
-L 219.497431 266.935023 
-L 223.585456 261.920676 
-L 227.673481 254.936772 
-L 231.761507 247.472579 
-L 235.849532 235.807931 
-L 239.937557 229.387671 
-L 244.025583 219.542917 
-L 248.113608 211.68475 
-L 252.201633 203.632292 
-L 256.289658 189.411881 
-L 260.377684 182.355968 
-L 264.465709 173.148389 
-L 268.553734 165.658729 
-L 272.64176 154.794161 
-L 276.729785 146.617201 
-L 280.81781 137.274409 
-L 284.905836 129.036216 
-L 288.993861 122.477401 
-L 293.081886 116.098256 
-L 297.169912 107.721662 
-L 301.257937 101.349592 
-L 305.345962 97.055385 
-L 309.433988 88.668187 
-L 313.522013 83.470065 
-L 317.610038 77.820563 
-L 321.698063 74.907644 
-L 325.786089 72.079786 
-L 329.874114 65.94502 
-L 333.962139 61.689118 
-L 338.050165 59.958574 
-L 342.13819 56.797133 
-L 346.226215 53.689071 
-L 350.314241 50.121905 
-L 354.402266 48.655015 
-L 358.490291 46.85583 
-L 362.578317 44.910358 
-L 366.666342 43.338556 
-L 370.754367 40.740695 
-L 374.842393 39.234 
-L 378.930418 38.760057 
-L 383.018443 37.632811 
-L 387.106468 37.588247 
-L 391.194494 36.341058 
-L 395.282519 34.143399 
-L 399.370544 33.39872 
-L 403.45857 32.831415 
-L 407.546595 32.952703 
-L 411.63462 32.037707 
-L 415.722646 30.881691 
-L 419.810671 30.873797 
-L 423.898696 30.316667 
-L 427.986722 29.801062 
-L 432.074747 29.691229 
-L 436.162772 28.681953 
-L 440.250798 29.354571 
-L 444.338823 29.015907 
-L 448.426848 28.681633 
-L 452.514873 28.092542 
-L 456.602899 28.540037 
-L 460.690924 27.992886 
-L 464.778949 27.572653 
-L 468.866975 27.795739 
-L 472.955 27.582672 
-" clip-path="url(#pa2476b4595)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="mdcd64f80ad" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#pa2476b4595)">
-     <use xlink:href="#mdcd64f80ad" x="68.055" y="180.32733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="72.34896" y="75.113288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="76.426765" y="88.848305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="80.50457" y="111.464105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="84.592595" y="136.454628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="88.680621" y="159.609766" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="92.768646" y="174.513797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="96.856671" y="192.813125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="100.944697" y="206.813965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="105.032722" y="217.435646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="109.120747" y="229.536459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="113.208773" y="243.597892" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="117.296798" y="253.390654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="121.384823" y="262.331855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="125.472849" y="270.762759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="129.560874" y="279.706815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="133.648899" y="285.831749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="137.736924" y="292.624792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="141.82495" y="296.261947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="145.912975" y="300.191124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="150.001" y="303.815224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="154.089026" y="306.448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="158.177051" y="308.076819" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="162.265076" y="309.238325" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="166.353102" y="308.974312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="170.441127" y="309.495758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="174.529152" y="308.391337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="178.617178" y="306.982694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="182.705203" y="306.205411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="186.793228" y="304.102823" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="190.881253" y="301.461565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="194.969279" y="298.928132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="199.057304" y="293.307335" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="203.145329" y="290.045989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="207.233355" y="285.489278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="211.32138" y="281.475596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="215.409405" y="277.404202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="219.497431" y="266.935023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="223.585456" y="261.920676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="227.673481" y="254.936772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="231.761507" y="247.472579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="235.849532" y="235.807931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="239.937557" y="229.387671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="244.025583" y="219.542917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="248.113608" y="211.68475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="252.201633" y="203.632292" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="256.289658" y="189.411881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="260.377684" y="182.355968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="264.465709" y="173.148389" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="268.553734" y="165.658729" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="272.64176" y="154.794161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="276.729785" y="146.617201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="280.81781" y="137.274409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="284.905836" y="129.036216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="288.993861" y="122.477401" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="293.081886" y="116.098256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="297.169912" y="107.721662" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="301.257937" y="101.349592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="305.345962" y="97.055385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="309.433988" y="88.668187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="313.522013" y="83.470065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="317.610038" y="77.820563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="321.698063" y="74.907644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="325.786089" y="72.079786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="329.874114" y="65.94502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="333.962139" y="61.689118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="338.050165" y="59.958574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="342.13819" y="56.797133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="346.226215" y="53.689071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="350.314241" y="50.121905" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="354.402266" y="48.655015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="358.490291" y="46.85583" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="362.578317" y="44.910358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="366.666342" y="43.338556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="370.754367" y="40.740695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="374.842393" y="39.234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="378.930418" y="38.760057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="383.018443" y="37.632811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="387.106468" y="37.588247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="391.194494" y="36.341058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="395.282519" y="34.143399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="399.370544" y="33.39872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="403.45857" y="32.831415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="407.546595" y="32.952703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="411.63462" y="32.037707" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="415.722646" y="30.881691" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="419.810671" y="30.873797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="423.898696" y="30.316667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="427.986722" y="29.801062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="432.074747" y="29.691229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="436.162772" y="28.681953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="440.250798" y="29.354571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="444.338823" y="29.015907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="448.426848" y="28.681633" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="452.514873" y="28.092542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="456.602899" y="28.540037" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="460.690924" y="27.992886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="464.778949" y="27.572653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="468.866975" y="27.795739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mdcd64f80ad" x="472.955" y="27.582672" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 68.056022 149.214113 
-L 72.34896 62.891704 
-L 76.426765 81.051505 
-L 80.50457 105.97211 
-L 84.592595 122.927948 
-L 88.680621 139.112778 
-L 92.768646 152.357492 
-L 96.856671 167.316505 
-L 100.944697 179.288717 
-L 105.032722 191.190774 
-L 109.120747 205.803881 
-L 113.208773 219.674234 
-L 117.296798 234.860266 
-L 121.384823 243.352563 
-L 125.472849 258.626991 
-L 129.560874 266.796518 
-L 133.648899 275.669036 
-L 137.736924 285.1749 
-L 141.82495 290.325917 
-L 145.912975 296.596905 
-L 150.001 301.224216 
-L 154.089026 304.260744 
-L 158.177051 306.626922 
-L 162.265076 306.927517 
-L 166.353102 308.295973 
-L 170.441127 307.736189 
-L 174.529152 307.312745 
-L 178.617178 305.258452 
-L 182.705203 304.33415 
-L 186.793228 300.76989 
-L 190.881253 295.58945 
-L 194.969279 293.070701 
-L 199.057304 287.023833 
-L 203.145329 282.219831 
-L 207.233355 273.382184 
-L 211.32138 265.991493 
-L 215.409405 258.827292 
-L 219.497431 249.6967 
-L 223.585456 239.007259 
-L 227.673481 230.033398 
-L 231.761507 219.988308 
-L 235.849532 209.724698 
-L 239.937557 196.985889 
-L 244.025583 189.092021 
-L 248.113608 175.260913 
-L 252.201633 165.951203 
-L 256.289658 152.555179 
-L 260.377684 145.699807 
-L 264.465709 136.673102 
-L 268.553734 127.823592 
-L 272.64176 115.731119 
-L 276.729785 108.366315 
-L 280.81781 98.023588 
-L 284.905836 88.938018 
-L 288.993861 84.383036 
-L 293.081886 78.739098 
-L 297.169912 71.776754 
-L 301.257937 66.794495 
-L 305.345962 61.734337 
-L 309.433988 57.667986 
-L 313.522013 53.483814 
-L 317.610038 50.961452 
-L 321.698063 47.523019 
-L 325.786089 43.018793 
-L 329.874114 41.954167 
-L 333.962139 41.283486 
-L 338.050165 39.434507 
-L 342.13819 36.56849 
-L 346.226215 34.990826 
-L 350.314241 34.276353 
-L 354.402266 32.6296 
-L 358.490291 31.456886 
-L 362.578317 31.710991 
-L 366.666342 30.84356 
-L 370.754367 30.654653 
-L 374.842393 29.661461 
-L 378.930418 28.576932 
-L 383.018443 28.116475 
-L 387.106468 27.973333 
-L 391.194494 27.714725 
-L 395.282519 27.166254 
-L 399.370544 27.28597 
-L 403.45857 26.784643 
-L 407.546595 26.646322 
-L 411.63462 26.428606 
-L 415.722646 26.080628 
-L 419.810671 26.182205 
-L 423.898696 26.277995 
-L 427.986722 25.949608 
-L 432.074747 25.831251 
-L 436.162772 25.887786 
-L 440.250798 25.636942 
-L 444.338823 25.74307 
-L 448.426848 25.631242 
-L 452.514873 25.584637 
-L 456.602899 25.552215 
-L 460.690924 25.5236 
-L 464.778949 25.555996 
-L 468.866975 25.556169 
-L 472.955 25.468546 
-" clip-path="url(#pa2476b4595)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m94881d5317" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#pa2476b4595)">
-     <use xlink:href="#m94881d5317" x="68.056022" y="149.214113" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="72.34896" y="62.891704" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="76.426765" y="81.051505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="80.50457" y="105.97211" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="84.592595" y="122.927948" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="88.680621" y="139.112778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="92.768646" y="152.357492" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="96.856671" y="167.316505" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="100.944697" y="179.288717" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="105.032722" y="191.190774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="109.120747" y="205.803881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="113.208773" y="219.674234" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="117.296798" y="234.860266" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="121.384823" y="243.352563" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="125.472849" y="258.626991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="129.560874" y="266.796518" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="133.648899" y="275.669036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="137.736924" y="285.1749" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="141.82495" y="290.325917" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="145.912975" y="296.596905" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="150.001" y="301.224216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="154.089026" y="304.260744" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="158.177051" y="306.626922" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="162.265076" y="306.927517" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="166.353102" y="308.295973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="170.441127" y="307.736189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="174.529152" y="307.312745" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="178.617178" y="305.258452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="182.705203" y="304.33415" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="186.793228" y="300.76989" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="190.881253" y="295.58945" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="194.969279" y="293.070701" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="199.057304" y="287.023833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="203.145329" y="282.219831" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="207.233355" y="273.382184" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="211.32138" y="265.991493" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="215.409405" y="258.827292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="219.497431" y="249.6967" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="223.585456" y="239.007259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="227.673481" y="230.033398" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="231.761507" y="219.988308" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="235.849532" y="209.724698" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="239.937557" y="196.985889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="244.025583" y="189.092021" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="248.113608" y="175.260913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="252.201633" y="165.951203" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="256.289658" y="152.555179" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="260.377684" y="145.699807" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="264.465709" y="136.673102" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="268.553734" y="127.823592" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="272.64176" y="115.731119" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="276.729785" y="108.366315" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="280.81781" y="98.023588" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="284.905836" y="88.938018" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="288.993861" y="84.383036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="293.081886" y="78.739098" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="297.169912" y="71.776754" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="301.257937" y="66.794495" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="305.345962" y="61.734337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="309.433988" y="57.667986" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="313.522013" y="53.483814" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="317.610038" y="50.961452" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="321.698063" y="47.523019" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="325.786089" y="43.018793" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="329.874114" y="41.954167" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="333.962139" y="41.283486" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="338.050165" y="39.434507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="342.13819" y="36.56849" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="346.226215" y="34.990826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="350.314241" y="34.276353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="354.402266" y="32.6296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="358.490291" y="31.456886" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="362.578317" y="31.710991" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="366.666342" y="30.84356" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="370.754367" y="30.654653" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="374.842393" y="29.661461" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="378.930418" y="28.576932" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="383.018443" y="28.116475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="387.106468" y="27.973333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="391.194494" y="27.714725" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="395.282519" y="27.166254" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="399.370544" y="27.28597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="403.45857" y="26.784643" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="407.546595" y="26.646322" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="411.63462" y="26.428606" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="415.722646" y="26.080628" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="419.810671" y="26.182205" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="423.898696" y="26.277995" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="427.986722" y="25.949608" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="432.074747" y="25.831251" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="436.162772" y="25.887786" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="440.250798" y="25.636942" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="444.338823" y="25.74307" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="448.426848" y="25.631242" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="452.514873" y="25.584637" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="456.602899" y="25.552215" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="460.690924" y="25.5236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="464.778949" y="25.555996" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="468.866975" y="25.556169" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m94881d5317" x="472.955" y="25.468546" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#pa2476b4595)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_19">
-    <path d="M 168.397114 318.04 
-L 168.397114 25.44 
-" clip-path="url(#pa2476b4595)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_13">
+    <path d="M 32.2596 92.1617 
+L 36.36 93.874466 
+L 40.44 96.750238 
+L 44.52 98.75168 
+L 48.6 101.047065 
+L 52.68 102.448908 
+L 56.76 103.913091 
+L 60.84 105.170714 
+L 64.92 105.970396 
+L 69 106.242958 
+L 73.08 106.256096 
+L 77.16 105.619242 
+L 81.24 104.658447 
+L 85.32 102.790499 
+L 89.4 100.15119 
+L 93.48 96.696735 
+L 97.56 91.501442 
+L 101.64 85.003529 
+L 105.72 77.61427 
+L 109.8 68.984176 
+L 113.88 60.416068 
+L 117.96 52.430487 
+L 122.04 45.406431 
+L 126.12 39.692605 
+L 130.2 35.497217 
+L 134.28 32.578092 
+L 138.36 30.708563 
+L 142.44 29.40098 
+L 146.52 28.65659 
+L 150.6 28.248655 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_14">
+    <path d="M 32.2596 86.451495 
+L 36.36 89.582129 
+L 40.44 92.988068 
+L 44.52 95.73315 
+L 48.6 98.685777 
+L 52.68 100.789424 
+L 56.76 102.944419 
+L 60.84 104.505978 
+L 64.92 105.488848 
+L 69 105.869493 
+L 73.08 105.807413 
+L 77.16 105.233309 
+L 81.24 103.500422 
+L 85.32 101.039016 
+L 89.4 97.254106 
+L 93.48 91.889503 
+L 97.56 84.862194 
+L 101.64 76.819166 
+L 105.72 67.534447 
+L 109.8 58.865894 
+L 113.88 49.551847 
+L 117.96 42.189268 
+L 122.04 36.557656 
+L 126.12 32.718194 
+L 130.2 30.42907 
+L 134.28 29.091338 
+L 138.36 28.236817 
+L 142.44 27.850205 
+L 146.52 27.663745 
+L 150.6 27.572984 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 102.348389 38.300196 
+Q 108.543145 40.604135 114.737902 42.908075 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
+   </g>
+   <g id="text_5">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="88.704744" y="34.784476" transform="rotate(-0 88.704744 34.784476)">HepG2</text>
+   </g>
+   <g id="line2d_15">
+    <path d="M 117.079142 43.778824 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="ma6d37ea53c" d="M 0 1.6 
+C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
+C 1.431414 0.831328 1.6 0.424325 1.6 0 
+C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
+C 0.831328 -1.431414 0.424325 -1.6 0 -1.6 
+C -0.424325 -1.6 -0.831328 -1.431414 -1.131371 -1.131371 
+C -1.431414 -0.831328 -1.6 -0.424325 -1.6 0 
+C -1.6 0.424325 -1.431414 0.831328 -1.131371 1.131371 
+C -0.831328 1.431414 -0.424325 1.6 0 1.6 
+z
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+    </defs>
+    <g clip-path="url(#pdadaa41ff0)">
+     <use xlink:href="#ma6d37ea53c" x="117.079142" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
+    </g>
    </g>
    <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 135.707421 71.507111 
+Q 129.968486 58.781953 124.22955 46.056794 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
    </g>
-   <g id="text_18">
-    <!-- Seelig - - deflated (minP power) -->
-    <g transform="translate(177.243437 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791 
-Q 2906 2416 2648 2759 
-Q 2391 3103 1925 3103 
-Q 1463 3103 1205 2759 
-Q 947 2416 947 1791 
-Q 947 1169 1205 825 
-Q 1463 481 1925 481 
-Q 2391 481 2648 825 
-Q 2906 1169 2906 1791 
-z
-M 3481 434 
-Q 3481 -459 3084 -895 
-Q 2688 -1331 1869 -1331 
-Q 1566 -1331 1297 -1286 
-Q 1028 -1241 775 -1147 
-L 775 -588 
-Q 1028 -725 1275 -790 
-Q 1522 -856 1778 -856 
-Q 2344 -856 2625 -561 
-Q 2906 -266 2906 331 
-L 2906 616 
-Q 2728 306 2450 153 
-Q 2172 0 1784 0 
-Q 1141 0 747 490 
-Q 353 981 353 1791 
-Q 353 2603 747 3093 
-Q 1141 3584 1784 3584 
-Q 2172 3584 2450 3431 
-Q 2728 3278 2906 2969 
-L 2906 3500 
-L 3481 3500 
-L 3481 434 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-53"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(125 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(186.523438 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(214.306641 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(242.089844 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(305.566406 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(337.353516 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(373.4375 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(409.521484 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(441.308594 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(504.785156 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(566.308594 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(601.513672 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(629.296875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(690.576172 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(729.785156 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(791.308594 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(854.785156 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(886.572266 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(925.585938 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1022.998047 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1050.78125 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1114.160156 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1174.462891 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1206.25 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1269.726562 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1330.908203 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1412.695312 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1474.21875 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1515.332031 0)"/>
-    </g>
+   <g id="text_6">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="138.578355" y="79.431535" transform="rotate(-0 138.578355 79.431535)">K562</text>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 434.69375 69.003125 
-L 487.6 69.003125 
-Q 489.2 69.003125 489.2 67.403125 
-L 489.2 31.04 
-Q 489.2 29.44 487.6 29.44 
-L 434.69375 29.44 
-Q 433.09375 29.44 433.09375 31.04 
-L 433.09375 67.403125 
-Q 433.09375 69.003125 434.69375 69.003125 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_19">
-     <!-- Cell type -->
-     <g transform="translate(439.041406 40.238438) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_20">
-     <path d="M 436.29375 49.596875 
-L 444.29375 49.596875 
-L 452.29375 49.596875 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mdcd64f80ad" x="444.29375" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- K562 -->
-     <g transform="translate(458.69375 52.396875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4b" d="M 628 4666 
-L 1259 4666 
-L 1259 2694 
-L 3353 4666 
-L 4166 4666 
-L 1850 2491 
-L 4331 0 
-L 3500 0 
-L 1259 2247 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-35" transform="translate(65.576172 0)"/>
-      <use xlink:href="#DejaVuSans-36" transform="translate(129.199219 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(192.822266 0)"/>
-     </g>
-    </g>
-    <g id="line2d_21">
-     <path d="M 436.29375 61.339375 
-L 444.29375 61.339375 
-L 452.29375 61.339375 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m94881d5317" x="444.29375" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- HepG2 -->
-     <g transform="translate(458.69375 64.139375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-48"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(75.195312 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(136.71875 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(200.195312 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(277.685547 0)"/>
-     </g>
+   <g id="line2d_16">
+    <path d="M 123.202205 43.778824 
+" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#pdadaa41ff0)">
+     <use xlink:href="#ma6d37ea53c" x="123.202205" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
   </g>
+  <g id="line2d_17">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_7">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Yin et al.</text>
+  </g>
+  <g id="text_8">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">no transfection reporter</text>
+  </g>
  </g>
  <defs>
-  <clipPath id="pa2476b4595">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="pdadaa41ff0">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:23.160579</dc:date>
+    <dc:date>2026-08-16T20:37:59.563284</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,3851 +21,458 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m8f9bc2e8d5" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.0 -->
-      <g transform="translate(49.749473 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.5 -->
-      <g transform="translate(101.910504 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(154.071534 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.5 -->
-      <g transform="translate(206.232565 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 2.0 -->
-      <g transform="translate(258.393595 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 2.5 -->
-      <g transform="translate(310.554626 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 3.0 -->
-      <g transform="translate(362.715657 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 3.5 -->
-      <g transform="translate(414.876687 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m8f9bc2e8d5" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 4.0 -->
-      <g transform="translate(467.037718 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_10">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
-     </g>
+    <g id="text_5">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="91.44" y="123.918828" transform="rotate(-0 91.44 123.918828)">fold change vs minP</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_10">
-      <defs>
-       <path id="m94fc6ad6a6" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_11">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="111.189238" transform="rotate(-0 28.24 111.189238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_12">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_8"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="70.601003" transform="rotate(-0 28.24 70.601003)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_9">
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_13">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_10"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="30.012768" transform="rotate(-0 28.24 30.012768)">1</text>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m94fc6ad6a6" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+    <g id="text_9">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="14.101211" y="67.32" transform="rotate(-90 14.101211 67.32)">power</text>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 68.060216 318.04 
-L 72.358285 318.04 
-L 76.426845 318.04 
-L 80.495406 318.04 
-L 84.563966 317.606519 
-L 88.684688 317.173037 
-L 92.805409 318.04 
-L 96.873969 317.564228 
-L 100.94253 318.04 
-L 105.01109 317.503119 
-L 109.079651 318.04 
-L 113.200372 317.166567 
-L 117.321093 316.812308 
-L 121.389654 316.689538 
-L 125.458214 318.04 
-L 129.526775 316.589091 
-L 133.595335 317.535517 
-L 137.716056 317.039658 
-L 141.836778 316.729851 
-L 145.905338 315.789231 
-L 149.973899 316.526552 
-L 154.042459 315.275276 
-L 158.16318 316.368 
-L 162.283902 314.766154 
-L 166.352462 314.175472 
-L 170.421023 313.3375 
-L 174.489583 312.393333 
-L 178.558143 314.96 
-L 182.678865 311.804262 
-L 186.799586 315.904234 
-L 190.868147 311.128189 
-L 194.936707 308.635 
-L 199.005267 311.212667 
-L 203.073828 306.633559 
-L 207.194549 308.367273 
-L 211.315271 309.353438 
-L 215.383831 309.353438 
-L 219.452391 305.360667 
-L 223.520952 299.859029 
-L 227.589512 303.047273 
-L 231.710233 306.436897 
-L 235.830955 302.851603 
-L 239.899515 300.205333 
-L 243.968076 299.3136 
-L 248.036636 295.313786 
-L 252.157357 300.073333 
-L 256.278079 297.727273 
-L 260.346639 295.313786 
-L 264.4152 291.706 
-L 268.48376 295.418824 
-L 272.55232 290.530598 
-L 276.673042 288.78 
-L 280.793763 286.02906 
-L 284.862324 283.86432 
-L 288.930884 283.983279 
-L 292.999444 292.664071 
-L 297.068005 274.304 
-L 301.188726 276.973333 
-L 305.309448 278.185862 
-L 309.378008 275.992296 
-L 313.446568 272.06 
-L 317.515129 269.2 
-L 321.583689 272.70018 
-L 325.704411 271.127273 
-L 329.825132 262.220923 
-L 333.893692 264.021538 
-L 337.962253 263.121231 
-L 342.030813 262.374634 
-L 346.151535 250.885902 
-L 350.272256 255.309928 
-L 354.340816 255.585882 
-L 358.409377 248.665484 
-L 362.477937 240.170645 
-L 366.546498 247.816 
-L 370.667219 244.096124 
-L 374.78794 251.845246 
-L 378.856501 252.261705 
-L 382.925061 241.447647 
-L 386.993622 244.402333 
-L 391.062182 234.44 
-L 395.182903 238.524275 
-L 399.303625 241.313778 
-L 403.372185 231.174375 
-L 407.440746 239.853443 
-L 411.509306 223.61 
-L 415.577866 218.834667 
-L 419.698588 226.571765 
-L 423.819309 214.933333 
-L 427.88787 210.68 
-L 431.95643 220.356615 
-L 436.02499 220.341356 
-L 440.145712 225.688125 
-L 444.266433 220.506667 
-L 448.334994 213.075556 
-L 452.403554 214.3 
-L 456.472114 218.068333 
-L 460.540675 221.02 
-L 464.661396 216.490588 
-L 468.782118 225.215172 
-L 472.850678 212.980472 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="mf4c2f13220" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#mf4c2f13220" x="68.060216" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="72.358285" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="76.426845" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="80.495406" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="84.563966" y="317.606519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="88.684688" y="317.173037" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="92.805409" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="96.873969" y="317.564228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="100.94253" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="105.01109" y="317.503119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="109.079651" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="113.200372" y="317.166567" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="117.321093" y="316.812308" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="121.389654" y="316.689538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="125.458214" y="318.04" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="129.526775" y="316.589091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="133.595335" y="317.535517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="137.716056" y="317.039658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="141.836778" y="316.729851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="145.905338" y="315.789231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="149.973899" y="316.526552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="154.042459" y="315.275276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="158.16318" y="316.368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="162.283902" y="314.766154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="166.352462" y="314.175472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="170.421023" y="313.3375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="174.489583" y="312.393333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="178.558143" y="314.96" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="182.678865" y="311.804262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="186.799586" y="315.904234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="190.868147" y="311.128189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="194.936707" y="308.635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="199.005267" y="311.212667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="203.073828" y="306.633559" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="207.194549" y="308.367273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="211.315271" y="309.353438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="215.383831" y="309.353438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="219.452391" y="305.360667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="223.520952" y="299.859029" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="227.589512" y="303.047273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="231.710233" y="306.436897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="235.830955" y="302.851603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="239.899515" y="300.205333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="243.968076" y="299.3136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="248.036636" y="295.313786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="252.157357" y="300.073333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="256.278079" y="297.727273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="260.346639" y="295.313786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="264.4152" y="291.706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="268.48376" y="295.418824" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="272.55232" y="290.530598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="276.673042" y="288.78" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="280.793763" y="286.02906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="284.862324" y="283.86432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="288.930884" y="283.983279" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="292.999444" y="292.664071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="297.068005" y="274.304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="301.188726" y="276.973333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="305.309448" y="278.185862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="309.378008" y="275.992296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="313.446568" y="272.06" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="317.515129" y="269.2" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="321.583689" y="272.70018" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="325.704411" y="271.127273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="329.825132" y="262.220923" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="333.893692" y="264.021538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="337.962253" y="263.121231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="342.030813" y="262.374634" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="346.151535" y="250.885902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="350.272256" y="255.309928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="354.340816" y="255.585882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="358.409377" y="248.665484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="362.477937" y="240.170645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="366.546498" y="247.816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="370.667219" y="244.096124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="374.78794" y="251.845246" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="378.856501" y="252.261705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="382.925061" y="241.447647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="386.993622" y="244.402333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="391.062182" y="234.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="395.182903" y="238.524275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="399.303625" y="241.313778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="403.372185" y="231.174375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="407.440746" y="239.853443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="411.509306" y="223.61" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="415.577866" y="218.834667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="419.698588" y="226.571765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="423.819309" y="214.933333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="427.88787" y="210.68" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="431.95643" y="220.356615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="436.02499" y="220.341356" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="440.145712" y="225.688125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="444.266433" y="220.506667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="448.334994" y="213.075556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="452.403554" y="214.3" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="456.472114" y="218.068333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="460.540675" y="221.02" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="464.661396" y="216.490588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="468.782118" y="225.215172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mf4c2f13220" x="472.850678" y="212.980472" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 68.065432 317.806853 
-L 72.358285 318.04 
-L 76.426845 317.430417 
-L 80.495406 316.956296 
-L 84.563966 316.705668 
-L 88.684688 314.32791 
-L 92.805409 313.66252 
-L 96.873969 312.247918 
-L 100.94253 311.891159 
-L 105.01109 311.068303 
-L 109.131812 313.752821 
-L 113.252533 313.675797 
-L 117.321093 311.869524 
-L 121.389654 314.420206 
-L 125.458214 313.623396 
-L 129.526775 313.408921 
-L 133.647496 313.874875 
-L 137.768217 315.038974 
-L 141.836778 314.938233 
-L 145.905338 315.14297 
-L 149.973899 314.24 
-L 154.09462 313.86 
-L 158.215341 313.646007 
-L 162.283902 313.163333 
-L 166.352462 313.04439 
-L 170.421023 312.600641 
-L 174.489583 311.008527 
-L 178.610304 308.353931 
-L 182.731026 310.039219 
-L 186.799586 307.870951 
-L 190.868147 305.5 
-L 194.936707 303.560825 
-L 199.057428 301.772708 
-L 203.17815 300.740292 
-L 207.24671 297.732687 
-L 211.315271 298.195848 
-L 215.383831 291.092646 
-L 219.452391 287.893333 
-L 223.573113 288.259359 
-L 227.693834 285.681882 
-L 231.762395 282.928 
-L 235.830955 270.4925 
-L 239.899515 273.893333 
-L 243.968076 268.899512 
-L 248.088797 262.579869 
-L 252.209519 255.437209 
-L 256.278079 248.713171 
-L 260.346639 248.180484 
-L 264.4152 247.048525 
-L 268.535921 234.88 
-L 272.656643 234.308553 
-L 276.725203 220.104467 
-L 280.793763 219.313813 
-L 284.862324 211.021774 
-L 288.930884 208.482885 
-L 293.051605 203.105036 
-L 297.172327 206.962415 
-L 301.240887 197.005461 
-L 305.309448 194.290701 
-L 309.378008 187.624 
-L 313.498729 177.959024 
-L 317.619451 175.283599 
-L 321.688011 163.523151 
-L 325.756572 162.467465 
-L 329.825132 163.481951 
-L 333.893692 150.228293 
-L 338.014414 149.104906 
-L 342.135135 157.459522 
-L 346.203696 144.970213 
-L 350.272256 138.961392 
-L 354.340816 141.661538 
-L 358.461538 136.755217 
-L 362.582259 128.844272 
-L 366.65082 125.23404 
-L 370.71938 123.367407 
-L 374.78794 117.4 
-L 378.856501 119.072 
-L 382.977222 115.740524 
-L 387.097944 111.690732 
-L 391.166504 110.538805 
-L 395.235064 112.429189 
-L 399.303625 113.417703 
-L 403.424346 104.432941 
-L 407.545068 96.127525 
-L 411.613628 103.064467 
-L 415.682188 99.050063 
-L 419.750749 89.595259 
-L 423.819309 98.346977 
-L 427.940031 99.628258 
-L 432.060752 91.824348 
-L 436.129312 92.997838 
-L 440.197873 91.462564 
-L 444.266433 91.361739 
-L 448.334994 87.133966 
-L 452.455715 87.211111 
-L 456.576436 88.728296 
-L 460.644997 83.559178 
-L 464.713557 88.836667 
-L 468.782118 84.352752 
-L 472.902839 84.724967 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m942f1f9cbb" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m942f1f9cbb" x="68.065432" y="317.806853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="72.358285" y="318.04" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="76.426845" y="317.430417" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="80.495406" y="316.956296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="84.563966" y="316.705668" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="88.684688" y="314.32791" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="92.805409" y="313.66252" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="96.873969" y="312.247918" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="100.94253" y="311.891159" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="105.01109" y="311.068303" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="109.131812" y="313.752821" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="113.252533" y="313.675797" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="117.321093" y="311.869524" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="121.389654" y="314.420206" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="125.458214" y="313.623396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="129.526775" y="313.408921" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="133.647496" y="313.874875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="137.768217" y="315.038974" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="141.836778" y="314.938233" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="145.905338" y="315.14297" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="149.973899" y="314.24" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="154.09462" y="313.86" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="158.215341" y="313.646007" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="162.283902" y="313.163333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="166.352462" y="313.04439" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="170.421023" y="312.600641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="174.489583" y="311.008527" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="178.610304" y="308.353931" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="182.731026" y="310.039219" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="186.799586" y="307.870951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="190.868147" y="305.5" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="194.936707" y="303.560825" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="199.057428" y="301.772708" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="203.17815" y="300.740292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="207.24671" y="297.732687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="211.315271" y="298.195848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="215.383831" y="291.092646" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="219.452391" y="287.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="223.573113" y="288.259359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="227.693834" y="285.681882" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="231.762395" y="282.928" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="235.830955" y="270.4925" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="239.899515" y="273.893333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="243.968076" y="268.899512" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="248.088797" y="262.579869" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="252.209519" y="255.437209" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="256.278079" y="248.713171" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="260.346639" y="248.180484" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="264.4152" y="247.048525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="268.535921" y="234.88" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="272.656643" y="234.308553" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="276.725203" y="220.104467" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="280.793763" y="219.313813" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="284.862324" y="211.021774" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="288.930884" y="208.482885" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="293.051605" y="203.105036" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="297.172327" y="206.962415" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="301.240887" y="197.005461" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="305.309448" y="194.290701" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="309.378008" y="187.624" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="313.498729" y="177.959024" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="317.619451" y="175.283599" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="321.688011" y="163.523151" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="325.756572" y="162.467465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="329.825132" y="163.481951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="333.893692" y="150.228293" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="338.014414" y="149.104906" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="342.135135" y="157.459522" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="346.203696" y="144.970213" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="350.272256" y="138.961392" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="354.340816" y="141.661538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="358.461538" y="136.755217" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="362.582259" y="128.844272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="366.65082" y="125.23404" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="370.71938" y="123.367407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="374.78794" y="117.4" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="378.856501" y="119.072" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="382.977222" y="115.740524" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="387.097944" y="111.690732" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="391.166504" y="110.538805" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="395.235064" y="112.429189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="399.303625" y="113.417703" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="403.424346" y="104.432941" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="407.545068" y="96.127525" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="411.613628" y="103.064467" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="415.682188" y="99.050063" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="419.750749" y="89.595259" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="423.819309" y="98.346977" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="427.940031" y="99.628258" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="432.060752" y="91.824348" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="436.129312" y="92.997838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="440.197873" y="91.462564" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="444.266433" y="91.361739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="448.334994" y="87.133966" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="452.455715" y="87.211111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="456.576436" y="88.728296" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="460.644997" y="83.559178" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="464.713557" y="88.836667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="468.782118" y="84.352752" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m942f1f9cbb" x="472.902839" y="84.724967" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 68.070648 318.04 
-L 72.358285 313.305372 
-L 76.426845 312.302745 
-L 80.495406 305.796454 
-L 84.616127 306.428889 
-L 88.736849 299.321481 
-L 92.805409 295.842759 
-L 96.873969 296.067807 
-L 100.94253 300.229565 
-L 105.063251 299.469077 
-L 109.183973 301.167445 
-L 113.252533 300.229565 
-L 117.321093 305.1425 
-L 121.389654 304.62 
-L 125.458214 306.872061 
-L 129.578936 308.876726 
-L 133.699657 308.73 
-L 137.768217 311.67913 
-L 141.836778 309.510769 
-L 145.905338 311.143 
-L 150.02606 310.698007 
-L 154.146781 310.1664 
-L 158.215341 312.739275 
-L 162.283902 312.902748 
-L 166.352462 309.422329 
-L 170.421023 309.49 
-L 174.541744 306.172308 
-L 178.662465 306.968649 
-L 182.731026 302.12256 
-L 186.799586 302.966667 
-L 190.868147 298.600137 
-L 194.988868 300.096585 
-L 199.109589 296.095 
-L 203.17815 291.065938 
-L 207.24671 284.687692 
-L 211.315271 286.179111 
-L 215.383831 277.03619 
-L 219.504552 277.033285 
-L 223.625274 269.648462 
-L 227.693834 263.066667 
-L 231.762395 259.06102 
-L 235.830955 249.729582 
-L 239.951676 252.433594 
-L 244.072398 235.599416 
-L 248.140958 235.87792 
-L 252.209519 225.649904 
-L 256.278079 217.478556 
-L 260.346639 209.201667 
-L 264.467361 197.28791 
-L 268.588082 199.71854 
-L 272.656643 193.992751 
-L 276.725203 189.205271 
-L 280.793763 181.572308 
-L 284.914485 170.22 
-L 289.035206 159.64311 
-L 293.103767 160.199203 
-L 297.172327 157.210897 
-L 301.240887 148.272082 
-L 305.309448 142.48 
-L 309.430169 135.399288 
-L 313.55089 138.770986 
-L 317.619451 122.628693 
-L 321.688011 121.109215 
-L 325.756572 118.096667 
-L 329.877293 108.542751 
-L 333.998014 114.737185 
-L 338.066575 106.011014 
-L 342.135135 100.087559 
-L 346.203696 94.699625 
-L 350.272256 101.306319 
-L 354.392977 94.359024 
-L 358.513699 87.68212 
-L 362.582259 86.874789 
-L 366.65082 80.66 
-L 370.71938 78.45812 
-L 374.840101 83.550769 
-L 378.960823 77.207692 
-L 383.029383 73.870345 
-L 387.097944 69.064 
-L 391.166504 69.33 
-L 395.235064 74.750295 
-L 399.355786 67.717714 
-L 403.476507 67.59957 
-L 407.545068 63.605217 
-L 411.613628 62.793191 
-L 415.682188 67.173386 
-L 419.80291 59.96259 
-L 423.923631 63.703077 
-L 427.992192 61.21371 
-L 432.060752 57.054253 
-L 436.129312 62.129655 
-L 440.197873 61.359172 
-L 444.318594 57.436547 
-L 448.439316 58.88 
-L 452.507876 57.685714 
-L 456.576436 56.707004 
-L 460.644997 55.350222 
-L 464.765718 56.96662 
-L 468.88644 55.659344 
-L 472.955 50.745946 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="m4d42af8b23" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m4d42af8b23" x="68.070648" y="318.04" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="72.358285" y="313.305372" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="76.426845" y="312.302745" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="80.495406" y="305.796454" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="84.616127" y="306.428889" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="88.736849" y="299.321481" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="92.805409" y="295.842759" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="96.873969" y="296.067807" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="100.94253" y="300.229565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="105.063251" y="299.469077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="109.183973" y="301.167445" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="113.252533" y="300.229565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="117.321093" y="305.1425" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="121.389654" y="304.62" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="125.458214" y="306.872061" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="129.578936" y="308.876726" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="133.699657" y="308.73" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="137.768217" y="311.67913" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="141.836778" y="309.510769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="145.905338" y="311.143" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="150.02606" y="310.698007" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="154.146781" y="310.1664" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="158.215341" y="312.739275" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="162.283902" y="312.902748" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="166.352462" y="309.422329" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="170.421023" y="309.49" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="174.541744" y="306.172308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="178.662465" y="306.968649" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="182.731026" y="302.12256" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="186.799586" y="302.966667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="190.868147" y="298.600137" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="194.988868" y="300.096585" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="199.109589" y="296.095" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="203.17815" y="291.065938" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="207.24671" y="284.687692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="211.315271" y="286.179111" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="215.383831" y="277.03619" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="219.504552" y="277.033285" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="223.625274" y="269.648462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="227.693834" y="263.066667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="231.762395" y="259.06102" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="235.830955" y="249.729582" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="239.951676" y="252.433594" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="244.072398" y="235.599416" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="248.140958" y="235.87792" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="252.209519" y="225.649904" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="256.278079" y="217.478556" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="260.346639" y="209.201667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="264.467361" y="197.28791" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="268.588082" y="199.71854" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="272.656643" y="193.992751" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="276.725203" y="189.205271" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="280.793763" y="181.572308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="284.914485" y="170.22" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="289.035206" y="159.64311" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="293.103767" y="160.199203" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="297.172327" y="157.210897" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="301.240887" y="148.272082" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="305.309448" y="142.48" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="309.430169" y="135.399288" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="313.55089" y="138.770986" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="317.619451" y="122.628693" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="321.688011" y="121.109215" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="325.756572" y="118.096667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="329.877293" y="108.542751" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="333.998014" y="114.737185" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="338.066575" y="106.011014" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="342.135135" y="100.087559" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="346.203696" y="94.699625" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="350.272256" y="101.306319" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="354.392977" y="94.359024" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="358.513699" y="87.68212" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="362.582259" y="86.874789" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="366.65082" y="80.66" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="370.71938" y="78.45812" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="374.840101" y="83.550769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="378.960823" y="77.207692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="383.029383" y="73.870345" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="387.097944" y="69.064" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="391.166504" y="69.33" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="395.235064" y="74.750295" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="399.355786" y="67.717714" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="403.476507" y="67.59957" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="407.545068" y="63.605217" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="411.613628" y="62.793191" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="415.682188" y="67.173386" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="419.80291" y="59.96259" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="423.923631" y="63.703077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="427.992192" y="61.21371" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="432.060752" y="57.054253" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="436.129312" y="62.129655" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="440.197873" y="61.359172" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="444.318594" y="57.436547" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="448.439316" y="58.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="452.507876" y="57.685714" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="456.576436" y="56.707004" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="460.644997" y="55.350222" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="464.765718" y="56.96662" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="468.88644" y="55.659344" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m4d42af8b23" x="472.955" y="50.745946" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_19">
-    <path d="M 68.060216 317.763962 
-L 72.358285 316.881188 
-L 76.426845 315.960609 
-L 80.495406 315.590326 
-L 84.563966 312.922281 
-L 88.684688 309.036923 
-L 92.805409 307.625424 
-L 96.873969 307.966885 
-L 100.94253 305.89434 
-L 105.01109 307.781514 
-L 109.131812 306.968649 
-L 113.252533 305.785812 
-L 117.321093 308.286667 
-L 121.389654 309.401333 
-L 125.458214 311.182187 
-L 129.526775 312.962922 
-L 133.647496 314.514699 
-L 137.768217 313.257115 
-L 141.836778 315.216667 
-L 145.905338 313.117757 
-L 149.973899 313.669212 
-L 154.042459 314.298995 
-L 158.16318 312.892407 
-L 162.283902 313.764566 
-L 166.352462 313.187122 
-L 170.421023 312.931111 
-L 174.489583 311.113143 
-L 178.610304 309.276135 
-L 182.731026 308.837258 
-L 186.799586 307.245049 
-L 190.868147 304.605447 
-L 194.936707 299.220793 
-L 199.005267 295.574976 
-L 203.125989 298.369412 
-L 207.24671 294.96169 
-L 211.315271 292.170644 
-L 215.383831 288.649956 
-L 219.452391 286.624 
-L 223.520952 277.663755 
-L 227.641673 285.074585 
-L 231.762395 268.623111 
-L 235.830955 269.100708 
-L 239.899515 260.467692 
-L 243.968076 254.386667 
-L 248.088797 252.333333 
-L 252.209519 250.914118 
-L 256.278079 244.760531 
-L 260.346639 237.322759 
-L 264.4152 227.853333 
-L 268.48376 234.097377 
-L 272.604481 217.17 
-L 276.725203 203.260429 
-L 280.793763 200.035385 
-L 284.862324 201.254435 
-L 288.930884 193.293663 
-L 293.051605 195.098824 
-L 297.172327 187.924103 
-L 301.240887 177.425592 
-L 305.309448 168.827867 
-L 309.378008 169.08 
-L 313.446568 161.986667 
-L 317.56729 157.235043 
-L 321.688011 147.643529 
-L 325.756572 142.931892 
-L 329.825132 144.32315 
-L 333.893692 144.44 
-L 337.962253 134.6425 
-L 342.082974 127.533333 
-L 346.203696 129.788916 
-L 350.272256 123.357323 
-L 354.340816 120.535 
-L 358.409377 111.21589 
-L 362.530098 117.440192 
-L 366.65082 107.866043 
-L 370.71938 104.784685 
-L 374.78794 109.475829 
-L 378.856501 106.313133 
-L 382.925061 96.776364 
-L 387.045783 100.984 
-L 391.166504 95.234495 
-L 395.235064 91.01375 
-L 399.303625 94.194439 
-L 403.372185 92.926774 
-L 407.492907 80.865192 
-L 411.613628 86.526667 
-L 415.682188 84.437714 
-L 419.750749 83.420645 
-L 423.819309 80.984407 
-L 427.88787 82.478481 
-L 432.008591 76.72973 
-L 436.129312 78.328368 
-L 440.197873 76.246 
-L 444.266433 72.097838 
-L 448.334994 73.255122 
-L 452.403554 72.151031 
-L 456.524275 82.018578 
-L 460.644997 72.053333 
-L 464.713557 73.615556 
-L 468.782118 72.121985 
-L 472.850678 69.268787 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-    <defs>
-     <path id="m75121de8ea" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m75121de8ea" x="68.060216" y="317.763962" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="72.358285" y="316.881188" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="76.426845" y="315.960609" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="80.495406" y="315.590326" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="84.563966" y="312.922281" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="88.684688" y="309.036923" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="92.805409" y="307.625424" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="96.873969" y="307.966885" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="100.94253" y="305.89434" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="105.01109" y="307.781514" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="109.131812" y="306.968649" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="113.252533" y="305.785812" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="117.321093" y="308.286667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="121.389654" y="309.401333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="125.458214" y="311.182187" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="129.526775" y="312.962922" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="133.647496" y="314.514699" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="137.768217" y="313.257115" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="141.836778" y="315.216667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="145.905338" y="313.117757" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="149.973899" y="313.669212" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="154.042459" y="314.298995" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="158.16318" y="312.892407" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="162.283902" y="313.764566" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="166.352462" y="313.187122" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="170.421023" y="312.931111" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="174.489583" y="311.113143" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="178.610304" y="309.276135" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="182.731026" y="308.837258" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="186.799586" y="307.245049" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="190.868147" y="304.605447" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="194.936707" y="299.220793" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="199.005267" y="295.574976" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="203.125989" y="298.369412" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="207.24671" y="294.96169" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="211.315271" y="292.170644" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="215.383831" y="288.649956" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="219.452391" y="286.624" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="223.520952" y="277.663755" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="227.641673" y="285.074585" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="231.762395" y="268.623111" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="235.830955" y="269.100708" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="239.899515" y="260.467692" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="243.968076" y="254.386667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="248.088797" y="252.333333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="252.209519" y="250.914118" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="256.278079" y="244.760531" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="260.346639" y="237.322759" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="264.4152" y="227.853333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="268.48376" y="234.097377" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="272.604481" y="217.17" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="276.725203" y="203.260429" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="280.793763" y="200.035385" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="284.862324" y="201.254435" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="288.930884" y="193.293663" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="293.051605" y="195.098824" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="297.172327" y="187.924103" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="301.240887" y="177.425592" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="305.309448" y="168.827867" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="309.378008" y="169.08" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="313.446568" y="161.986667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="317.56729" y="157.235043" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="321.688011" y="147.643529" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="325.756572" y="142.931892" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="329.825132" y="144.32315" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="333.893692" y="144.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="337.962253" y="134.6425" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="342.082974" y="127.533333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="346.203696" y="129.788916" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="350.272256" y="123.357323" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="354.340816" y="120.535" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="358.409377" y="111.21589" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="362.530098" y="117.440192" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="366.65082" y="107.866043" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="370.71938" y="104.784685" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="374.78794" y="109.475829" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="378.856501" y="106.313133" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="382.925061" y="96.776364" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="387.045783" y="100.984" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="391.166504" y="95.234495" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="395.235064" y="91.01375" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="399.303625" y="94.194439" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="403.372185" y="92.926774" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="407.492907" y="80.865192" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="411.613628" y="86.526667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="415.682188" y="84.437714" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="419.750749" y="83.420645" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="423.819309" y="80.984407" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="427.88787" y="82.478481" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="432.008591" y="76.72973" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="436.129312" y="78.328368" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="440.197873" y="76.246" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="444.266433" y="72.097838" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="448.334994" y="73.255122" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="452.403554" y="72.151031" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="456.524275" y="82.018578" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="460.644997" y="72.053333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="464.713557" y="73.615556" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="468.782118" y="72.121985" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m75121de8ea" x="472.850678" y="69.268787" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_20">
-    <path d="M 68.060216 318.04 
-L 72.358285 318.04 
-L 76.426845 318.04 
-L 80.495406 318.04 
-L 84.563966 318.04 
-L 88.684688 317.146565 
-L 92.805409 318.04 
-L 96.873969 316.5 
-L 100.94253 316.861745 
-L 105.01109 318.04 
-L 109.131812 315.567324 
-L 113.252533 315.601667 
-L 117.321093 314.912977 
-L 121.389654 316.479467 
-L 125.458214 316.182222 
-L 129.526775 315.888529 
-L 133.647496 315.359695 
-L 137.768217 316.468993 
-L 141.836778 316.343768 
-L 145.905338 315.872593 
-L 149.973899 315.290738 
-L 154.09462 315.027941 
-L 158.215341 313.47461 
-L 162.283902 315.134752 
-L 166.352462 312.756944 
-L 170.421023 314.059048 
-L 174.489583 314.575 
-L 178.610304 310.825205 
-L 182.731026 309.552366 
-L 186.799586 308.661795 
-L 190.868147 310.454074 
-L 194.936707 308.561408 
-L 199.057428 307.636444 
-L 203.17815 307.014493 
-L 207.24671 300.666875 
-L 211.315271 307.0675 
-L 215.383831 304.222778 
-L 219.452391 299.805507 
-L 223.573113 301.808175 
-L 227.693834 297.685217 
-L 231.762395 296.958261 
-L 235.830955 299.23 
-L 239.899515 295.637812 
-L 244.020237 290.6192 
-L 248.140958 295.305612 
-L 252.209519 280.838 
-L 256.278079 286.590476 
-L 260.346639 280.298841 
-L 264.4152 282.45984 
-L 268.535921 278.084966 
-L 272.656643 273.873962 
-L 276.725203 263.76058 
-L 280.793763 269.771679 
-L 284.862324 266.835 
-L 288.983045 270.342192 
-L 293.103767 259.923586 
-L 297.172327 254.504 
-L 301.240887 253.017778 
-L 305.309448 253.668 
-L 309.378008 243.599118 
-L 313.498729 242.673333 
-L 317.619451 238.362769 
-L 321.688011 229.16 
-L 325.756572 233.471463 
-L 329.825132 235.678519 
-L 333.945853 239.058462 
-L 338.066575 227.264882 
-L 342.135135 217.17626 
-L 346.203696 219.778806 
-L 350.272256 218.703529 
-L 354.340816 212.429688 
-L 358.461538 214.743333 
-L 362.582259 209.640537 
-L 366.65082 207.700763 
-L 370.71938 201.88 
-L 374.78794 202.090435 
-L 378.856501 194.864839 
-L 382.977222 188.278261 
-L 387.097944 187.251325 
-L 391.166504 189.776986 
-L 395.235064 184.341022 
-L 399.303625 193.08 
-L 403.424346 184.28 
-L 407.545068 173.483974 
-L 411.613628 177.023056 
-L 415.682188 179.158028 
-L 419.750749 175.641333 
-L 423.819309 187.025075 
-L 427.940031 168.69696 
-L 432.060752 179.276667 
-L 436.129312 165.30695 
-L 440.197873 175.097705 
-L 444.266433 161.486496 
-L 448.387155 162.267338 
-L 452.507876 162.393056 
-L 456.576436 157.816276 
-L 460.644997 147.485 
-L 464.713557 154.867445 
-L 468.782118 160.116164 
-L 472.902839 152.370704 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
-    <defs>
-     <path id="m593a170770" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #9467bd"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m593a170770" x="68.060216" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="72.358285" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="76.426845" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="80.495406" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="84.563966" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="88.684688" y="317.146565" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="92.805409" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="96.873969" y="316.5" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="100.94253" y="316.861745" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="105.01109" y="318.04" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="109.131812" y="315.567324" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="113.252533" y="315.601667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="117.321093" y="314.912977" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="121.389654" y="316.479467" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="125.458214" y="316.182222" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="129.526775" y="315.888529" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="133.647496" y="315.359695" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="137.768217" y="316.468993" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="141.836778" y="316.343768" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="145.905338" y="315.872593" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="149.973899" y="315.290738" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="154.09462" y="315.027941" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="158.215341" y="313.47461" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="162.283902" y="315.134752" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="166.352462" y="312.756944" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="170.421023" y="314.059048" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="174.489583" y="314.575" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="178.610304" y="310.825205" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="182.731026" y="309.552366" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="186.799586" y="308.661795" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="190.868147" y="310.454074" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="194.936707" y="308.561408" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="199.057428" y="307.636444" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="203.17815" y="307.014493" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="207.24671" y="300.666875" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="211.315271" y="307.0675" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="215.383831" y="304.222778" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="219.452391" y="299.805507" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="223.573113" y="301.808175" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="227.693834" y="297.685217" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="231.762395" y="296.958261" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="235.830955" y="299.23" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="239.899515" y="295.637812" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="244.020237" y="290.6192" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="248.140958" y="295.305612" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="252.209519" y="280.838" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="256.278079" y="286.590476" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="260.346639" y="280.298841" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="264.4152" y="282.45984" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="268.535921" y="278.084966" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="272.656643" y="273.873962" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="276.725203" y="263.76058" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="280.793763" y="269.771679" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="284.862324" y="266.835" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="288.983045" y="270.342192" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="293.103767" y="259.923586" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="297.172327" y="254.504" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="301.240887" y="253.017778" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="305.309448" y="253.668" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="309.378008" y="243.599118" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="313.498729" y="242.673333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="317.619451" y="238.362769" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="321.688011" y="229.16" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="325.756572" y="233.471463" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="329.825132" y="235.678519" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="333.945853" y="239.058462" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="338.066575" y="227.264882" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="342.135135" y="217.17626" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="346.203696" y="219.778806" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="350.272256" y="218.703529" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="354.340816" y="212.429688" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="358.461538" y="214.743333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="362.582259" y="209.640537" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="366.65082" y="207.700763" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="370.71938" y="201.88" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="374.78794" y="202.090435" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="378.856501" y="194.864839" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="382.977222" y="188.278261" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="387.097944" y="187.251325" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="391.166504" y="189.776986" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="395.235064" y="184.341022" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="399.303625" y="193.08" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="403.424346" y="184.28" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="407.545068" y="173.483974" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="411.613628" y="177.023056" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="415.682188" y="179.158028" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="419.750749" y="175.641333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="423.819309" y="187.025075" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="427.940031" y="168.69696" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="432.060752" y="179.276667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="436.129312" y="165.30695" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="440.197873" y="175.097705" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="444.266433" y="161.486496" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="448.387155" y="162.267338" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="452.507876" y="162.393056" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="456.576436" y="157.816276" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="460.644997" y="147.485" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="464.713557" y="154.867445" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="468.782118" y="160.116164" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#m593a170770" x="472.902839" y="152.370704" style="fill: #9467bd; stroke: #9467bd"/>
-    </g>
-   </g>
-   <g id="line2d_21">
-    <path d="M 68.055 308.16 
-L 72.358285 286.843676 
-L 76.426845 269.273333 
-L 80.495406 259.745077 
-L 84.563966 246.491019 
-L 88.684688 247.092973 
-L 92.805409 251.831241 
-L 96.873969 246.082074 
-L 100.94253 253.168992 
-L 105.01109 256.496827 
-L 109.079651 265.807273 
-L 113.200372 271.921589 
-L 117.321093 278.471317 
-L 121.389654 281.348889 
-L 125.458214 287.279487 
-L 129.526775 296.304 
-L 133.647496 296.152598 
-L 137.768217 299.410796 
-L 141.836778 306.110923 
-L 145.905338 307.700777 
-L 149.973899 308.6768 
-L 154.09462 309.262 
-L 158.215341 308.830295 
-L 162.283902 309.68 
-L 166.352462 306.986222 
-L 170.421023 306.769481 
-L 174.489583 304.889438 
-L 178.610304 303.98681 
-L 182.731026 302.241825 
-L 186.799586 299.819487 
-L 190.868147 291.945836 
-L 194.936707 283.667658 
-L 199.057428 287.114797 
-L 203.17815 274.465755 
-L 207.24671 266.304928 
-L 211.315271 263.816923 
-L 215.383831 259.927805 
-L 219.452391 245.166038 
-L 223.573113 239.138897 
-L 227.693834 225.002344 
-L 231.762395 215.479175 
-L 235.830955 208.392 
-L 239.899515 207.387746 
-L 244.020237 180.985725 
-L 248.140958 181.059852 
-L 252.209519 171.161739 
-L 256.278079 166.717761 
-L 260.346639 150.964312 
-L 264.467361 140.854444 
-L 268.588082 129.338667 
-L 272.656643 125.578917 
-L 276.725203 118.383529 
-L 280.793763 102.450694 
-L 284.862324 105.444615 
-L 288.983045 103.3248 
-L 293.103767 91.857163 
-L 297.172327 91.249689 
-L 301.240887 81.751698 
-L 305.309448 72.706154 
-L 309.430169 72.337561 
-L 313.55089 65.580072 
-L 317.619451 62.81729 
-L 321.688011 67.921185 
-L 325.756572 58.227801 
-L 329.825132 54.595872 
-L 333.945853 51.0425 
-L 338.066575 55.264865 
-L 342.135135 51.666355 
-L 346.203696 50.390388 
-L 350.272256 45.504 
-L 354.392977 44.946667 
-L 358.513699 43.212741 
-L 362.582259 43.858645 
-L 366.65082 41.195385 
-L 370.71938 39.652 
-L 374.840101 39.713171 
-L 378.960823 38.247407 
-L 383.029383 36.511351 
-L 387.097944 35.269531 
-L 391.166504 37.100812 
-L 395.235064 36.230922 
-L 399.355786 35.921194 
-L 403.476507 34.668961 
-L 407.545068 34.935698 
-L 411.613628 34.295 
-L 415.682188 34.857011 
-L 419.80291 32.779142 
-L 423.923631 33.491409 
-L 427.992192 33.480916 
-L 432.060752 31.623245 
-L 436.129312 30.92625 
-L 440.197873 33.873013 
-L 444.318594 32.948226 
-L 448.439316 32.936364 
-L 452.507876 29.807164 
-L 456.576436 31.203333 
-L 460.644997 31.942222 
-L 464.765718 29.873333 
-L 468.88644 33.309931 
-L 472.955 29.28438 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
-    <defs>
-     <path id="m32f79c2545" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #8c564b"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m32f79c2545" x="68.055" y="308.16" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="72.358285" y="286.843676" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="76.426845" y="269.273333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="80.495406" y="259.745077" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="84.563966" y="246.491019" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="88.684688" y="247.092973" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="92.805409" y="251.831241" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="96.873969" y="246.082074" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="100.94253" y="253.168992" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="105.01109" y="256.496827" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="109.079651" y="265.807273" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="113.200372" y="271.921589" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="117.321093" y="278.471317" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="121.389654" y="281.348889" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="125.458214" y="287.279487" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="129.526775" y="296.304" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="133.647496" y="296.152598" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="137.768217" y="299.410796" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="141.836778" y="306.110923" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="145.905338" y="307.700777" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="149.973899" y="308.6768" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="154.09462" y="309.262" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="158.215341" y="308.830295" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="162.283902" y="309.68" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="166.352462" y="306.986222" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="170.421023" y="306.769481" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="174.489583" y="304.889438" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="178.610304" y="303.98681" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="182.731026" y="302.241825" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="186.799586" y="299.819487" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="190.868147" y="291.945836" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="194.936707" y="283.667658" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="199.057428" y="287.114797" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="203.17815" y="274.465755" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="207.24671" y="266.304928" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="211.315271" y="263.816923" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="215.383831" y="259.927805" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="219.452391" y="245.166038" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="223.573113" y="239.138897" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="227.693834" y="225.002344" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="231.762395" y="215.479175" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="235.830955" y="208.392" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="239.899515" y="207.387746" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="244.020237" y="180.985725" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="248.140958" y="181.059852" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="252.209519" y="171.161739" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="256.278079" y="166.717761" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="260.346639" y="150.964312" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="264.467361" y="140.854444" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="268.588082" y="129.338667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="272.656643" y="125.578917" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="276.725203" y="118.383529" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="280.793763" y="102.450694" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="284.862324" y="105.444615" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="288.983045" y="103.3248" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="293.103767" y="91.857163" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="297.172327" y="91.249689" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="301.240887" y="81.751698" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="305.309448" y="72.706154" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="309.430169" y="72.337561" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="313.55089" y="65.580072" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="317.619451" y="62.81729" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="321.688011" y="67.921185" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="325.756572" y="58.227801" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="329.825132" y="54.595872" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="333.945853" y="51.0425" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="338.066575" y="55.264865" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="342.135135" y="51.666355" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="346.203696" y="50.390388" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="350.272256" y="45.504" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="354.392977" y="44.946667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="358.513699" y="43.212741" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="362.582259" y="43.858645" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="366.65082" y="41.195385" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="370.71938" y="39.652" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="374.840101" y="39.713171" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="378.960823" y="38.247407" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="383.029383" y="36.511351" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="387.097944" y="35.269531" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="391.166504" y="37.100812" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="395.235064" y="36.230922" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="399.355786" y="35.921194" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="403.476507" y="34.668961" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="407.545068" y="34.935698" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="411.613628" y="34.295" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="415.682188" y="34.857011" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="419.80291" y="32.779142" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="423.923631" y="33.491409" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="427.992192" y="33.480916" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="432.060752" y="31.623245" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="436.129312" y="30.92625" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="440.197873" y="33.873013" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="444.318594" y="32.948226" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="448.439316" y="32.936364" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="452.507876" y="29.807164" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="456.576436" y="31.203333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="460.644997" y="31.942222" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="464.765718" y="29.873333" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="468.88644" y="33.309931" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m32f79c2545" x="472.955" y="29.28438" style="fill: #8c564b; stroke: #8c564b"/>
-    </g>
-   </g>
-   <g id="line2d_22">
-    <path d="M 68.055 304.964103 
-L 72.358285 284.211163 
-L 76.426845 259.095942 
-L 80.495406 252.287191 
-L 84.563966 252.595878 
-L 88.684688 249.661792 
-L 92.805409 239.026615 
-L 96.873969 249.166462 
-L 100.94253 256.130811 
-L 105.01109 261.11393 
-L 109.079651 261.463469 
-L 113.200372 269.434545 
-L 117.321093 278.636533 
-L 121.389654 280.471605 
-L 125.458214 286.8 
-L 129.526775 291.418197 
-L 133.647496 297.63089 
-L 137.768217 300.828235 
-L 141.836778 308.837258 
-L 145.905338 309.434118 
-L 149.973899 310.294706 
-L 154.042459 310.991971 
-L 158.16318 311.415094 
-L 162.283902 308.027072 
-L 166.352462 309.561837 
-L 170.421023 307.636444 
-L 174.489583 305.137953 
-L 178.610304 303.011518 
-L 182.731026 301.064733 
-L 186.799586 296.513 
-L 190.868147 288.23206 
-L 194.936707 281.437603 
-L 199.005267 278.593185 
-L 203.125989 270.293556 
-L 207.24671 269.273333 
-L 211.315271 255.159686 
-L 215.383831 246.515556 
-L 219.452391 242.703908 
-L 223.573113 234.753109 
-L 227.693834 222.473065 
-L 231.762395 208.7 
-L 235.830955 199.943682 
-L 239.899515 187.738273 
-L 243.968076 174.852766 
-L 248.088797 167.154478 
-L 252.209519 152.268043 
-L 256.278079 142.866271 
-L 260.346639 144.505692 
-L 264.4152 132.355433 
-L 268.535921 118.654 
-L 272.656643 112.058051 
-L 276.725203 110.065576 
-L 280.793763 102.233043 
-L 284.862324 90.262154 
-L 288.930884 86.556451 
-L 293.051605 82.868209 
-L 297.172327 79.269466 
-L 301.240887 76.590815 
-L 305.309448 68.019068 
-L 309.378008 66.678926 
-L 313.498729 61.709049 
-L 317.619451 57.456377 
-L 321.688011 54.921667 
-L 325.756572 52.990653 
-L 329.825132 51.728281 
-L 333.893692 47.947692 
-L 338.014414 45.25753 
-L 342.135135 49.611304 
-L 346.203696 44.872214 
-L 350.272256 45.510909 
-L 354.340816 41.211348 
-L 358.461538 40.34397 
-L 362.582259 40.998889 
-L 366.65082 36.545985 
-L 370.71938 38.4208 
-L 374.78794 40.885799 
-L 378.856501 35.670769 
-L 382.977222 35.9736 
-L 387.097944 35.436299 
-L 391.166504 37.79 
-L 395.235064 33.91531 
-L 399.303625 32.967469 
-L 403.424346 32.829898 
-L 407.545068 35.9736 
-L 411.613628 32.958194 
-L 415.682188 35.358644 
-L 419.750749 31.442051 
-L 423.819309 32.834224 
-L 427.940031 32.755 
-L 432.060752 31.479431 
-L 436.129312 33.533191 
-L 440.197873 32.337 
-L 444.266433 33.890542 
-L 448.387155 33.325674 
-L 452.507876 33.440781 
-L 456.576436 31.870769 
-L 460.644997 31.351111 
-L 464.713557 31.685217 
-L 468.782118 30.82384 
-L 472.902839 34.02 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
-    <defs>
-     <path id="m5f84e627c7" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #e377c2"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m5f84e627c7" x="68.055" y="304.964103" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="72.358285" y="284.211163" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="76.426845" y="259.095942" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="80.495406" y="252.287191" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="84.563966" y="252.595878" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="88.684688" y="249.661792" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="92.805409" y="239.026615" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="96.873969" y="249.166462" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="100.94253" y="256.130811" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="105.01109" y="261.11393" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="109.079651" y="261.463469" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="113.200372" y="269.434545" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="117.321093" y="278.636533" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="121.389654" y="280.471605" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="125.458214" y="286.8" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="129.526775" y="291.418197" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="133.647496" y="297.63089" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="137.768217" y="300.828235" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="141.836778" y="308.837258" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="145.905338" y="309.434118" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="149.973899" y="310.294706" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="154.042459" y="310.991971" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="158.16318" y="311.415094" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="162.283902" y="308.027072" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="166.352462" y="309.561837" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="170.421023" y="307.636444" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="174.489583" y="305.137953" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="178.610304" y="303.011518" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="182.731026" y="301.064733" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="186.799586" y="296.513" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="190.868147" y="288.23206" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="194.936707" y="281.437603" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="199.005267" y="278.593185" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="203.125989" y="270.293556" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="207.24671" y="269.273333" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="211.315271" y="255.159686" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="215.383831" y="246.515556" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="219.452391" y="242.703908" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="223.573113" y="234.753109" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="227.693834" y="222.473065" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="231.762395" y="208.7" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="235.830955" y="199.943682" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="239.899515" y="187.738273" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="243.968076" y="174.852766" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="248.088797" y="167.154478" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="252.209519" y="152.268043" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="256.278079" y="142.866271" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="260.346639" y="144.505692" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="264.4152" y="132.355433" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="268.535921" y="118.654" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="272.656643" y="112.058051" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="276.725203" y="110.065576" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="280.793763" y="102.233043" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="284.862324" y="90.262154" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="288.930884" y="86.556451" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="293.051605" y="82.868209" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="297.172327" y="79.269466" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="301.240887" y="76.590815" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="305.309448" y="68.019068" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="309.378008" y="66.678926" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="313.498729" y="61.709049" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="317.619451" y="57.456377" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="321.688011" y="54.921667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="325.756572" y="52.990653" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="329.825132" y="51.728281" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="333.893692" y="47.947692" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="338.014414" y="45.25753" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="342.135135" y="49.611304" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="346.203696" y="44.872214" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="350.272256" y="45.510909" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="354.340816" y="41.211348" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="358.461538" y="40.34397" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="362.582259" y="40.998889" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="366.65082" y="36.545985" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="370.71938" y="38.4208" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="374.78794" y="40.885799" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="378.856501" y="35.670769" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="382.977222" y="35.9736" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="387.097944" y="35.436299" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="391.166504" y="37.79" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="395.235064" y="33.91531" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="399.303625" y="32.967469" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="403.424346" y="32.829898" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="407.545068" y="35.9736" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="411.613628" y="32.958194" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="415.682188" y="35.358644" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="419.750749" y="31.442051" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="423.819309" y="32.834224" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="427.940031" y="32.755" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="432.060752" y="31.479431" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="436.129312" y="33.533191" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="440.197873" y="32.337" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="444.266433" y="33.890542" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="448.387155" y="33.325674" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="452.507876" y="33.440781" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="456.576436" y="31.870769" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="460.644997" y="31.351111" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="464.713557" y="31.685217" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="468.782118" y="30.82384" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#m5f84e627c7" x="472.902839" y="34.02" style="fill: #e377c2; stroke: #e377c2"/>
-    </g>
-   </g>
-   <g id="line2d_23">
-    <path d="M 68.060216 318.04 
-L 72.358285 317.662452 
-L 76.426845 317.539829 
-L 80.495406 314.446667 
-L 84.563966 312.951304 
-L 88.684688 311.052537 
-L 92.805409 311.39 
-L 96.873969 307.093813 
-L 100.94253 305.902519 
-L 105.01109 307.093813 
-L 109.131812 304.535385 
-L 113.252533 309.552366 
-L 117.321093 309.885574 
-L 121.389654 309.61312 
-L 125.458214 312.330732 
-L 129.526775 309.68 
-L 133.647496 314.138667 
-L 137.768217 312.806504 
-L 141.836778 313.243279 
-L 145.905338 311.124 
-L 149.973899 314.626333 
-L 154.09462 311.85831 
-L 158.215341 312.302745 
-L 162.283902 311.88 
-L 166.352462 310.08128 
-L 170.421023 311.585588 
-L 174.489583 309.609153 
-L 178.610304 303.115436 
-L 182.731026 304.884341 
-L 186.799586 303.203944 
-L 190.868147 302.162481 
-L 194.936707 298.033162 
-L 199.057428 298.233231 
-L 203.17815 294.292754 
-L 207.24671 296.402353 
-L 211.315271 289.863704 
-L 215.383831 290.90029 
-L 219.504552 283.945739 
-L 223.625274 279.608955 
-L 227.693834 274.786087 
-L 231.762395 268.808889 
-L 235.830955 260.011765 
-L 239.899515 256.026269 
-L 244.020237 251.497097 
-L 248.140958 255.804444 
-L 252.209519 248.682963 
-L 256.278079 243.969231 
-L 260.346639 245.851095 
-L 264.467361 236.196812 
-L 268.588082 230.849128 
-L 272.656643 216.635115 
-L 276.725203 213.107586 
-L 280.793763 209.016438 
-L 284.862324 208.136585 
-L 288.983045 198.135385 
-L 293.103767 184.411654 
-L 297.172327 194.142188 
-L 301.240887 189.729481 
-L 305.309448 168.814 
-L 309.430169 169.523333 
-L 313.55089 175.694054 
-L 317.619451 159.469677 
-L 321.688011 151.72 
-L 325.756572 149.542759 
-L 329.825132 150.365674 
-L 333.945853 143.41632 
-L 338.066575 136.079375 
-L 342.135135 132.499845 
-L 346.203696 139.015 
-L 350.272256 125.295556 
-L 354.392977 125.411667 
-L 358.513699 122.391045 
-L 362.582259 114.195333 
-L 366.65082 125.295556 
-L 370.71938 103.76 
-L 374.78794 125.698529 
-L 378.908662 117.587164 
-L 383.029383 99.296276 
-L 387.097944 100.99194 
-L 391.166504 106.077795 
-L 395.235064 100.171622 
-L 399.355786 101.112414 
-L 403.476507 98.808358 
-L 407.545068 106.017538 
-L 411.613628 86.210769 
-L 415.682188 97.729412 
-L 419.750749 93.713333 
-L 423.87147 79.845313 
-L 427.992192 91.107481 
-L 432.060752 83.96 
-L 436.129312 81.555068 
-L 440.197873 86.08029 
-L 444.318594 78.296774 
-L 448.439316 84.464483 
-L 452.507876 76.099104 
-L 456.576436 68.674925 
-L 460.644997 70.843448 
-L 464.713557 81.015597 
-L 468.834279 66.943546 
-L 472.955 74.920325 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
-    <defs>
-     <path id="m220b9d30a3" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #7f7f7f"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m220b9d30a3" x="68.060216" y="318.04" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="72.358285" y="317.662452" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="76.426845" y="317.539829" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="80.495406" y="314.446667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="84.563966" y="312.951304" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="88.684688" y="311.052537" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="92.805409" y="311.39" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="96.873969" y="307.093813" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="100.94253" y="305.902519" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="105.01109" y="307.093813" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="109.131812" y="304.535385" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="113.252533" y="309.552366" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="117.321093" y="309.885574" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="121.389654" y="309.61312" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="125.458214" y="312.330732" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="129.526775" y="309.68" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="133.647496" y="314.138667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="137.768217" y="312.806504" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="141.836778" y="313.243279" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="145.905338" y="311.124" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="149.973899" y="314.626333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="154.09462" y="311.85831" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="158.215341" y="312.302745" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="162.283902" y="311.88" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="166.352462" y="310.08128" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="170.421023" y="311.585588" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="174.489583" y="309.609153" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="178.610304" y="303.115436" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="182.731026" y="304.884341" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="186.799586" y="303.203944" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="190.868147" y="302.162481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="194.936707" y="298.033162" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="199.057428" y="298.233231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="203.17815" y="294.292754" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="207.24671" y="296.402353" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="211.315271" y="289.863704" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="215.383831" y="290.90029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="219.504552" y="283.945739" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="223.625274" y="279.608955" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="227.693834" y="274.786087" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="231.762395" y="268.808889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="235.830955" y="260.011765" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="239.899515" y="256.026269" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="244.020237" y="251.497097" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="248.140958" y="255.804444" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="252.209519" y="248.682963" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="256.278079" y="243.969231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="260.346639" y="245.851095" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="264.467361" y="236.196812" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="268.588082" y="230.849128" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="272.656643" y="216.635115" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="276.725203" y="213.107586" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="280.793763" y="209.016438" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="284.862324" y="208.136585" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="288.983045" y="198.135385" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="293.103767" y="184.411654" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="297.172327" y="194.142188" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="301.240887" y="189.729481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="305.309448" y="168.814" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="309.430169" y="169.523333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="313.55089" y="175.694054" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="317.619451" y="159.469677" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="321.688011" y="151.72" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="325.756572" y="149.542759" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="329.825132" y="150.365674" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="333.945853" y="143.41632" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="338.066575" y="136.079375" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="342.135135" y="132.499845" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="346.203696" y="139.015" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="350.272256" y="125.295556" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="354.392977" y="125.411667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="358.513699" y="122.391045" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="362.582259" y="114.195333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="366.65082" y="125.295556" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="370.71938" y="103.76" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="374.78794" y="125.698529" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="378.908662" y="117.587164" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="383.029383" y="99.296276" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="387.097944" y="100.99194" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="391.166504" y="106.077795" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="395.235064" y="100.171622" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="399.355786" y="101.112414" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="403.476507" y="98.808358" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="407.545068" y="106.017538" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="411.613628" y="86.210769" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="415.682188" y="97.729412" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="419.750749" y="93.713333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="423.87147" y="79.845313" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="427.992192" y="91.107481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="432.060752" y="83.96" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="436.129312" y="81.555068" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="440.197873" y="86.08029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="444.318594" y="78.296774" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="448.439316" y="84.464483" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="452.507876" y="76.099104" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="456.576436" y="68.674925" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="460.644997" y="70.843448" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="464.713557" y="81.015597" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="468.834279" y="66.943546" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m220b9d30a3" x="472.955" y="74.920325" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-    </g>
-   </g>
-   <g id="line2d_24">
-    <path d="M 68.055 314.943704 
-L 72.358285 300.874133 
-L 76.426845 288.014031 
-L 80.495406 275.530189 
-L 84.563966 266.373694 
-L 88.684688 267.758252 
-L 92.805409 255.686812 
-L 96.873969 265.994553 
-L 100.94253 266.835 
-L 105.01109 269.753005 
-L 109.079651 274.821101 
-L 113.200372 282.928 
-L 117.321093 284.28893 
-L 121.389654 286.373333 
-L 125.458214 295.939362 
-L 129.526775 295.130043 
-L 133.647496 298.951931 
-L 137.768217 304.418966 
-L 141.836778 308.954703 
-L 145.905338 307.470308 
-L 149.973899 310.255229 
-L 154.042459 312.094118 
-L 158.16318 312.270423 
-L 162.283902 310.76 
-L 166.352462 308.286667 
-L 170.421023 307.59 
-L 174.489583 306.918552 
-L 178.610304 304.385333 
-L 182.731026 303.478685 
-L 186.799586 299.6323 
-L 190.868147 295.785915 
-L 194.936707 290.582749 
-L 199.005267 290.694206 
-L 203.125989 278.484815 
-L 207.24671 275.42835 
-L 211.315271 265.839061 
-L 215.383831 258.988 
-L 219.452391 259.52 
-L 223.573113 246.305806 
-L 227.693834 233.604 
-L 231.762395 218.610185 
-L 235.830955 227.967742 
-L 239.899515 214.032838 
-L 244.020237 197.973103 
-L 248.140958 200.437308 
-L 252.209519 180.1 
-L 256.278079 175.593756 
-L 260.346639 171.882732 
-L 264.4152 159.052035 
-L 268.535921 145.127964 
-L 272.656643 148.84087 
-L 276.725203 140.39 
-L 280.793763 136.88 
-L 284.862324 127.336667 
-L 288.983045 121.458252 
-L 293.103767 109.257708 
-L 297.172327 105.152428 
-L 301.240887 97.407149 
-L 305.309448 106.4275 
-L 309.378008 83.446667 
-L 313.498729 89.729577 
-L 317.619451 85.476062 
-L 321.688011 81.665098 
-L 325.756572 73.842056 
-L 329.825132 72.256 
-L 333.945853 73.53863 
-L 338.066575 69.6226 
-L 342.135135 69.396199 
-L 346.203696 65.353641 
-L 350.272256 66.642857 
-L 354.340816 56.213448 
-L 358.461538 54.562629 
-L 362.582259 56.650667 
-L 366.65082 55.936338 
-L 370.71938 53.902 
-L 374.78794 43.832 
-L 378.908662 45.686256 
-L 383.029383 44.848643 
-L 387.097944 48.4 
-L 391.166504 45.984255 
-L 395.235064 46.595117 
-L 399.303625 44.260503 
-L 403.424346 40.827729 
-L 407.545068 42.083303 
-L 411.613628 42.859907 
-L 415.682188 38.085025 
-L 419.750749 42.741565 
-L 423.87147 41.027103 
-L 427.992192 39.29256 
-L 432.060752 39.7774 
-L 436.129312 38.148889 
-L 440.197873 37.688372 
-L 444.318594 36.525286 
-L 448.439316 40.780194 
-L 452.507876 39.667339 
-L 456.576436 38.137736 
-L 460.644997 42.237407 
-L 464.713557 34.543111 
-L 468.834279 35.716683 
-L 472.955 37.144 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
-    <defs>
-     <path id="m80f4c965dc" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #bcbd22"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m80f4c965dc" x="68.055" y="314.943704" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="72.358285" y="300.874133" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="76.426845" y="288.014031" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="80.495406" y="275.530189" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="84.563966" y="266.373694" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="88.684688" y="267.758252" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="92.805409" y="255.686812" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="96.873969" y="265.994553" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="100.94253" y="266.835" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="105.01109" y="269.753005" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="109.079651" y="274.821101" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="113.200372" y="282.928" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="117.321093" y="284.28893" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="121.389654" y="286.373333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="125.458214" y="295.939362" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="129.526775" y="295.130043" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="133.647496" y="298.951931" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="137.768217" y="304.418966" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="141.836778" y="308.954703" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="145.905338" y="307.470308" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="149.973899" y="310.255229" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="154.042459" y="312.094118" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="158.16318" y="312.270423" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="162.283902" y="310.76" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="166.352462" y="308.286667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="170.421023" y="307.59" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="174.489583" y="306.918552" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="178.610304" y="304.385333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="182.731026" y="303.478685" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="186.799586" y="299.6323" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="190.868147" y="295.785915" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="194.936707" y="290.582749" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="199.005267" y="290.694206" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="203.125989" y="278.484815" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="207.24671" y="275.42835" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="211.315271" y="265.839061" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="215.383831" y="258.988" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="219.452391" y="259.52" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="223.573113" y="246.305806" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="227.693834" y="233.604" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="231.762395" y="218.610185" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="235.830955" y="227.967742" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="239.899515" y="214.032838" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="244.020237" y="197.973103" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="248.140958" y="200.437308" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="252.209519" y="180.1" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="256.278079" y="175.593756" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="260.346639" y="171.882732" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="264.4152" y="159.052035" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="268.535921" y="145.127964" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="272.656643" y="148.84087" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="276.725203" y="140.39" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="280.793763" y="136.88" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="284.862324" y="127.336667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="288.983045" y="121.458252" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="293.103767" y="109.257708" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="297.172327" y="105.152428" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="301.240887" y="97.407149" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="305.309448" y="106.4275" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="309.378008" y="83.446667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="313.498729" y="89.729577" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="317.619451" y="85.476062" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="321.688011" y="81.665098" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="325.756572" y="73.842056" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="329.825132" y="72.256" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="333.945853" y="73.53863" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="338.066575" y="69.6226" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="342.135135" y="69.396199" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="346.203696" y="65.353641" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="350.272256" y="66.642857" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="354.340816" y="56.213448" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="358.461538" y="54.562629" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="362.582259" y="56.650667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="366.65082" y="55.936338" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="370.71938" y="53.902" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="374.78794" y="43.832" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="378.908662" y="45.686256" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="383.029383" y="44.848643" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="387.097944" y="48.4" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="391.166504" y="45.984255" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="395.235064" y="46.595117" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="399.303625" y="44.260503" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="403.424346" y="40.827729" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="407.545068" y="42.083303" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="411.613628" y="42.859907" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="415.682188" y="38.085025" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="419.750749" y="42.741565" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="423.87147" y="41.027103" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="427.992192" y="39.29256" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="432.060752" y="39.7774" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="436.129312" y="38.148889" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="440.197873" y="37.688372" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="444.318594" y="36.525286" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="448.439316" y="40.780194" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="452.507876" y="39.667339" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="456.576436" y="38.137736" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="460.644997" y="42.237407" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="464.713557" y="34.543111" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="468.834279" y="35.716683" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m80f4c965dc" x="472.955" y="37.144" style="fill: #bcbd22; stroke: #bcbd22"/>
-    </g>
-   </g>
-   <g id="line2d_25">
-    <path d="M 68.060216 307.195385 
-L 72.358285 298.846945 
-L 76.426845 284.29227 
-L 80.495406 269.373883 
-L 84.563966 265.511809 
-L 88.684688 262.096352 
-L 92.805409 262.582093 
-L 96.873969 258.20283 
-L 100.94253 266.93 
-L 105.01109 270.737891 
-L 109.131812 277.828889 
-L 113.252533 277.842556 
-L 117.321093 284.679873 
-L 121.389654 283.605976 
-L 125.458214 291.361765 
-L 129.526775 296.828867 
-L 133.647496 300.019556 
-L 137.768217 307.144384 
-L 141.836778 306.819351 
-L 145.905338 307.766897 
-L 149.973899 308.039747 
-L 154.09462 310.80908 
-L 158.215341 312.100657 
-L 162.283902 310.557115 
-L 166.352462 309.036923 
-L 170.421023 309.142222 
-L 174.541744 306.228624 
-L 178.662465 305.39679 
-L 182.731026 302.84 
-L 186.799586 302.407945 
-L 190.868147 290.855177 
-L 194.936707 289.908724 
-L 199.057428 282.379375 
-L 203.17815 273.915294 
-L 207.24671 273.884 
-L 211.315271 263.7 
-L 215.383831 256.603721 
-L 219.504552 251.417231 
-L 223.625274 239.096913 
-L 227.693834 229.972197 
-L 231.762395 226.002353 
-L 235.830955 212.225535 
-L 239.899515 199.48 
-L 244.020237 195.006988 
-L 248.140958 181.61758 
-L 252.209519 179.951935 
-L 256.278079 162.797033 
-L 260.346639 158.56858 
-L 264.467361 141.7485 
-L 268.588082 141.736889 
-L 272.656643 127.322361 
-L 276.725203 131.76012 
-L 280.793763 115.830892 
-L 284.862324 113.892644 
-L 288.983045 105.19292 
-L 293.103767 99.553103 
-L 297.172327 94.843293 
-L 301.240887 91.40424 
-L 305.309448 89.862594 
-L 309.430169 80.596782 
-L 313.55089 81.291915 
-L 317.619451 76.168385 
-L 321.688011 69.80472 
-L 325.756572 73.224317 
-L 329.825132 63.346985 
-L 333.945853 64.891685 
-L 338.066575 65.422609 
-L 342.135135 57.990638 
-L 346.203696 55.262692 
-L 350.272256 54.518261 
-L 354.392977 56.950769 
-L 358.513699 52.394667 
-L 362.582259 48.70908 
-L 366.65082 46.176817 
-L 370.71938 45.07131 
-L 374.840101 43.310201 
-L 378.960823 44.506194 
-L 383.029383 45.066708 
-L 387.097944 40.488 
-L 391.166504 41.297032 
-L 395.235064 37.721975 
-L 399.355786 39.176206 
-L 403.476507 41.570513 
-L 407.545068 41.748852 
-L 411.613628 40.07 
-L 415.682188 39.938985 
-L 419.80291 39.128889 
-L 423.923631 35.033443 
-L 427.992192 37.80858 
-L 432.060752 40.020068 
-L 436.129312 34.572102 
-L 440.197873 37.105752 
-L 444.318594 35.392381 
-L 448.439316 34.296142 
-L 452.507876 36.742928 
-L 456.576436 34.630641 
-L 460.644997 36.4752 
-L 464.765718 35.308757 
-L 468.88644 35.672025 
-L 472.955 33.267516 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
-    <defs>
-     <path id="m4a97e00387" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #17becf"/>
-    </defs>
-    <g clip-path="url(#pb06ad7982b)">
-     <use xlink:href="#m4a97e00387" x="68.060216" y="307.195385" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="72.358285" y="298.846945" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="76.426845" y="284.29227" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="80.495406" y="269.373883" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="84.563966" y="265.511809" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="88.684688" y="262.096352" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="92.805409" y="262.582093" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="96.873969" y="258.20283" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="100.94253" y="266.93" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="105.01109" y="270.737891" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="109.131812" y="277.828889" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="113.252533" y="277.842556" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="117.321093" y="284.679873" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="121.389654" y="283.605976" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="125.458214" y="291.361765" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="129.526775" y="296.828867" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="133.647496" y="300.019556" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="137.768217" y="307.144384" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="141.836778" y="306.819351" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="145.905338" y="307.766897" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="149.973899" y="308.039747" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="154.09462" y="310.80908" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="158.215341" y="312.100657" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="162.283902" y="310.557115" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="166.352462" y="309.036923" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="170.421023" y="309.142222" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="174.541744" y="306.228624" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="178.662465" y="305.39679" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="182.731026" y="302.84" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="186.799586" y="302.407945" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="190.868147" y="290.855177" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="194.936707" y="289.908724" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="199.057428" y="282.379375" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="203.17815" y="273.915294" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="207.24671" y="273.884" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="211.315271" y="263.7" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="215.383831" y="256.603721" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="219.504552" y="251.417231" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="223.625274" y="239.096913" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="227.693834" y="229.972197" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="231.762395" y="226.002353" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="235.830955" y="212.225535" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="239.899515" y="199.48" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="244.020237" y="195.006988" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="248.140958" y="181.61758" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="252.209519" y="179.951935" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="256.278079" y="162.797033" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="260.346639" y="158.56858" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="264.467361" y="141.7485" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="268.588082" y="141.736889" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="272.656643" y="127.322361" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="276.725203" y="131.76012" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="280.793763" y="115.830892" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="284.862324" y="113.892644" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="288.983045" y="105.19292" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="293.103767" y="99.553103" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="297.172327" y="94.843293" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="301.240887" y="91.40424" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="305.309448" y="89.862594" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="309.430169" y="80.596782" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="313.55089" y="81.291915" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="317.619451" y="76.168385" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="321.688011" y="69.80472" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="325.756572" y="73.224317" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="329.825132" y="63.346985" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="333.945853" y="64.891685" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="338.066575" y="65.422609" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="342.135135" y="57.990638" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="346.203696" y="55.262692" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="350.272256" y="54.518261" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="354.392977" y="56.950769" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="358.513699" y="52.394667" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="362.582259" y="48.70908" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="366.65082" y="46.176817" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="370.71938" y="45.07131" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="374.840101" y="43.310201" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="378.960823" y="44.506194" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="383.029383" y="45.066708" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="387.097944" y="40.488" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="391.166504" y="41.297032" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="395.235064" y="37.721975" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="399.355786" y="39.176206" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="403.476507" y="41.570513" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="407.545068" y="41.748852" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="411.613628" y="40.07" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="415.682188" y="39.938985" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="419.80291" y="39.128889" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="423.923631" y="35.033443" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="427.992192" y="37.80858" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="432.060752" y="40.020068" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="436.129312" y="34.572102" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="440.197873" y="37.105752" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="444.318594" y="35.392381" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="448.439316" y="34.296142" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="452.507876" y="36.742928" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="456.576436" y="34.630641" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="460.644997" y="36.4752" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="464.765718" y="35.308757" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="468.88644" y="35.672025" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m4a97e00387" x="472.955" y="33.267516" style="fill: #17becf; stroke: #17becf"/>
-    </g>
-   </g>
-   <g id="line2d_26">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_27">
-    <path d="M 162.023097 318.04 
-L 162.023097 25.44 
-" clip-path="url(#pb06ad7982b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_13">
+    <path d="M 32.2596 108.592163 
+L 36.36 108.484706 
+L 40.44 108.369598 
+L 44.52 108.49451 
+L 48.6 108.388667 
+L 52.68 108.507774 
+L 56.76 108.621004 
+L 60.84 108.053937 
+L 64.92 108.050503 
+L 69 108.185505 
+L 73.08 107.613048 
+L 77.16 107.373294 
+L 81.24 107.46145 
+L 85.32 106.89709 
+L 89.4 106.359549 
+L 93.48 106.237539 
+L 97.56 104.761394 
+L 101.64 104.661176 
+L 105.72 103.443529 
+L 109.8 102.42725 
+L 113.88 101.119741 
+L 117.96 99.692303 
+L 122.04 96.927362 
+L 126.12 95.117456 
+L 130.2 92.324225 
+L 134.28 88.601264 
+L 138.36 88.167807 
+L 142.44 84.574643 
+L 146.52 81.087201 
+L 150.6 80.930391 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_14">
+    <path d="M 32.2596 107.476167 
+L 36.36 107.187297 
+L 40.44 107.517386 
+L 44.52 107.655391 
+L 48.6 107.379471 
+L 52.68 107.783348 
+L 56.76 107.825141 
+L 60.84 107.81603 
+L 64.92 107.677983 
+L 69 107.4612 
+L 73.08 107.110838 
+L 77.16 106.989773 
+L 81.24 106.261839 
+L 85.32 105.391525 
+L 89.4 104.115961 
+L 93.48 102.689748 
+L 97.56 100.674556 
+L 101.64 97.427735 
+L 105.72 94.241256 
+L 109.8 89.64313 
+L 113.88 83.834005 
+L 117.96 78.282305 
+L 122.04 73.688723 
+L 126.12 66.575987 
+L 130.2 61.471131 
+L 134.28 56.470319 
+L 138.36 52.291672 
+L 142.44 48.713619 
+L 146.52 46.538547 
+L 150.6 44.46779 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_18">
-    <!-- Shendure - - deflated (minP power) -->
-    <g transform="translate(166.838125 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-53"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(126.855469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(188.378906 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(251.757812 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(315.234375 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(378.613281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(417.476562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(479 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(510.787109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(546.871094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(582.955078 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(614.742188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(678.21875 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(739.742188 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(774.947266 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(802.730469 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(864.009766 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(903.21875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(964.742188 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1028.21875 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(1060.005859 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1099.019531 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1196.431641 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1224.214844 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1287.59375 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1347.896484 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1379.683594 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1443.160156 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1504.341797 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1586.128906 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1647.652344 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1688.765625 0)"/>
-    </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 104.115961 
+L 36.36 104.287337 
+L 40.44 104.633185 
+L 44.52 105.723553 
+L 48.6 106.192349 
+L 52.68 106.272468 
+L 56.76 106.639712 
+L 60.84 106.625123 
+L 64.92 106.79501 
+L 69 107.014761 
+L 73.08 106.592832 
+L 77.16 105.803816 
+L 81.24 104.819901 
+L 85.32 104.081345 
+L 89.4 101.995776 
+L 93.48 99.485036 
+L 97.56 95.861333 
+L 101.64 91.278172 
+L 105.72 86.544964 
+L 109.8 78.755181 
+L 113.88 73.916292 
+L 117.96 66.089356 
+L 122.04 60.214884 
+L 126.12 53.45064 
+L 130.2 48.939067 
+L 134.28 44.096011 
+L 138.36 41.183708 
+L 142.44 38.65728 
+L 146.52 37.157476 
+L 150.6 36.062955 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 53.41 238.491563 
-L 171.88125 238.491563 
-Q 173.48125 238.491563 173.48125 236.891563 
-L 173.48125 106.588437 
-Q 173.48125 104.988438 171.88125 104.988438 
-L 53.41 104.988438 
-Q 51.81 104.988438 51.81 106.588437 
-L 51.81 236.891563 
-Q 51.81 238.491563 53.41 238.491563 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_19">
-     <!-- Cell type -->
-     <g transform="translate(90.540156 115.786875) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_28">
-     <path d="M 55.01 125.145313 
-L 63.01 125.145313 
-L 71.01 125.145313 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mf4c2f13220" x="63.01" y="125.145313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- Cardiomyocytes -->
-     <g transform="translate(77.41 127.945312) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(131.103516 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(170.466797 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(233.943359 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(261.726562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(322.908203 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(420.320312 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(479.5 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(540.681641 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(595.662109 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(654.841797 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(694.050781 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(755.574219 0)"/>
-     </g>
-    </g>
-    <g id="line2d_29">
-     <path d="M 55.01 136.887812 
-L 63.01 136.887812 
-L 71.01 136.887812 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m942f1f9cbb" x="63.01" y="136.887812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- EpiblastPrimitiveStreak -->
-     <g transform="translate(77.41 139.687813) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-45" d="M 628 4666 
-L 3578 4666 
-L 3578 4134 
-L 1259 4134 
-L 1259 2753 
-L 3481 2753 
-L 3481 2222 
-L 1259 2222 
-L 1259 531 
-L 3634 531 
-L 3634 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(126.660156 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(154.443359 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(217.919922 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(245.703125 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(306.982422 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(359.082031 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(398.291016 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(456.84375 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(497.957031 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(525.740234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(623.152344 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(650.935547 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(690.144531 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(717.927734 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(777.107422 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(838.630859 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(902.107422 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(941.316406 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(980.179688 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1041.703125 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(1102.982422 0)"/>
-     </g>
-    </g>
-    <g id="line2d_30">
-     <path d="M 55.01 148.630313 
-L 63.01 148.630313 
-L 71.01 148.630313 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m4d42af8b23" x="63.01" y="148.630313" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- ExEndodermParietal -->
-     <g transform="translate(77.41 151.430313) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(122.363281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(185.546875 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(248.925781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(312.402344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(373.583984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(437.060547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(498.583984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(537.947266 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(635.359375 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(691.162109 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(752.441406 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(793.554688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(821.337891 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(882.861328 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(922.070312 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(983.349609 0)"/>
-     </g>
-    </g>
-    <g id="line2d_31">
-     <path d="M 55.01 160.372813 
-L 63.01 160.372813 
-L 71.01 160.372813 
-" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m75121de8ea" x="63.01" y="160.372813" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="text_23">
-     <!-- ExEndodermVisceral -->
-     <g transform="translate(77.41 163.172813) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-56" d="M 1831 0 
-L 50 4666 
-L 709 4666 
-L 2188 738 
-L 3669 4666 
-L 4325 4666 
-L 2547 0 
-L 1831 0 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(122.363281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(185.546875 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(248.925781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(312.402344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(373.583984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(437.060547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(498.583984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(537.947266 0)"/>
-      <use xlink:href="#DejaVuSans-56" transform="translate(635.359375 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(701.517578 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(729.300781 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(781.400391 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(836.380859 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(897.904297 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(939.017578 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1000.296875 0)"/>
-     </g>
-    </g>
-    <g id="line2d_32">
-     <path d="M 55.01 172.115312 
-L 63.01 172.115312 
-L 71.01 172.115312 
-" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m593a170770" x="63.01" y="172.115312" style="fill: #9467bd; stroke: #9467bd"/>
-     </g>
-    </g>
-    <g id="text_24">
-     <!-- Haematoendothelial -->
-     <g transform="translate(77.41 174.915312) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-48"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(75.195312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(136.474609 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(197.998047 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(295.410156 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(356.689453 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(395.898438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(457.080078 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(518.603516 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(581.982422 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(645.458984 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(706.640625 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(745.849609 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(809.228516 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(870.751953 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(898.535156 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(926.318359 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(987.597656 0)"/>
-     </g>
-    </g>
-    <g id="line2d_33">
-     <path d="M 55.01 183.857812 
-L 63.01 183.857812 
-L 71.01 183.857812 
-" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m32f79c2545" x="63.01" y="183.857812" style="fill: #8c564b; stroke: #8c564b"/>
-     </g>
-    </g>
-    <g id="text_25">
-     <!-- Mesoderm -->
-     <g transform="translate(77.41 186.657813) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(147.802734 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(199.902344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(261.083984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(324.560547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(386.083984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(425.447266 0)"/>
-     </g>
-    </g>
-    <g id="line2d_34">
-     <path d="M 55.01 195.600312 
-L 63.01 195.600312 
-L 71.01 195.600312 
-" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m5f84e627c7" x="63.01" y="195.600312" style="fill: #e377c2; stroke: #e377c2"/>
-     </g>
-    </g>
-    <g id="text_26">
-     <!-- NeuroectodermBrain -->
-     <g transform="translate(77.41 198.400312) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4e" d="M 628 4666 
-L 1478 4666 
-L 3547 763 
-L 3547 4666 
-L 4159 4666 
-L 4159 0 
-L 3309 0 
-L 1241 3903 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4e"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(74.804688 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(136.328125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(199.707031 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(238.570312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(299.751953 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(361.275391 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(416.255859 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(455.464844 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(516.646484 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(580.123047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(641.646484 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(681.009766 0)"/>
-      <use xlink:href="#DejaVuSans-42" transform="translate(778.421875 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(847.025391 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(888.138672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(949.417969 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(977.201172 0)"/>
-     </g>
-    </g>
-    <g id="line2d_35">
-     <path d="M 55.01 207.342812 
-L 63.01 207.342812 
-L 71.01 207.342812 
-" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m220b9d30a3" x="63.01" y="207.342812" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     </g>
-    </g>
-    <g id="text_27">
-     <!-- NeuroectodermRostral -->
-     <g transform="translate(77.41 210.142812) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-4e"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(74.804688 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(136.328125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(199.707031 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(238.570312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(299.751953 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(361.275391 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(416.255859 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(455.464844 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(516.646484 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(580.123047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(641.646484 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(681.009766 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(778.421875 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(843.404297 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(904.585938 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(956.685547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(995.894531 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1037.007812 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1098.287109 0)"/>
-     </g>
-    </g>
-    <g id="line2d_36">
-     <path d="M 55.01 219.085312 
-L 63.01 219.085312 
-L 71.01 219.085312 
-" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m80f4c965dc" x="63.01" y="219.085312" style="fill: #bcbd22; stroke: #bcbd22"/>
-     </g>
-    </g>
-    <g id="text_28">
-     <!-- SurfaceEctoderm -->
-     <g transform="translate(77.41 221.885312) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-53"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(126.855469 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(167.96875 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(203.173828 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(264.453125 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(319.433594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(380.957031 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(444.140625 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(499.121094 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(538.330078 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(599.511719 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(662.988281 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(724.511719 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(763.875 0)"/>
-     </g>
-    </g>
-    <g id="line2d_37">
-     <path d="M 55.01 230.827812 
-L 63.01 230.827812 
-L 71.01 230.827812 
-" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m4a97e00387" x="63.01" y="230.827812" style="fill: #17becf; stroke: #17becf"/>
-     </g>
-    </g>
-    <g id="text_29">
-     <!-- Pluripotent -->
-     <g transform="translate(77.41 233.627813) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(60.302734 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(88.085938 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(151.464844 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(192.578125 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(220.361328 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(283.837891 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(345.019531 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(384.228516 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(445.751953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(509.130859 0)"/>
-     </g>
-    </g>
+   <g id="line2d_16">
+    <path d="M 32.2596 105.818373 
+L 36.36 105.612767 
+L 40.44 106.280895 
+L 44.52 106.623191 
+L 48.6 107.207034 
+L 52.68 107.66576 
+L 56.76 107.662326 
+L 60.84 107.534566 
+L 64.92 107.569467 
+L 69 107.388534 
+L 73.08 107.474325 
+L 77.16 107.027384 
+L 81.24 105.864713 
+L 85.32 105.011747 
+L 89.4 102.878889 
+L 93.48 101.794857 
+L 97.56 99.005439 
+L 101.64 95.673782 
+L 105.72 91.083253 
+L 109.8 86.514958 
+L 113.88 80.619692 
+L 117.96 74.31995 
+L 122.04 68.441993 
+L 126.12 61.494131 
+L 130.2 56.654092 
+L 134.28 51.612637 
+L 138.36 48.19357 
+L 142.44 44.78455 
+L 146.52 42.125029 
+L 150.6 40.75278 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
+   <g id="line2d_17">
+    <path d="M 32.2596 107.859037 
+L 36.36 108.109651 
+L 40.44 107.902395 
+L 44.52 108.199638 
+L 48.6 108.225022 
+L 52.68 107.764983 
+L 56.76 108.489166 
+L 60.84 108.010691 
+L 64.92 108.052796 
+L 69 107.527203 
+L 73.08 107.608839 
+L 77.16 107.536176 
+L 81.24 106.628674 
+L 85.32 106.289292 
+L 89.4 105.709809 
+L 93.48 104.907845 
+L 97.56 103.795155 
+L 101.64 103.236078 
+L 105.72 101.284508 
+L 109.8 98.796483 
+L 113.88 95.852026 
+L 117.96 93.924005 
+L 122.04 89.802353 
+L 126.12 85.677185 
+L 130.2 82.364003 
+L 134.28 78.209639 
+L 138.36 73.553588 
+L 142.44 70.432907 
+L 146.52 68.657083 
+L 150.6 63.899346 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_18">
+    <path d="M 32.2596 94.977527 
+L 36.36 97.64521 
+L 40.44 98.054478 
+L 44.52 99.606323 
+L 48.6 102.390987 
+L 52.68 102.741134 
+L 56.76 104.233932 
+L 60.84 105.924772 
+L 64.92 106.222262 
+L 69 106.355016 
+L 73.08 106.019606 
+L 77.16 105.053966 
+L 81.24 104.51926 
+L 85.32 101.704749 
+L 89.4 98.083083 
+L 93.48 93.7818 
+L 97.56 87.378444 
+L 101.64 80.093586 
+L 105.72 72.072462 
+L 109.8 63.354565 
+L 113.88 54.063211 
+L 117.96 47.881605 
+L 122.04 41.408499 
+L 126.12 37.38006 
+L 130.2 34.558334 
+L 134.28 32.167211 
+L 138.36 30.7991 
+L 142.44 30.106997 
+L 146.52 29.575337 
+L 150.6 29.104957 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_19">
+    <path d="M 32.2596 94.317723 
+L 36.36 97.558235 
+L 40.44 97.629693 
+L 44.52 99.551147 
+L 48.6 101.187638 
+L 52.68 103.261582 
+L 56.76 104.899931 
+L 60.84 106.249412 
+L 64.92 106.657163 
+L 69 106.712599 
+L 73.08 106.024941 
+L 77.16 105.702531 
+L 81.24 103.687343 
+L 85.32 101.17931 
+L 89.4 96.634886 
+L 93.48 92.366888 
+L 97.56 86.291406 
+L 101.64 77.328997 
+L 105.72 68.258039 
+L 109.8 59.385106 
+L 113.88 51.537138 
+L 117.96 44.806957 
+L 122.04 39.740814 
+L 126.12 35.573745 
+L 130.2 33.372587 
+L 134.28 31.417861 
+L 138.36 30.623537 
+L 142.44 29.793864 
+L 146.52 29.562328 
+L 150.6 29.478627 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_20">
+    <path d="M 32.2596 106.097376 
+L 36.36 106.608092 
+L 40.44 106.175663 
+L 44.52 107.071103 
+L 48.6 106.501513 
+L 52.68 107.376389 
+L 56.76 107.546364 
+L 60.84 106.906001 
+L 64.92 107.401397 
+L 69 107.179893 
+L 73.08 106.946396 
+L 77.16 106.334406 
+L 81.24 104.745152 
+L 85.32 104.241298 
+L 89.4 102.498999 
+L 93.48 101.749167 
+L 97.56 98.693671 
+L 101.64 94.302721 
+L 105.72 91.135173 
+L 109.8 87.295022 
+L 113.88 81.416703 
+L 117.96 75.5809 
+L 122.04 69.953499 
+L 126.12 62.839881 
+L 130.2 57.987912 
+L 134.28 53.235084 
+L 138.36 50.222073 
+L 142.44 47.500749 
+L 146.52 43.798151 
+L 150.6 41.148021 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_21">
+    <path d="M 32.2596 98.191171 
+L 36.36 99.857255 
+L 40.44 99.422866 
+L 44.52 101.594102 
+L 48.6 102.133439 
+L 52.68 103.53518 
+L 56.76 106.176471 
+L 60.84 105.854948 
+L 64.92 106.727939 
+L 69 107.043529 
+L 73.08 106.048898 
+L 77.16 105.594896 
+L 81.24 104.468772 
+L 85.32 102.346641 
+L 89.4 99.946697 
+L 93.48 94.934759 
+L 97.56 90.369358 
+L 101.64 82.687546 
+L 105.72 75.426214 
+L 109.8 67.725882 
+L 113.88 60.477408 
+L 117.96 53.604439 
+L 122.04 46.933305 
+L 126.12 42.165275 
+L 130.2 39.580606 
+L 134.28 35.682483 
+L 138.36 33.128934 
+L 142.44 32.149997 
+L 146.52 31.257106 
+L 150.6 31.107105 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
+   </g>
+   <g id="line2d_22">
+    <path d="M 32.2596 97.575913 
+L 36.36 99.257712 
+L 40.44 98.839806 
+L 44.52 101.072322 
+L 48.6 102.420368 
+L 52.68 104.075575 
+L 56.76 105.761725 
+L 60.84 105.610417 
+L 64.92 106.444024 
+L 69 106.88984 
+L 73.08 106.566628 
+L 77.16 105.567275 
+L 81.24 104.722861 
+L 85.32 101.937255 
+L 89.4 98.193182 
+L 93.48 94.494604 
+L 97.56 88.32181 
+L 101.64 81.137457 
+L 105.72 73.289041 
+L 109.8 64.235294 
+L 113.88 56.825042 
+L 117.96 49.759601 
+L 122.04 44.487841 
+L 126.12 40.082984 
+L 130.2 37.074953 
+L 134.28 34.14563 
+L 138.36 32.220863 
+L 142.44 31.595873 
+L 146.52 30.695771 
+L 150.6 30.262599 
+" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+   </g>
+  </g>
+  <g id="line2d_23">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_11">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Lalanne et al.</text>
+  </g>
+  <g id="text_12">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter withheld</text>
   </g>
  </g>
  <defs>
-  <clipPath id="pb06ad7982b">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="p0e167e066b">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:23.020178</dc:date>
+    <dc:date>2026-08-16T20:37:59.485308</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,3855 +21,498 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m9ec1b69fa3" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="57.701035" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.0 -->
-      <g transform="translate(49.749473 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="109.862066" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.5 -->
-      <g transform="translate(101.910504 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="162.023097" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(154.071534 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="214.184127" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.5 -->
-      <g transform="translate(206.232565 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="266.345158" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 2.0 -->
-      <g transform="translate(258.393595 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="318.506188" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 2.5 -->
-      <g transform="translate(310.554626 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="370.667219" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 3.0 -->
-      <g transform="translate(362.715657 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="422.82825" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 3.5 -->
-      <g transform="translate(414.876687 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m9ec1b69fa3" x="474.98928" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 4.0 -->
-      <g transform="translate(467.037718 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_10">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_10">
-      <defs>
-       <path id="m494d02eb14" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_11">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_6"/>
+     <g id="text_5">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="111.189238" transform="rotate(-0 28.24 111.189238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_12">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_8"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="70.601003" transform="rotate(-0 28.24 70.601003)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_9">
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_13">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_10"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="30.012768" transform="rotate(-0 28.24 30.012768)">1</text>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m494d02eb14" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+    <g id="text_8">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="14.101211" y="67.32" transform="rotate(-90 14.101211 67.32)">power</text>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 68.060216 26.822362 
-L 72.358285 25.976881 
-L 76.426845 27.656667 
-L 80.495406 29.002087 
-L 84.563966 31.508741 
-L 88.684688 35.410074 
-L 92.805409 38.8996 
-L 96.873969 46.373984 
-L 100.94253 62.3076 
-L 105.01109 71.074862 
-L 109.079651 93.713333 
-L 113.200372 114.530149 
-L 117.321093 139.206154 
-L 121.389654 179.842769 
-L 125.458214 178.347097 
-L 129.526775 220.345455 
-L 133.595335 238.836207 
-L 137.716056 258.519658 
-L 141.836778 270.001194 
-L 145.905338 290.130462 
-L 149.973899 296.347241 
-L 154.042459 306.981102 
-L 158.16318 306.336 
-L 162.283902 308.218462 
-L 166.352462 309.206792 
-L 170.421023 302.8875 
-L 174.489583 299.046667 
-L 178.558143 288.266667 
-L 182.678865 279.186557 
-L 186.799586 268.490219 
-L 190.868147 255.372913 
-L 194.936707 236.53 
-L 199.005267 215.142333 
-L 203.073828 221.829153 
-L 207.194549 204.385455 
-L 211.315271 183.169688 
-L 215.383831 172.654375 
-L 219.452391 158.085333 
-L 223.520952 135.662136 
-L 227.589512 125.552727 
-L 231.710233 108.175172 
-L 235.830955 101.828702 
-L 239.899515 93.434667 
-L 243.968076 85.36448 
-L 248.036636 74.869515 
-L 252.157357 72.153333 
-L 256.278079 61.229091 
-L 260.346639 64.642718 
-L 264.4152 53.237 
-L 268.48376 44.127059 
-L 272.55232 45.446838 
-L 276.673042 41.4 
-L 280.793763 37.944274 
-L 284.862324 40.42112 
-L 288.930884 38.391148 
-L 292.999444 34.76177 
-L 297.068005 34.68 
-L 301.188726 36.22 
-L 305.309448 31.998276 
-L 309.378008 32.809185 
-L 313.446568 30.1425 
-L 317.515129 30.72 
-L 321.583689 29.13045 
-L 325.704411 28.825455 
-L 329.825132 29.491385 
-L 333.893692 29.441368 
-L 337.962253 27.240615 
-L 342.030813 27.818862 
-L 346.151535 27.838361 
-L 350.272256 26.703022 
-L 354.340816 25.931765 
-L 358.409377 26.383871 
-L 362.477937 28.271613 
-L 366.546498 27.7808 
-L 370.667219 26.80093 
-L 374.78794 26.879016 
-L 378.856501 26.347287 
-L 382.925061 27.161176 
-L 386.993622 26.903 
-L 391.062182 27.53 
-L 395.182903 26.333435 
-L 399.303625 25.44 
-L 403.372185 26.354375 
-L 407.440746 25.919672 
-L 411.509306 25.883333 
-L 415.577866 26.554667 
-L 419.698588 25.44 
-L 423.819309 25.44 
-L 427.88787 25.88 
-L 431.95643 26.340308 
-L 436.02499 25.44 
-L 440.145712 25.44 
-L 444.266433 25.953333 
-L 448.334994 25.904444 
-L 452.403554 25.972 
-L 456.472114 25.44 
-L 460.540675 25.953333 
-L 464.661396 25.44 
-L 468.782118 25.944483 
-L 472.850678 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="me3d1f519f4" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#me3d1f519f4" x="68.060216" y="26.822362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="72.358285" y="25.976881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="76.426845" y="27.656667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="80.495406" y="29.002087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="84.563966" y="31.508741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="88.684688" y="35.410074" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="92.805409" y="38.8996" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="96.873969" y="46.373984" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="100.94253" y="62.3076" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="105.01109" y="71.074862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="109.079651" y="93.713333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="113.200372" y="114.530149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="117.321093" y="139.206154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="121.389654" y="179.842769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="125.458214" y="178.347097" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="129.526775" y="220.345455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="133.595335" y="238.836207" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="137.716056" y="258.519658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="141.836778" y="270.001194" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="145.905338" y="290.130462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="149.973899" y="296.347241" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="154.042459" y="306.981102" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="158.16318" y="306.336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="162.283902" y="308.218462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="166.352462" y="309.206792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="170.421023" y="302.8875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="174.489583" y="299.046667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="178.558143" y="288.266667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="182.678865" y="279.186557" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="186.799586" y="268.490219" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="190.868147" y="255.372913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="194.936707" y="236.53" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="199.005267" y="215.142333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="203.073828" y="221.829153" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="207.194549" y="204.385455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="211.315271" y="183.169688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="215.383831" y="172.654375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="219.452391" y="158.085333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="223.520952" y="135.662136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="227.589512" y="125.552727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="231.710233" y="108.175172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="235.830955" y="101.828702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="239.899515" y="93.434667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="243.968076" y="85.36448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="248.036636" y="74.869515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="252.157357" y="72.153333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="256.278079" y="61.229091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="260.346639" y="64.642718" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="264.4152" y="53.237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="268.48376" y="44.127059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="272.55232" y="45.446838" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="276.673042" y="41.4" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="280.793763" y="37.944274" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="284.862324" y="40.42112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="288.930884" y="38.391148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="292.999444" y="34.76177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="297.068005" y="34.68" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="301.188726" y="36.22" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="305.309448" y="31.998276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="309.378008" y="32.809185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="313.446568" y="30.1425" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="317.515129" y="30.72" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="321.583689" y="29.13045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="325.704411" y="28.825455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="329.825132" y="29.491385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="333.893692" y="29.441368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="337.962253" y="27.240615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="342.030813" y="27.818862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="346.151535" y="27.838361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="350.272256" y="26.703022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="354.340816" y="25.931765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="358.409377" y="26.383871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="362.477937" y="28.271613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="366.546498" y="27.7808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="370.667219" y="26.80093" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="374.78794" y="26.879016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="378.856501" y="26.347287" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="382.925061" y="27.161176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="386.993622" y="26.903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="391.062182" y="27.53" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="395.182903" y="26.333435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="399.303625" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="403.372185" y="26.354375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="407.440746" y="25.919672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="411.509306" y="25.883333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="415.577866" y="26.554667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="419.698588" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="423.819309" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="427.88787" y="25.88" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="431.95643" y="26.340308" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="436.02499" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="440.145712" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="444.266433" y="25.953333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="448.334994" y="25.904444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="452.403554" y="25.972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="456.472114" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="460.540675" y="25.953333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="464.661396" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="468.782118" y="25.944483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#me3d1f519f4" x="472.850678" y="25.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 68.065432 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.620617 
-L 84.563966 25.44 
-L 88.684688 26.095075 
-L 92.805409 27.052756 
-L 96.873969 26.838089 
-L 100.94253 29.468551 
-L 105.01109 33.256751 
-L 109.131812 35.94359 
-L 113.252533 43.888678 
-L 117.321093 53.90381 
-L 121.389654 74.307216 
-L 125.458214 103.393057 
-L 129.526775 130.691799 
-L 133.647496 167.262491 
-L 137.768217 202.500513 
-L 141.836778 235.119435 
-L 145.905338 264.541518 
-L 149.973899 284.03 
-L 154.09462 293.159048 
-L 158.215341 303.659659 
-L 162.283902 303.613194 
-L 166.352462 301.804268 
-L 170.421023 296.845256 
-L 174.489583 286.738605 
-L 178.610304 272.636552 
-L 182.731026 247.175938 
-L 186.799586 223.448656 
-L 190.868147 200.20381 
-L 194.936707 174.253746 
-L 199.057428 142.691264 
-L 203.17815 125.180292 
-L 207.24671 99.463433 
-L 211.315271 89.022284 
-L 215.383831 72.09512 
-L 219.452391 57.557037 
-L 223.573113 58.344484 
-L 227.693834 46.323608 
-L 231.762395 44.729926 
-L 235.830955 38.24125 
-L 239.899515 33.653333 
-L 243.968076 31.760976 
-L 248.088797 30.412288 
-L 252.209519 30.300465 
-L 256.278079 29.110244 
-L 260.346639 28.072388 
-L 264.4152 27.358689 
-L 268.535921 28.109333 
-L 272.656643 27.464277 
-L 276.725203 26.445498 
-L 280.793763 26.703022 
-L 284.862324 25.79792 
-L 288.930884 25.631869 
-L 293.051605 25.44 
-L 297.172327 25.44 
-L 301.240887 25.639727 
-L 305.309448 25.626369 
-L 309.378008 25.858 
-L 313.498729 25.44 
-L 317.619451 25.44 
-L 321.688011 25.640411 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.893692 25.643902 
-L 338.014414 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.634419 
-L 378.856501 25.44 
-L 382.977222 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.819309 25.44 
-L 427.940031 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.334994 25.44 
-L 452.455715 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.782118 25.44 
-L 472.902839 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m305b67a360" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#m305b67a360" x="68.065432" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="72.358285" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="76.426845" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="80.495406" y="25.620617" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="84.563966" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="88.684688" y="26.095075" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="92.805409" y="27.052756" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="96.873969" y="26.838089" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="100.94253" y="29.468551" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="105.01109" y="33.256751" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="109.131812" y="35.94359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="113.252533" y="43.888678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="117.321093" y="53.90381" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="121.389654" y="74.307216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="125.458214" y="103.393057" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="129.526775" y="130.691799" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="133.647496" y="167.262491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="137.768217" y="202.500513" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="141.836778" y="235.119435" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="145.905338" y="264.541518" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="149.973899" y="284.03" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="154.09462" y="293.159048" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="158.215341" y="303.659659" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="162.283902" y="303.613194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="166.352462" y="301.804268" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="170.421023" y="296.845256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="174.489583" y="286.738605" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="178.610304" y="272.636552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="182.731026" y="247.175938" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="186.799586" y="223.448656" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="190.868147" y="200.20381" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="194.936707" y="174.253746" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="199.057428" y="142.691264" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="203.17815" y="125.180292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="207.24671" y="99.463433" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="211.315271" y="89.022284" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="215.383831" y="72.09512" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="219.452391" y="57.557037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="223.573113" y="58.344484" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="227.693834" y="46.323608" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="231.762395" y="44.729926" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="235.830955" y="38.24125" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="239.899515" y="33.653333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="243.968076" y="31.760976" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="248.088797" y="30.412288" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="252.209519" y="30.300465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="256.278079" y="29.110244" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="260.346639" y="28.072388" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="264.4152" y="27.358689" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="268.535921" y="28.109333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="272.656643" y="27.464277" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="276.725203" y="26.445498" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="280.793763" y="26.703022" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="284.862324" y="25.79792" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="288.930884" y="25.631869" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="293.051605" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="297.172327" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="301.240887" y="25.639727" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="305.309448" y="25.626369" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="309.378008" y="25.858" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="313.498729" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="317.619451" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="321.688011" y="25.640411" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="325.756572" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="329.825132" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="333.893692" y="25.643902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="338.014414" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="342.135135" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="346.203696" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="350.272256" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="354.340816" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="358.461538" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="362.582259" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="366.65082" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="370.71938" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="374.78794" y="25.634419" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="378.856501" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="382.977222" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="387.097944" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="391.166504" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="395.235064" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="399.303625" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="403.424346" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="407.545068" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="411.613628" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="415.682188" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="419.750749" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="423.819309" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="427.940031" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="432.060752" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="436.129312" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="440.197873" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="444.266433" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="448.334994" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="452.455715" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="456.576436" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="460.644997" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="464.713557" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="468.782118" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m305b67a360" x="472.902839" y="25.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 68.070648 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.616127 25.44 
-L 88.736849 25.834074 
-L 92.805409 26.112644 
-L 96.873969 25.875093 
-L 100.94253 26.288116 
-L 105.063251 26.735646 
-L 109.183973 29.070803 
-L 113.252533 34.443077 
-L 117.321093 37.5675 
-L 121.389654 46.12 
-L 125.458214 66.538015 
-L 129.578936 88.333381 
-L 133.699657 120.25 
-L 137.768217 160.502464 
-L 141.836778 204.08 
-L 145.905338 244.263 
-L 150.02606 265.566347 
-L 154.146781 290.8016 
-L 158.215341 299.16942 
-L 162.283902 301.064733 
-L 166.352462 299.602192 
-L 170.421023 292.2 
-L 174.541744 272.615385 
-L 178.662465 248.222703 
-L 182.731026 222.76944 
-L 186.799586 194.571667 
-L 190.868147 162.320685 
-L 194.988868 130.245854 
-L 199.109589 106.791667 
-L 203.17815 84.417187 
-L 207.24671 64.930769 
-L 211.315271 55.566963 
-L 215.383831 47.534286 
-L 219.504552 41.671825 
-L 223.625274 35.568462 
-L 227.693834 34.306667 
-L 231.762395 31.636235 
-L 235.830955 30.335209 
-L 239.951676 28.640312 
-L 244.072398 26.72146 
-L 248.140958 26.14224 
-L 252.209519 26.75717 
-L 256.278079 26.285054 
-L 260.346639 26.326667 
-L 264.467361 25.44 
-L 268.588082 25.653577 
-L 272.656643 25.629385 
-L 276.725203 25.44 
-L 280.793763 25.913846 
-L 284.914485 25.44 
-L 289.035206 25.44 
-L 293.103767 25.44 
-L 297.172327 25.641793 
-L 301.240887 25.44 
-L 305.309448 25.44 
-L 309.430169 25.44 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.44 
-L 329.877293 25.44 
-L 333.998014 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.840101 25.44 
-L 378.960823 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="mda5000919b" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#mda5000919b" x="68.070648" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="72.358285" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="76.426845" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="80.495406" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="84.616127" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="88.736849" y="25.834074" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="92.805409" y="26.112644" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="96.873969" y="25.875093" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="100.94253" y="26.288116" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="105.063251" y="26.735646" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="109.183973" y="29.070803" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="113.252533" y="34.443077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="117.321093" y="37.5675" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="121.389654" y="46.12" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="125.458214" y="66.538015" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="129.578936" y="88.333381" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="133.699657" y="120.25" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="137.768217" y="160.502464" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="141.836778" y="204.08" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="145.905338" y="244.263" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="150.02606" y="265.566347" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="154.146781" y="290.8016" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="158.215341" y="299.16942" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="162.283902" y="301.064733" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="166.352462" y="299.602192" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="170.421023" y="292.2" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="174.541744" y="272.615385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="178.662465" y="248.222703" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="182.731026" y="222.76944" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="186.799586" y="194.571667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="190.868147" y="162.320685" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="194.988868" y="130.245854" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="199.109589" y="106.791667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="203.17815" y="84.417187" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="207.24671" y="64.930769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="211.315271" y="55.566963" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="215.383831" y="47.534286" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="219.504552" y="41.671825" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="223.625274" y="35.568462" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="227.693834" y="34.306667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="231.762395" y="31.636235" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="235.830955" y="30.335209" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="239.951676" y="28.640312" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="244.072398" y="26.72146" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="248.140958" y="26.14224" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="252.209519" y="26.75717" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="256.278079" y="26.285054" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="260.346639" y="26.326667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="264.467361" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="268.588082" y="25.653577" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="272.656643" y="25.629385" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="276.725203" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="280.793763" y="25.913846" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="284.914485" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="289.035206" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="293.103767" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="297.172327" y="25.641793" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="301.240887" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="305.309448" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="309.430169" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="313.55089" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="317.619451" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="321.688011" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="325.756572" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="329.877293" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="333.998014" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="338.066575" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="342.135135" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="346.203696" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="350.272256" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="354.392977" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="358.513699" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="362.582259" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="366.65082" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="370.71938" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="374.840101" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="378.960823" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="383.029383" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="387.097944" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="391.166504" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="395.235064" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="399.355786" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="403.476507" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="407.545068" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="411.613628" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="415.682188" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="419.80291" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="423.923631" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="427.992192" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="432.060752" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="436.129312" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="440.197873" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="444.318594" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="448.439316" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="452.507876" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="456.576436" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="460.644997" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="464.765718" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="468.88644" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mda5000919b" x="472.955" y="25.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_19">
-    <path d="M 68.060216 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.66251 
-L 88.684688 25.44 
-L 92.805409 26.927797 
-L 96.873969 26.63918 
-L 100.94253 28.200377 
-L 105.01109 31.501833 
-L 109.131812 33.348108 
-L 113.252533 38.444444 
-L 117.321093 46.061333 
-L 121.389654 63.06 
-L 125.458214 81.674062 
-L 129.526775 111.75032 
-L 133.647496 144.125141 
-L 137.768217 180.743077 
-L 141.836778 225.383333 
-L 145.905338 247.761308 
-L 149.973899 280.888299 
-L 154.042459 294.792329 
-L 158.16318 302.05537 
-L 162.283902 306.816986 
-L 166.352462 304.337756 
-L 170.421023 293.424444 
-L 174.489583 280.778286 
-L 178.610304 256.692947 
-L 182.731026 242.058387 
-L 186.799586 203.840777 
-L 190.868147 185.288405 
-L 194.936707 151.502907 
-L 199.005267 129.722085 
-L 203.125989 111.990588 
-L 207.24671 94.125446 
-L 211.315271 75.169442 
-L 215.383831 55.610311 
-L 219.452391 54.084 
-L 223.520952 46.39476 
-L 227.641673 40.772751 
-L 231.762395 37.577481 
-L 235.830955 32.431327 
-L 239.899515 32.547692 
-L 243.968076 32.113333 
-L 248.088797 28.776667 
-L 252.209519 29.865882 
-L 256.278079 28.288319 
-L 260.346639 27.009502 
-L 264.4152 28.733333 
-L 268.48376 27.118852 
-L 272.604481 27.236667 
-L 276.725203 26.444635 
-L 280.793763 26.726154 
-L 284.862324 25.94887 
-L 288.930884 26.884938 
-L 293.051605 26.669412 
-L 297.172327 26.511795 
-L 301.240887 26.82673 
-L 305.309448 26.549384 
-L 309.378008 26.28 
-L 313.446568 25.953333 
-L 317.56729 25.44 
-L 321.688011 26.669412 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.893692 26 
-L 337.962253 25.44 
-L 342.082974 25.693333 
-L 346.203696 25.67502 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.409377 25.44 
-L 362.530098 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.856501 25.44 
-L 382.925061 25.44 
-L 387.045783 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.372185 25.44 
-L 407.492907 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.819309 25.687966 
-L 427.88787 25.44 
-L 432.008591 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.334994 25.44 
-L 452.403554 25.44 
-L 456.524275 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.782118 25.44 
-L 472.850678 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-    <defs>
-     <path id="mbfc1946f7d" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#mbfc1946f7d" x="68.060216" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="72.358285" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="76.426845" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="80.495406" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="84.563966" y="25.66251" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="88.684688" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="92.805409" y="26.927797" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="96.873969" y="26.63918" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="100.94253" y="28.200377" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="105.01109" y="31.501833" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="109.131812" y="33.348108" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="113.252533" y="38.444444" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="117.321093" y="46.061333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="121.389654" y="63.06" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="125.458214" y="81.674062" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="129.526775" y="111.75032" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="133.647496" y="144.125141" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="137.768217" y="180.743077" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="141.836778" y="225.383333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="145.905338" y="247.761308" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="149.973899" y="280.888299" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="154.042459" y="294.792329" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="158.16318" y="302.05537" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="162.283902" y="306.816986" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="166.352462" y="304.337756" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="170.421023" y="293.424444" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="174.489583" y="280.778286" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="178.610304" y="256.692947" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="182.731026" y="242.058387" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="186.799586" y="203.840777" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="190.868147" y="185.288405" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="194.936707" y="151.502907" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="199.005267" y="129.722085" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="203.125989" y="111.990588" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="207.24671" y="94.125446" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="211.315271" y="75.169442" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="215.383831" y="55.610311" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="219.452391" y="54.084" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="223.520952" y="46.39476" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="227.641673" y="40.772751" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="231.762395" y="37.577481" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="235.830955" y="32.431327" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="239.899515" y="32.547692" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="243.968076" y="32.113333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="248.088797" y="28.776667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="252.209519" y="29.865882" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="256.278079" y="28.288319" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="260.346639" y="27.009502" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="264.4152" y="28.733333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="268.48376" y="27.118852" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="272.604481" y="27.236667" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="276.725203" y="26.444635" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="280.793763" y="26.726154" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="284.862324" y="25.94887" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="288.930884" y="26.884938" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="293.051605" y="26.669412" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="297.172327" y="26.511795" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="301.240887" y="26.82673" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="305.309448" y="26.549384" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="309.378008" y="26.28" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="313.446568" y="25.953333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="317.56729" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="321.688011" y="26.669412" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="325.756572" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="329.825132" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="333.893692" y="26" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="337.962253" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="342.082974" y="25.693333" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="346.203696" y="25.67502" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="350.272256" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="354.340816" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="358.409377" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="362.530098" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="366.65082" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="370.71938" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="374.78794" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="378.856501" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="382.925061" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="387.045783" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="391.166504" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="395.235064" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="399.303625" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="403.372185" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="407.492907" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="411.613628" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="415.682188" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="419.750749" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="423.819309" y="25.687966" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="427.88787" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="432.008591" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="436.129312" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="440.197873" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="444.266433" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="448.334994" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="452.403554" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="456.524275" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="460.644997" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="464.713557" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="468.782118" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#mbfc1946f7d" x="472.850678" y="25.44" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_20">
-    <path d="M 68.060216 25.44 
-L 72.358285 25.44 
-L 76.426845 25.832752 
-L 80.495406 25.855035 
-L 84.563966 26.618255 
-L 88.684688 28.120305 
-L 92.805409 31.480774 
-L 96.873969 33.14 
-L 100.94253 37.22255 
-L 105.01109 48.848 
-L 109.131812 62.942254 
-L 113.252533 76.238611 
-L 117.321093 103.615573 
-L 121.389654 119.852267 
-L 125.458214 156.877778 
-L 129.526775 182.067059 
-L 133.647496 214.401527 
-L 137.768217 236.347651 
-L 141.836778 265.456812 
-L 145.905338 279.026667 
-L 149.973899 290.547383 
-L 154.09462 296.955588 
-L 158.215341 308.079149 
-L 162.283902 307.249078 
-L 166.352462 303.41 
-L 170.421023 298.533333 
-L 174.489583 291.09 
-L 178.610304 279.961918 
-L 182.731026 267.114198 
-L 186.799586 257.269231 
-L 190.868147 236.762222 
-L 194.936707 217.072394 
-L 199.057428 195.798222 
-L 203.17815 189.550435 
-L 207.24671 145.223125 
-L 211.315271 141.667222 
-L 215.383831 135.977778 
-L 219.452391 111.947826 
-L 223.573113 98.056058 
-L 227.693834 86.504348 
-L 231.762395 72.328696 
-L 235.830955 68.076 
-L 239.899515 56.52875 
-L 244.020237 53.864 
-L 248.140958 47.753381 
-L 252.209519 39.652 
-L 256.278079 42.16 
-L 260.346639 37.313623 
-L 264.4152 40.42112 
-L 268.535921 35.529655 
-L 272.656643 32.801006 
-L 276.725203 30.528696 
-L 280.793763 30.992993 
-L 284.862324 29.29 
-L 288.983045 27.844932 
-L 293.103767 29.475862 
-L 297.172327 28.784 
-L 301.240887 28.040889 
-L 305.309448 27.112 
-L 309.378008 26.300588 
-L 313.498729 26.77 
-L 317.619451 26.340308 
-L 321.688011 27.64 
-L 325.756572 26.510488 
-L 329.825132 25.873481 
-L 333.945853 25.849231 
-L 338.066575 25.900787 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.931765 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.886718 
-L 370.71938 26.32 
-L 374.78794 25.803478 
-L 378.856501 25.44 
-L 382.977222 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.82755 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.819309 25.44 
-L 427.940031 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.387155 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.782118 25.44 
-L 472.902839 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
-    <defs>
-     <path id="me874039bf3" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #9467bd"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#me874039bf3" x="68.060216" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="72.358285" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="76.426845" y="25.832752" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="80.495406" y="25.855035" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="84.563966" y="26.618255" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="88.684688" y="28.120305" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="92.805409" y="31.480774" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="96.873969" y="33.14" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="100.94253" y="37.22255" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="105.01109" y="48.848" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="109.131812" y="62.942254" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="113.252533" y="76.238611" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="117.321093" y="103.615573" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="121.389654" y="119.852267" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="125.458214" y="156.877778" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="129.526775" y="182.067059" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="133.647496" y="214.401527" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="137.768217" y="236.347651" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="141.836778" y="265.456812" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="145.905338" y="279.026667" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="149.973899" y="290.547383" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="154.09462" y="296.955588" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="158.215341" y="308.079149" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="162.283902" y="307.249078" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="166.352462" y="303.41" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="170.421023" y="298.533333" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="174.489583" y="291.09" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="178.610304" y="279.961918" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="182.731026" y="267.114198" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="186.799586" y="257.269231" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="190.868147" y="236.762222" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="194.936707" y="217.072394" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="199.057428" y="195.798222" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="203.17815" y="189.550435" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="207.24671" y="145.223125" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="211.315271" y="141.667222" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="215.383831" y="135.977778" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="219.452391" y="111.947826" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="223.573113" y="98.056058" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="227.693834" y="86.504348" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="231.762395" y="72.328696" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="235.830955" y="68.076" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="239.899515" y="56.52875" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="244.020237" y="53.864" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="248.140958" y="47.753381" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="252.209519" y="39.652" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="256.278079" y="42.16" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="260.346639" y="37.313623" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="264.4152" y="40.42112" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="268.535921" y="35.529655" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="272.656643" y="32.801006" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="276.725203" y="30.528696" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="280.793763" y="30.992993" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="284.862324" y="29.29" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="288.983045" y="27.844932" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="293.103767" y="29.475862" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="297.172327" y="28.784" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="301.240887" y="28.040889" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="305.309448" y="27.112" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="309.378008" y="26.300588" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="313.498729" y="26.77" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="317.619451" y="26.340308" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="321.688011" y="27.64" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="325.756572" y="26.510488" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="329.825132" y="25.873481" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="333.945853" y="25.849231" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="338.066575" y="25.900787" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="342.135135" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="346.203696" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="350.272256" y="25.931765" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="354.340816" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="358.461538" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="362.582259" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="366.65082" y="25.886718" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="370.71938" y="26.32" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="374.78794" y="25.803478" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="378.856501" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="382.977222" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="387.097944" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="391.166504" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="395.235064" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="399.303625" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="403.424346" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="407.545068" y="25.82755" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="411.613628" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="415.682188" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="419.750749" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="423.819309" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="427.940031" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="432.060752" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="436.129312" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="440.197873" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="444.266433" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="448.387155" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="452.507876" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="456.576436" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="460.644997" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="464.713557" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="468.782118" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-     <use xlink:href="#me874039bf3" x="472.902839" y="25.44" style="fill: #9467bd; stroke: #9467bd"/>
-    </g>
-   </g>
-   <g id="line2d_21">
-    <path d="M 68.055 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.44 
-L 88.684688 25.44 
-L 92.805409 25.44 
-L 96.873969 25.656741 
-L 100.94253 25.666822 
-L 105.01109 26.087823 
-L 109.079651 25.44 
-L 113.200372 26.021325 
-L 117.321093 27.314306 
-L 121.389654 29.155556 
-L 125.458214 38.006795 
-L 129.526775 50.102 
-L 133.647496 74.744252 
-L 137.768217 115.346159 
-L 141.836778 149.457385 
-L 145.905338 200.379647 
-L 149.973899 239.85728 
-L 154.09462 280.42 
-L 158.215341 298.661246 
-L 162.283902 304.964103 
-L 166.352462 302.651407 
-L 170.421023 277.076 
-L 174.489583 248.780375 
-L 178.610304 212.536201 
-L 182.731026 172.741293 
-L 186.799586 140.122051 
-L 190.868147 101.611934 
-L 194.936707 72.430037 
-L 199.057428 56.365203 
-L 203.17815 45.858849 
-L 207.24671 38.373768 
-L 211.315271 34.443077 
-L 215.383831 30.333659 
-L 219.452391 30.077434 
-L 223.573113 28.265103 
-L 227.693834 27.040156 
-L 231.762395 26.043299 
-L 235.830955 25.850667 
-L 239.899515 25.646056 
-L 244.020237 25.44 
-L 248.140958 25.873481 
-L 252.209519 25.671304 
-L 256.278079 25.44 
-L 260.346639 25.657546 
-L 264.467361 25.44 
-L 268.588082 25.44 
-L 272.656643 25.44 
-L 276.725203 25.631242 
-L 280.793763 25.44 
-L 284.862324 25.44 
-L 288.983045 25.44 
-L 293.103767 25.44 
-L 297.172327 25.44 
-L 301.240887 25.44 
-L 305.309448 25.44 
-L 309.430169 25.44 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.840101 25.44 
-L 378.960823 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
-    <defs>
-     <path id="m41c5f4e4dc" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #8c564b"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#m41c5f4e4dc" x="68.055" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="72.358285" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="76.426845" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="80.495406" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="84.563966" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="88.684688" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="92.805409" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="96.873969" y="25.656741" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="100.94253" y="25.666822" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="105.01109" y="26.087823" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="109.079651" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="113.200372" y="26.021325" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="117.321093" y="27.314306" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="121.389654" y="29.155556" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="125.458214" y="38.006795" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="129.526775" y="50.102" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="133.647496" y="74.744252" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="137.768217" y="115.346159" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="141.836778" y="149.457385" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="145.905338" y="200.379647" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="149.973899" y="239.85728" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="154.09462" y="280.42" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="158.215341" y="298.661246" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="162.283902" y="304.964103" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="166.352462" y="302.651407" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="170.421023" y="277.076" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="174.489583" y="248.780375" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="178.610304" y="212.536201" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="182.731026" y="172.741293" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="186.799586" y="140.122051" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="190.868147" y="101.611934" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="194.936707" y="72.430037" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="199.057428" y="56.365203" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="203.17815" y="45.858849" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="207.24671" y="38.373768" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="211.315271" y="34.443077" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="215.383831" y="30.333659" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="219.452391" y="30.077434" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="223.573113" y="28.265103" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="227.693834" y="27.040156" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="231.762395" y="26.043299" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="235.830955" y="25.850667" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="239.899515" y="25.646056" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="244.020237" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="248.140958" y="25.873481" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="252.209519" y="25.671304" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="256.278079" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="260.346639" y="25.657546" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="264.467361" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="268.588082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="272.656643" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="276.725203" y="25.631242" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="280.793763" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="284.862324" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="288.983045" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="293.103767" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="297.172327" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="301.240887" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="305.309448" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="309.430169" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="313.55089" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="317.619451" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="321.688011" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="325.756572" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="329.825132" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="333.945853" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="338.066575" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="342.135135" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="346.203696" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="350.272256" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="354.392977" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="358.513699" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="362.582259" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="366.65082" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="370.71938" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="374.840101" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="378.960823" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="383.029383" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="387.097944" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="391.166504" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="395.235064" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="399.355786" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="403.476507" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="407.545068" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="411.613628" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="415.682188" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="419.80291" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="423.923631" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="427.992192" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="432.060752" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="436.129312" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="440.197873" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="444.318594" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="448.439316" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="452.507876" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="456.576436" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="460.644997" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="464.765718" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="468.88644" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-     <use xlink:href="#m41c5f4e4dc" x="472.955" y="25.44" style="fill: #8c564b; stroke: #8c564b"/>
-    </g>
-   </g>
-   <g id="line2d_22">
-    <path d="M 68.055 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.44 
-L 88.684688 25.649749 
-L 92.805409 25.44 
-L 96.873969 25.665077 
-L 100.94253 25.891892 
-L 105.01109 25.44 
-L 109.079651 25.871882 
-L 113.200372 26.649091 
-L 117.321093 27.390667 
-L 121.389654 30.256461 
-L 125.458214 34.02 
-L 129.526775 44.866721 
-L 133.647496 71.048114 
-L 137.768217 103.007686 
-L 141.836778 146.491452 
-L 145.905338 195.836471 
-L 149.973899 242.093088 
-L 154.042459 283.440584 
-L 158.16318 301.919396 
-L 162.283902 304.68943 
-L 166.352462 297.15477 
-L 170.421023 279.243407 
-L 174.489583 250.304252 
-L 178.610304 206.464903 
-L 182.731026 167.272824 
-L 186.799586 133.493 
-L 190.868147 85.932584 
-L 194.936707 72.562846 
-L 199.005267 54.483259 
-L 203.125989 42.334895 
-L 207.24671 36.677536 
-L 211.315271 34.160627 
-L 215.383831 32.390651 
-L 219.452391 29.924291 
-L 223.573113 27.63176 
-L 227.693834 28.271613 
-L 231.762395 26.32 
-L 235.830955 26.285054 
-L 239.899515 26.071511 
-L 243.968076 25.647518 
-L 248.088797 25.876716 
-L 252.209519 25.44 
-L 256.278079 25.44 
-L 260.346639 25.665077 
-L 264.4152 25.642491 
-L 268.535921 25.44 
-L 272.656643 25.44 
-L 276.725203 25.44 
-L 280.793763 25.44 
-L 284.862324 25.44 
-L 288.930884 25.44 
-L 293.051605 25.44 
-L 297.172327 25.44 
-L 301.240887 25.44 
-L 305.309448 25.44 
-L 309.378008 25.44 
-L 313.498729 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.893692 25.44 
-L 338.014414 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.856501 25.44 
-L 382.977222 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.819309 25.44 
-L 427.940031 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.266433 25.44 
-L 448.387155 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.782118 25.44 
-L 472.902839 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
-    <defs>
-     <path id="ma92c121c75" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #e377c2"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#ma92c121c75" x="68.055" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="72.358285" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="76.426845" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="80.495406" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="84.563966" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="88.684688" y="25.649749" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="92.805409" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="96.873969" y="25.665077" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="100.94253" y="25.891892" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="105.01109" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="109.079651" y="25.871882" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="113.200372" y="26.649091" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="117.321093" y="27.390667" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="121.389654" y="30.256461" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="125.458214" y="34.02" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="129.526775" y="44.866721" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="133.647496" y="71.048114" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="137.768217" y="103.007686" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="141.836778" y="146.491452" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="145.905338" y="195.836471" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="149.973899" y="242.093088" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="154.042459" y="283.440584" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="158.16318" y="301.919396" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="162.283902" y="304.68943" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="166.352462" y="297.15477" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="170.421023" y="279.243407" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="174.489583" y="250.304252" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="178.610304" y="206.464903" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="182.731026" y="167.272824" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="186.799586" y="133.493" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="190.868147" y="85.932584" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="194.936707" y="72.562846" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="199.005267" y="54.483259" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="203.125989" y="42.334895" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="207.24671" y="36.677536" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="211.315271" y="34.160627" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="215.383831" y="32.390651" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="219.452391" y="29.924291" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="223.573113" y="27.63176" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="227.693834" y="28.271613" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="231.762395" y="26.32" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="235.830955" y="26.285054" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="239.899515" y="26.071511" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="243.968076" y="25.647518" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="248.088797" y="25.876716" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="252.209519" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="256.278079" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="260.346639" y="25.665077" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="264.4152" y="25.642491" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="268.535921" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="272.656643" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="276.725203" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="280.793763" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="284.862324" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="288.930884" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="293.051605" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="297.172327" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="301.240887" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="305.309448" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="309.378008" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="313.498729" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="317.619451" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="321.688011" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="325.756572" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="329.825132" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="333.893692" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="338.014414" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="342.135135" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="346.203696" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="350.272256" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="354.340816" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="358.461538" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="362.582259" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="366.65082" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="370.71938" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="374.78794" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="378.856501" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="382.977222" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="387.097944" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="391.166504" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="395.235064" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="399.303625" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="403.424346" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="407.545068" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="411.613628" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="415.682188" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="419.750749" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="423.819309" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="427.940031" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="432.060752" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="436.129312" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="440.197873" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="444.266433" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="448.387155" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="452.507876" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="456.576436" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="460.644997" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="464.713557" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="468.782118" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-     <use xlink:href="#ma92c121c75" x="472.902839" y="25.44" style="fill: #e377c2; stroke: #e377c2"/>
-    </g>
-   </g>
-   <g id="line2d_23">
-    <path d="M 68.060216 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.953333 
-L 84.563966 25.44 
-L 88.684688 25.876716 
-L 92.805409 26.326667 
-L 96.873969 27.545036 
-L 100.94253 27.607407 
-L 105.01109 29.650072 
-L 109.131812 38.044308 
-L 113.252533 43.75542 
-L 117.321093 49.903279 
-L 121.389654 68.97888 
-L 125.458214 84.911545 
-L 129.526775 121.36 
-L 133.647496 143.037333 
-L 137.768217 194.339187 
-L 141.836778 237.455082 
-L 145.905338 269.096 
-L 149.973899 277.563667 
-L 154.09462 297.434366 
-L 158.215341 308.860392 
-L 162.283902 307.04 
-L 166.352462 302.12256 
-L 170.421023 295.664706 
-L 174.489583 277.373559 
-L 178.610304 256.770738 
-L 182.731026 235.023256 
-L 186.799586 201 
-L 190.868147 186.029767 
-L 194.936707 154.984274 
-L 199.057428 135.727692 
-L 203.17815 112.371884 
-L 207.24671 88.385882 
-L 211.315271 72.400494 
-L 215.383831 64.029275 
-L 219.504552 51.392348 
-L 223.625274 45.965672 
-L 227.693834 40.706087 
-L 231.762395 34.728889 
-L 235.830955 33.8 
-L 239.899515 30.243881 
-L 244.020237 29.215484 
-L 248.140958 31.477778 
-L 252.209519 28.691111 
-L 256.278079 30.350769 
-L 260.346639 29.28438 
-L 264.467361 27.56029 
-L 268.588082 27.011007 
-L 272.656643 25.44 
-L 276.725203 26.448966 
-L 280.793763 25.840822 
-L 284.862324 26.391545 
-L 288.983045 25.849231 
-L 293.103767 25.44 
-L 297.172327 25.44 
-L 301.240887 25.873481 
-L 305.309448 25.44 
-L 309.430169 25.44 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.44 
-L 329.825132 25.855035 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.908662 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.87147 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.834279 25.44 
-L 472.955 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
-    <defs>
-     <path id="m33a79e1f90" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #7f7f7f"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#m33a79e1f90" x="68.060216" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="72.358285" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="76.426845" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="80.495406" y="25.953333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="84.563966" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="88.684688" y="25.876716" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="92.805409" y="26.326667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="96.873969" y="27.545036" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="100.94253" y="27.607407" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="105.01109" y="29.650072" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="109.131812" y="38.044308" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="113.252533" y="43.75542" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="117.321093" y="49.903279" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="121.389654" y="68.97888" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="125.458214" y="84.911545" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="129.526775" y="121.36" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="133.647496" y="143.037333" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="137.768217" y="194.339187" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="141.836778" y="237.455082" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="145.905338" y="269.096" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="149.973899" y="277.563667" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="154.09462" y="297.434366" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="158.215341" y="308.860392" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="162.283902" y="307.04" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="166.352462" y="302.12256" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="170.421023" y="295.664706" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="174.489583" y="277.373559" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="178.610304" y="256.770738" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="182.731026" y="235.023256" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="186.799586" y="201" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="190.868147" y="186.029767" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="194.936707" y="154.984274" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="199.057428" y="135.727692" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="203.17815" y="112.371884" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="207.24671" y="88.385882" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="211.315271" y="72.400494" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="215.383831" y="64.029275" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="219.504552" y="51.392348" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="223.625274" y="45.965672" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="227.693834" y="40.706087" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="231.762395" y="34.728889" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="235.830955" y="33.8" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="239.899515" y="30.243881" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="244.020237" y="29.215484" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="248.140958" y="31.477778" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="252.209519" y="28.691111" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="256.278079" y="30.350769" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="260.346639" y="29.28438" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="264.467361" y="27.56029" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="268.588082" y="27.011007" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="272.656643" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="276.725203" y="26.448966" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="280.793763" y="25.840822" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="284.862324" y="26.391545" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="288.983045" y="25.849231" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="293.103767" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="297.172327" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="301.240887" y="25.873481" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="305.309448" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="309.430169" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="313.55089" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="317.619451" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="321.688011" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="325.756572" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="329.825132" y="25.855035" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="333.945853" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="338.066575" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="342.135135" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="346.203696" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="350.272256" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="354.392977" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="358.513699" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="362.582259" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="366.65082" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="370.71938" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="374.78794" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="378.908662" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="383.029383" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="387.097944" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="391.166504" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="395.235064" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="399.355786" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="403.476507" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="407.545068" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="411.613628" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="415.682188" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="419.750749" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="423.87147" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="427.992192" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="432.060752" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="436.129312" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="440.197873" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="444.318594" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="448.439316" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="452.507876" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="456.576436" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="460.644997" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="464.713557" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="468.834279" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     <use xlink:href="#m33a79e1f90" x="472.955" y="25.44" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-    </g>
-   </g>
-   <g id="line2d_24">
-    <path d="M 68.055 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.44 
-L 84.563966 25.44 
-L 88.684688 25.44 
-L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.94253 25.44 
-L 105.01109 26.079563 
-L 109.079651 26.782202 
-L 113.200372 27.948 
-L 117.321093 29.522791 
-L 121.389654 34.306667 
-L 125.458214 46.295532 
-L 129.526775 65.034383 
-L 133.647496 84.211159 
-L 137.768217 128.354483 
-L 141.836778 174.011324 
-L 145.905338 216.210044 
-L 149.973899 258.983119 
-L 154.042459 285.807059 
-L 158.16318 302.65446 
-L 162.283902 306.56 
-L 166.352462 294.579279 
-L 170.421023 279.8975 
-L 174.489583 253.429683 
-L 178.610304 220.228 
-L 182.731026 180.119624 
-L 186.799586 142.754742 
-L 190.868147 108.961502 
-L 194.936707 84.792038 
-L 199.005267 68.919813 
-L 203.125989 58.763889 
-L 207.24671 46.17767 
-L 211.315271 38.627606 
-L 215.383831 33.42 
-L 219.452391 30.316667 
-L 223.573113 30.833548 
-L 227.693834 28.505333 
-L 231.762395 28.962037 
-L 235.830955 27.058065 
-L 239.899515 25.951092 
-L 244.020237 27.20569 
-L 248.140958 26.846731 
-L 252.209519 27.112 
-L 256.278079 26.010927 
-L 260.346639 26.010927 
-L 264.4152 25.957876 
-L 268.535921 26.499186 
-L 272.656643 25.694435 
-L 276.725203 25.70125 
-L 280.793763 25.72 
-L 284.862324 25.44 
-L 288.983045 25.724078 
-L 293.103767 25.744792 
-L 297.172327 25.44 
-L 301.240887 25.44 
-L 305.309448 25.70125 
-L 309.378008 25.44 
-L 313.498729 25.44 
-L 317.619451 25.44 
-L 321.688011 25.44 
-L 325.756572 25.713458 
-L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.340816 25.44 
-L 358.461538 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.78794 25.44 
-L 378.908662 25.44 
-L 383.029383 25.44 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.303625 25.44 
-L 403.424346 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.750749 25.44 
-L 423.87147 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.713557 25.44 
-L 468.834279 25.44 
-L 472.955 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
-    <defs>
-     <path id="m047d9af936" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #bcbd22"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#m047d9af936" x="68.055" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="72.358285" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="76.426845" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="80.495406" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="84.563966" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="88.684688" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="92.805409" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="96.873969" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="100.94253" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="105.01109" y="26.079563" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="109.079651" y="26.782202" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="113.200372" y="27.948" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="117.321093" y="29.522791" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="121.389654" y="34.306667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="125.458214" y="46.295532" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="129.526775" y="65.034383" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="133.647496" y="84.211159" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="137.768217" y="128.354483" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="141.836778" y="174.011324" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="145.905338" y="216.210044" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="149.973899" y="258.983119" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="154.042459" y="285.807059" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="158.16318" y="302.65446" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="162.283902" y="306.56" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="166.352462" y="294.579279" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="170.421023" y="279.8975" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="174.489583" y="253.429683" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="178.610304" y="220.228" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="182.731026" y="180.119624" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="186.799586" y="142.754742" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="190.868147" y="108.961502" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="194.936707" y="84.792038" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="199.005267" y="68.919813" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="203.125989" y="58.763889" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="207.24671" y="46.17767" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="211.315271" y="38.627606" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="215.383831" y="33.42" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="219.452391" y="30.316667" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="223.573113" y="30.833548" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="227.693834" y="28.505333" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="231.762395" y="28.962037" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="235.830955" y="27.058065" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="239.899515" y="25.951092" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="244.020237" y="27.20569" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="248.140958" y="26.846731" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="252.209519" y="27.112" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="256.278079" y="26.010927" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="260.346639" y="26.010927" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="264.4152" y="25.957876" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="268.535921" y="26.499186" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="272.656643" y="25.694435" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="276.725203" y="25.70125" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="280.793763" y="25.72" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="284.862324" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="288.983045" y="25.724078" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="293.103767" y="25.744792" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="297.172327" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="301.240887" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="305.309448" y="25.70125" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="309.378008" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="313.498729" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="317.619451" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="321.688011" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="325.756572" y="25.713458" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="329.825132" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="333.945853" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="338.066575" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="342.135135" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="346.203696" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="350.272256" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="354.340816" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="358.461538" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="362.582259" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="366.65082" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="370.71938" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="374.78794" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="378.908662" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="383.029383" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="387.097944" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="391.166504" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="395.235064" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="399.303625" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="403.424346" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="407.545068" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="411.613628" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="415.682188" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="419.750749" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="423.87147" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="427.992192" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="432.060752" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="436.129312" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="440.197873" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="444.318594" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="448.439316" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="452.507876" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="456.576436" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="460.644997" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="464.713557" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="468.834279" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-     <use xlink:href="#m047d9af936" x="472.955" y="25.44" style="fill: #bcbd22; stroke: #bcbd22"/>
-    </g>
-   </g>
-   <g id="line2d_25">
-    <path d="M 68.060216 25.44 
-L 72.358285 25.44 
-L 76.426845 25.44 
-L 80.495406 25.6411 
-L 84.563966 25.44 
-L 88.684688 25.44 
-L 92.805409 25.44 
-L 96.873969 25.44 
-L 100.94253 25.63 
-L 105.01109 25.44 
-L 109.131812 26.808889 
-L 113.252533 27.309649 
-L 117.321093 29.912866 
-L 121.389654 30.970854 
-L 125.458214 38.348824 
-L 129.526775 56.120388 
-L 133.647496 75.414222 
-L 137.768217 111.726246 
-L 141.836778 162.504543 
-L 145.905338 203.201379 
-L 149.973899 250.445696 
-L 154.09462 277.681379 
-L 158.215341 299.872597 
-L 162.283902 307.487213 
-L 166.352462 300.784103 
-L 170.421023 283.304444 
-L 174.541744 256.656636 
-L 178.662465 222.132222 
-L 182.731026 190.74 
-L 186.799586 146.488219 
-L 190.868147 109.692199 
-L 194.936707 85.696499 
-L 199.057428 68.23275 
-L 203.17815 52.196471 
-L 207.24671 42.818667 
-L 211.315271 36.162609 
-L 215.383831 32.43907 
-L 219.504552 30.481723 
-L 223.625274 29.171141 
-L 227.693834 28.126164 
-L 231.762395 27.432941 
-L 235.830955 27.464277 
-L 239.899515 26.58 
-L 244.020237 26.673855 
-L 248.140958 25.999108 
-L 252.209519 26.237275 
-L 256.278079 25.7873 
-L 260.346639 25.970393 
-L 264.467361 26.1715 
-L 268.588082 25.625778 
-L 272.656643 25.44 
-L 276.725203 25.44 
-L 280.793763 25.44 
-L 284.862324 25.44 
-L 288.983045 25.612625 
-L 293.103767 25.44 
-L 297.172327 25.44 
-L 301.240887 25.44 
-L 305.309448 25.44 
-L 309.430169 25.44 
-L 313.55089 25.44 
-L 317.619451 25.44 
-L 321.688011 25.612625 
-L 325.756572 25.44 
-L 329.825132 25.44 
-L 333.945853 25.44 
-L 338.066575 25.44 
-L 342.135135 25.44 
-L 346.203696 25.44 
-L 350.272256 25.44 
-L 354.392977 25.44 
-L 358.513699 25.44 
-L 362.582259 25.44 
-L 366.65082 25.44 
-L 370.71938 25.44 
-L 374.840101 25.44 
-L 378.960823 25.44 
-L 383.029383 25.620062 
-L 387.097944 25.44 
-L 391.166504 25.44 
-L 395.235064 25.44 
-L 399.355786 25.44 
-L 403.476507 25.44 
-L 407.545068 25.44 
-L 411.613628 25.44 
-L 415.682188 25.44 
-L 419.80291 25.44 
-L 423.923631 25.44 
-L 427.992192 25.44 
-L 432.060752 25.44 
-L 436.129312 25.44 
-L 440.197873 25.44 
-L 444.318594 25.44 
-L 448.439316 25.44 
-L 452.507876 25.44 
-L 456.576436 25.44 
-L 460.644997 25.44 
-L 464.765718 25.44 
-L 468.88644 25.44 
-L 472.955 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
-    <defs>
-     <path id="m5d8c125293" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #17becf"/>
-    </defs>
-    <g clip-path="url(#p977ae3448e)">
-     <use xlink:href="#m5d8c125293" x="68.060216" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="72.358285" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="76.426845" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="80.495406" y="25.6411" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="84.563966" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="88.684688" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="92.805409" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="96.873969" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="100.94253" y="25.63" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="105.01109" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="109.131812" y="26.808889" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="113.252533" y="27.309649" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="117.321093" y="29.912866" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="121.389654" y="30.970854" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="125.458214" y="38.348824" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="129.526775" y="56.120388" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="133.647496" y="75.414222" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="137.768217" y="111.726246" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="141.836778" y="162.504543" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="145.905338" y="203.201379" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="149.973899" y="250.445696" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="154.09462" y="277.681379" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="158.215341" y="299.872597" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="162.283902" y="307.487213" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="166.352462" y="300.784103" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="170.421023" y="283.304444" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="174.541744" y="256.656636" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="178.662465" y="222.132222" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="182.731026" y="190.74" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="186.799586" y="146.488219" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="190.868147" y="109.692199" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="194.936707" y="85.696499" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="199.057428" y="68.23275" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="203.17815" y="52.196471" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="207.24671" y="42.818667" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="211.315271" y="36.162609" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="215.383831" y="32.43907" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="219.504552" y="30.481723" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="223.625274" y="29.171141" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="227.693834" y="28.126164" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="231.762395" y="27.432941" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="235.830955" y="27.464277" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="239.899515" y="26.58" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="244.020237" y="26.673855" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="248.140958" y="25.999108" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="252.209519" y="26.237275" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="256.278079" y="25.7873" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="260.346639" y="25.970393" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="264.467361" y="26.1715" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="268.588082" y="25.625778" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="272.656643" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="276.725203" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="280.793763" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="284.862324" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="288.983045" y="25.612625" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="293.103767" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="297.172327" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="301.240887" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="305.309448" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="309.430169" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="313.55089" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="317.619451" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="321.688011" y="25.612625" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="325.756572" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="329.825132" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="333.945853" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="338.066575" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="342.135135" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="346.203696" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="350.272256" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="354.392977" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="358.513699" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="362.582259" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="366.65082" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="370.71938" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="374.840101" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="378.960823" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="383.029383" y="25.620062" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="387.097944" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="391.166504" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="395.235064" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="399.355786" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="403.476507" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="407.545068" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="411.613628" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="415.682188" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="419.80291" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="423.923631" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="427.992192" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="432.060752" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="436.129312" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="440.197873" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="444.318594" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="448.439316" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="452.507876" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="456.576436" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="460.644997" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="464.765718" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="468.88644" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-     <use xlink:href="#m5d8c125293" x="472.955" y="25.44" style="fill: #17becf; stroke: #17becf"/>
-    </g>
-   </g>
-   <g id="line2d_26">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_27">
-    <path d="M 162.023097 318.04 
-L 162.023097 25.44 
-" clip-path="url(#p977ae3448e)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_13">
+    <path d="M 32.2596 50.554182 
+L 36.36 56.837647 
+L 40.44 64.686145 
+L 44.52 71.175882 
+L 48.6 78.900072 
+L 52.68 87.179054 
+L 56.76 93.672654 
+L 60.84 100.227692 
+L 64.92 103.949836 
+L 69 105.57984 
+L 73.08 105.989519 
+L 77.16 103.482808 
+L 81.24 98.274036 
+L 85.32 91.345387 
+L 89.4 81.661176 
+L 93.48 72.773967 
+L 97.56 61.417168 
+L 101.64 50.528328 
+L 105.72 42.696471 
+L 109.8 37.737784 
+L 113.88 32.324913 
+L 117.96 30.710504 
+L 122.04 29.830191 
+L 126.12 28.713641 
+L 130.2 28.078465 
+L 134.28 28.019564 
+L 138.36 27.918912 
+L 142.44 27.674635 
+L 146.52 27.625526 
+L 150.6 27.622533 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_14">
+    <path d="M 32.2596 31.471423 
+L 36.36 33.84464 
+L 40.44 39.519564 
+L 44.52 45.854812 
+L 48.6 55.893233 
+L 52.68 68.443982 
+L 56.76 80.468031 
+L 60.84 93.063246 
+L 64.92 100.182185 
+L 69 104.782215 
+L 73.08 104.15113 
+L 77.16 100.760957 
+L 81.24 90.884043 
+L 85.32 76.273358 
+L 89.4 58.729833 
+L 93.48 45.347131 
+L 97.56 36.476036 
+L 101.64 32.103048 
+L 105.72 29.112486 
+L 109.8 28.421544 
+L 113.88 28.030893 
+L 117.96 27.627073 
+L 122.04 27.596327 
+L 126.12 27.556076 
+L 130.2 27.555093 
+L 134.28 27.554204 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 29.603231 
+L 36.36 30.267214 
+L 40.44 32.246166 
+L 44.52 36.587351 
+L 48.6 44.070476 
+L 52.68 55.526976 
+L 56.76 69.601534 
+L 60.84 87.448945 
+L 64.92 97.20638 
+L 69 103.284551 
+L 73.08 103.339517 
+L 77.16 97.559988 
+L 81.24 83.807742 
+L 85.32 65.340925 
+L 89.4 48.534358 
+L 93.48 36.550469 
+L 97.56 31.509103 
+L 101.64 28.982904 
+L 105.72 27.996081 
+L 109.8 27.717541 
+L 113.88 27.591801 
+L 117.96 27.573237 
+L 122.04 27.543529 
+L 126.12 27.543529 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_16">
+    <path d="M 32.2596 30.997847 
+L 36.36 32.126699 
+L 40.44 35.927954 
+L 44.52 41.442379 
+L 48.6 49.597925 
+L 52.68 61.279206 
+L 56.76 77.359969 
+L 60.84 88.722241 
+L 64.92 100.112311 
+L 69 104.467899 
+L 73.08 104.816886 
+L 77.16 98.875194 
+L 81.24 87.338549 
+L 85.32 70.577965 
+L 89.4 55.101593 
+L 93.48 42.342072 
+L 97.56 34.090878 
+L 101.64 30.375785 
+L 105.72 28.944982 
+L 109.8 28.309916 
+L 113.88 27.958805 
+L 117.96 27.804268 
+L 122.04 27.853758 
+L 126.12 27.618278 
+L 130.2 27.601461 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.554339 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_17">
+    <path d="M 32.2596 40.580963 
+L 36.36 46.95264 
+L 40.44 52.305273 
+L 44.52 58.973394 
+L 48.6 70.012683 
+L 52.68 79.973979 
+L 56.76 89.714703 
+L 60.84 98.316802 
+L 64.92 101.529025 
+L 69 105.804274 
+L 73.08 104.645744 
+L 77.16 101.673431 
+L 81.24 95.291486 
+L 85.32 86.568455 
+L 89.4 75.114422 
+L 93.48 60.238362 
+L 97.56 49.287972 
+L 101.64 40.856471 
+L 105.72 34.399189 
+L 109.8 31.505923 
+L 113.88 29.587974 
+L 117.96 28.522253 
+L 122.04 27.995294 
+L 126.12 27.851794 
+L 130.2 27.622597 
+L 134.28 27.612714 
+L 138.36 27.563647 
+L 142.44 27.563114 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_18">
+    <path d="M 32.2596 27.543529 
+L 36.36 27.949412 
+L 40.44 28.550829 
+L 44.52 29.884201 
+L 48.6 33.734955 
+L 52.68 42.417781 
+L 56.76 56.467988 
+L 60.84 74.564617 
+L 64.92 92.363848 
+L 69 103.286929 
+L 73.08 104.109572 
+L 77.16 91.560496 
+L 81.24 71.140403 
+L 85.32 49.641569 
+L 89.4 35.279469 
+L 93.48 30.116099 
+L 97.56 28.590968 
+L 101.64 27.699638 
+L 105.72 27.60023 
+L 109.8 27.579448 
+L 113.88 27.558788 
+L 117.96 27.543529 
+L 122.04 27.543529 
+L 126.12 27.543529 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_19">
+    <path d="M 32.2596 27.739924 
+L 36.36 27.987463 
+L 40.44 28.343861 
+L 44.52 29.762742 
+L 48.6 32.225809 
+L 52.68 41.072941 
+L 56.76 54.329491 
+L 60.84 73.734706 
+L 64.92 93.095917 
+L 69 104.071282 
+L 73.08 102.972706 
+L 77.16 92.320713 
+L 81.24 69.084273 
+L 85.32 47.240564 
+L 89.4 34.852022 
+L 93.48 30.159085 
+L 97.56 28.627357 
+L 101.64 27.813426 
+L 105.72 27.633725 
+L 109.8 27.57753 
+L 113.88 27.543529 
+L 117.96 27.543529 
+L 122.04 27.543529 
+L 126.12 27.543529 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_20">
+    <path d="M 32.2596 31.415023 
+L 36.36 33.879254 
+L 40.44 37.236242 
+L 44.52 43.017794 
+L 48.6 52.451092 
+L 52.68 62.365436 
+L 56.76 80.943955 
+L 60.84 93.482406 
+L 64.92 100.396321 
+L 69 105.639786 
+L 73.08 104.968146 
+L 77.16 98.382425 
+L 81.24 86.718377 
+L 85.32 71.77071 
+L 89.4 55.967938 
+L 93.48 41.350275 
+L 97.56 34.534364 
+L 101.64 30.249412 
+L 105.72 28.893063 
+L 109.8 28.525361 
+L 113.88 27.776891 
+L 117.96 27.639031 
+L 122.04 27.572677 
+L 126.12 27.569218 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_21">
+    <path d="M 32.2596 28.025766 
+L 36.36 28.406275 
+L 40.44 29.555596 
+L 44.52 31.363599 
+L 48.6 38.116692 
+L 52.68 45.768956 
+L 56.76 61.637647 
+L 60.84 79.544221 
+L 64.92 95.273591 
+L 69 104.264118 
+L 73.08 102.9187 
+L 77.16 92.522817 
+L 81.24 73.464124 
+L 85.32 51.192047 
+L 89.4 39.189231 
+L 93.48 31.587594 
+L 97.56 28.918505 
+L 101.64 28.230603 
+L 105.72 27.886529 
+L 109.8 27.791569 
+L 113.88 27.664388 
+L 117.96 27.601101 
+L 122.04 27.560673 
+L 126.12 27.560164 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.543529 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="text_9">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
+   </g>
+   <g id="line2d_22">
+    <path d="M 32.2596 28.05265 
+L 36.36 28.190949 
+L 40.44 28.933708 
+L 44.52 30.534241 
+L 48.6 34.900147 
+L 52.68 42.648007 
+L 56.76 57.231931 
+L 60.84 75.660228 
+L 64.92 93.486135 
+L 69 103.465668 
+L 73.08 104.016581 
+L 77.16 93.750761 
+L 81.24 75.114422 
+L 85.32 52.124967 
+L 89.4 37.818787 
+L 93.48 30.977919 
+L 97.56 28.849165 
+L 101.64 28.102163 
+L 105.72 27.792824 
+L 109.8 27.684706 
+L 113.88 27.57114 
+L 117.96 27.55581 
+L 122.04 27.543529 
+L 126.12 27.554529 
+L 130.2 27.543529 
+L 134.28 27.543529 
+L 138.36 27.552865 
+L 142.44 27.543529 
+L 146.52 27.543529 
+L 150.6 27.543529 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 79.598181 38.988716 
+Q 82.575137 40.748753 85.552093 42.50879 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="69.850829" y="34.78471" transform="rotate(-0 69.850829 34.78471)">Pluripotent</text>
+   </g>
+   <g id="line2d_23">
+    <path d="M 87.700249 43.778824 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m76c2ed5d30" d="M 0 1.6 
+C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
+C 1.431414 0.831328 1.6 0.424325 1.6 0 
+C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
+C 0.831328 -1.431414 0.424325 -1.6 0 -1.6 
+C -0.424325 -1.6 -0.831328 -1.431414 -1.131371 -1.131371 
+C -1.431414 -0.831328 -1.6 -0.424325 -1.6 0 
+C -1.6 0.424325 -1.431414 0.831328 -1.131371 1.131371 
+C -0.831328 1.431414 -0.424325 1.6 0 1.6 
+z
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+    </defs>
+    <g clip-path="url(#p02b69f2398)">
+     <use xlink:href="#m76c2ed5d30" x="87.700249" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
+    </g>
    </g>
    <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 120.871023 79.613459 
+Q 113.515227 62.840033 106.15943 46.066606 
+" style="fill: none; stroke: #666666; stroke-width: 0.5; stroke-linecap: round"/>
    </g>
-   <g id="text_18">
-    <!-- Shendure - - reporter (minP power) -->
-    <g transform="translate(167.167188 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-53"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(126.855469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(188.378906 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(251.757812 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(315.234375 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(378.613281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(417.476562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(479 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(510.787109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(546.871094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(582.955078 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(614.742188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(653.605469 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(715.128906 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(778.605469 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(839.787109 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(880.900391 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(920.109375 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(981.632812 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1022.746094 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(1054.533203 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1093.546875 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1190.958984 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1218.742188 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1282.121094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1342.423828 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1374.210938 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1437.6875 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1498.869141 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1580.65625 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1642.179688 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1683.292969 0)"/>
-    </g>
+   <g id="text_11">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="99.436548" y="87.549416" transform="rotate(-0 99.436548 87.549416)">Cardiomyocytes</text>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 369.12875 314.04 
-L 487.6 314.04 
-Q 489.2 314.04 489.2 312.44 
-L 489.2 182.136875 
-Q 489.2 180.536875 487.6 180.536875 
-L 369.12875 180.536875 
-Q 367.52875 180.536875 367.52875 182.136875 
-L 367.52875 312.44 
-Q 367.52875 314.04 369.12875 314.04 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_19">
-     <!-- Cell type -->
-     <g transform="translate(406.258906 191.335313) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_28">
-     <path d="M 370.72875 200.69375 
-L 378.72875 200.69375 
-L 386.72875 200.69375 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#me3d1f519f4" x="378.72875" y="200.69375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- Cardiomyocytes -->
-     <g transform="translate(393.12875 203.49375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(131.103516 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(170.466797 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(233.943359 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(261.726562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(322.908203 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(420.320312 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(479.5 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(540.681641 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(595.662109 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(654.841797 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(694.050781 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(755.574219 0)"/>
-     </g>
-    </g>
-    <g id="line2d_29">
-     <path d="M 370.72875 212.43625 
-L 378.72875 212.43625 
-L 386.72875 212.43625 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m305b67a360" x="378.72875" y="212.43625" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- EpiblastPrimitiveStreak -->
-     <g transform="translate(393.12875 215.23625) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-45" d="M 628 4666 
-L 3578 4666 
-L 3578 4134 
-L 1259 4134 
-L 1259 2753 
-L 3481 2753 
-L 3481 2222 
-L 1259 2222 
-L 1259 531 
-L 3634 531 
-L 3634 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(126.660156 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(154.443359 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(217.919922 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(245.703125 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(306.982422 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(359.082031 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(398.291016 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(456.84375 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(497.957031 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(525.740234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(623.152344 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(650.935547 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(690.144531 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(717.927734 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(777.107422 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(838.630859 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(902.107422 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(941.316406 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(980.179688 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1041.703125 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(1102.982422 0)"/>
-     </g>
-    </g>
-    <g id="line2d_30">
-     <path d="M 370.72875 224.17875 
-L 378.72875 224.17875 
-L 386.72875 224.17875 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mda5000919b" x="378.72875" y="224.17875" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- ExEndodermParietal -->
-     <g transform="translate(393.12875 226.97875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(122.363281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(185.546875 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(248.925781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(312.402344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(373.583984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(437.060547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(498.583984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(537.947266 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(635.359375 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(691.162109 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(752.441406 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(793.554688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(821.337891 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(882.861328 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(922.070312 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(983.349609 0)"/>
-     </g>
-    </g>
-    <g id="line2d_31">
-     <path d="M 370.72875 235.92125 
-L 378.72875 235.92125 
-L 386.72875 235.92125 
-" style="fill: none; stroke: #d62728; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mbfc1946f7d" x="378.72875" y="235.92125" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="text_23">
-     <!-- ExEndodermVisceral -->
-     <g transform="translate(393.12875 238.72125) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-56" d="M 1831 0 
-L 50 4666 
-L 709 4666 
-L 2188 738 
-L 3669 4666 
-L 4325 4666 
-L 2547 0 
-L 1831 0 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(122.363281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(185.546875 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(248.925781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(312.402344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(373.583984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(437.060547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(498.583984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(537.947266 0)"/>
-      <use xlink:href="#DejaVuSans-56" transform="translate(635.359375 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(701.517578 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(729.300781 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(781.400391 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(836.380859 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(897.904297 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(939.017578 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1000.296875 0)"/>
-     </g>
-    </g>
-    <g id="line2d_32">
-     <path d="M 370.72875 247.66375 
-L 378.72875 247.66375 
-L 386.72875 247.66375 
-" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#me874039bf3" x="378.72875" y="247.66375" style="fill: #9467bd; stroke: #9467bd"/>
-     </g>
-    </g>
-    <g id="text_24">
-     <!-- Haematoendothelial -->
-     <g transform="translate(393.12875 250.46375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-48"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(75.195312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(136.474609 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(197.998047 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(295.410156 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(356.689453 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(395.898438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(457.080078 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(518.603516 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(581.982422 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(645.458984 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(706.640625 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(745.849609 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(809.228516 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(870.751953 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(898.535156 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(926.318359 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(987.597656 0)"/>
-     </g>
-    </g>
-    <g id="line2d_33">
-     <path d="M 370.72875 259.40625 
-L 378.72875 259.40625 
-L 386.72875 259.40625 
-" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m41c5f4e4dc" x="378.72875" y="259.40625" style="fill: #8c564b; stroke: #8c564b"/>
-     </g>
-    </g>
-    <g id="text_25">
-     <!-- Mesoderm -->
-     <g transform="translate(393.12875 262.20625) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(147.802734 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(199.902344 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(261.083984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(324.560547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(386.083984 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(425.447266 0)"/>
-     </g>
-    </g>
-    <g id="line2d_34">
-     <path d="M 370.72875 271.14875 
-L 378.72875 271.14875 
-L 386.72875 271.14875 
-" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#ma92c121c75" x="378.72875" y="271.14875" style="fill: #e377c2; stroke: #e377c2"/>
-     </g>
-    </g>
-    <g id="text_26">
-     <!-- NeuroectodermBrain -->
-     <g transform="translate(393.12875 273.94875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4e" d="M 628 4666 
-L 1478 4666 
-L 3547 763 
-L 3547 4666 
-L 4159 4666 
-L 4159 0 
-L 3309 0 
-L 1241 3903 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4e"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(74.804688 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(136.328125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(199.707031 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(238.570312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(299.751953 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(361.275391 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(416.255859 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(455.464844 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(516.646484 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(580.123047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(641.646484 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(681.009766 0)"/>
-      <use xlink:href="#DejaVuSans-42" transform="translate(778.421875 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(847.025391 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(888.138672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(949.417969 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(977.201172 0)"/>
-     </g>
-    </g>
-    <g id="line2d_35">
-     <path d="M 370.72875 282.89125 
-L 378.72875 282.89125 
-L 386.72875 282.89125 
-" style="fill: none; stroke: #7f7f7f; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m33a79e1f90" x="378.72875" y="282.89125" style="fill: #7f7f7f; stroke: #7f7f7f"/>
-     </g>
-    </g>
-    <g id="text_27">
-     <!-- NeuroectodermRostral -->
-     <g transform="translate(393.12875 285.69125) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-4e"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(74.804688 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(136.328125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(199.707031 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(238.570312 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(299.751953 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(361.275391 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(416.255859 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(455.464844 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(516.646484 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(580.123047 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(641.646484 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(681.009766 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(778.421875 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(843.404297 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(904.585938 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(956.685547 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(995.894531 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1037.007812 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1098.287109 0)"/>
-     </g>
-    </g>
-    <g id="line2d_36">
-     <path d="M 370.72875 294.63375 
-L 378.72875 294.63375 
-L 386.72875 294.63375 
-" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m047d9af936" x="378.72875" y="294.63375" style="fill: #bcbd22; stroke: #bcbd22"/>
-     </g>
-    </g>
-    <g id="text_28">
-     <!-- SurfaceEctoderm -->
-     <g transform="translate(393.12875 297.43375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-53"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(126.855469 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(167.96875 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(203.173828 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(264.453125 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(319.433594 0)"/>
-      <use xlink:href="#DejaVuSans-45" transform="translate(380.957031 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(444.140625 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(499.121094 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(538.330078 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(599.511719 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(662.988281 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(724.511719 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(763.875 0)"/>
-     </g>
-    </g>
-    <g id="line2d_37">
-     <path d="M 370.72875 306.37625 
-L 378.72875 306.37625 
-L 386.72875 306.37625 
-" style="fill: none; stroke: #17becf; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m5d8c125293" x="378.72875" y="306.37625" style="fill: #17becf; stroke: #17becf"/>
-     </g>
-    </g>
-    <g id="text_29">
-     <!-- Pluripotent -->
-     <g transform="translate(393.12875 309.17625) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(60.302734 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(88.085938 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(151.464844 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(192.578125 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(220.361328 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(283.837891 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(345.019531 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(384.228516 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(445.751953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(509.130859 0)"/>
-     </g>
+   <g id="line2d_24">
+    <path d="M 105.156149 43.778824 
+" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#p02b69f2398)">
+     <use xlink:href="#m76c2ed5d30" x="105.156149" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
   </g>
+  <g id="line2d_25">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_12">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Lalanne et al.</text>
+  </g>
+  <g id="text_13">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter used</text>
+  </g>
  </g>
  <defs>
-  <clipPath id="p977ae3448e">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="p02b69f2398">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:23.423233</dc:date>
+    <dc:date>2026-08-16T20:37:59.739343</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,1972 +21,227 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m4c64647b98" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m4c64647b98" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.0 -->
-      <g transform="translate(43.863001 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m4c64647b98" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.5 -->
-      <g transform="translate(96.763445 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m4c64647b98" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(149.66389 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m4c64647b98" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.5 -->
-      <g transform="translate(202.564334 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m4c64647b98" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 2.0 -->
-      <g transform="translate(255.464778 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m4c64647b98" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 2.5 -->
-      <g transform="translate(308.365222 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m4c64647b98" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 3.0 -->
-      <g transform="translate(361.265666 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m4c64647b98" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 3.5 -->
-      <g transform="translate(414.166111 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m4c64647b98" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 4.0 -->
-      <g transform="translate(467.066555 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_10">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
-     </g>
+    <g id="text_5">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="91.44" y="123.918828" transform="rotate(-0 91.44 123.918828)">fold change vs minP</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_10">
-      <defs>
-       <path id="md9b03d171b" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_11">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="111.189238" transform="rotate(-0 28.24 111.189238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_12">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_8"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="70.601003" transform="rotate(-0 28.24 70.601003)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_9">
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_13">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_10"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="30.012768" transform="rotate(-0 28.24 30.012768)">1</text>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#md9b03d171b" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+    <g id="text_9">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="14.101211" y="67.32" transform="rotate(-90 14.101211 67.32)">power</text>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 68.055 207.175477 
-L 72.339936 212.891765 
-L 76.41327 219.461667 
-L 80.539505 223.925361 
-L 84.612839 224.063765 
-L 88.686173 226.127232 
-L 92.759507 234.23358 
-L 96.832842 241.210061 
-L 100.959076 244.253913 
-L 105.032411 252.80459 
-L 109.105745 260.08 
-L 113.231979 269.046512 
-L 117.305314 271.923696 
-L 121.378648 280.977333 
-L 125.504882 281.608431 
-L 129.578217 277.481584 
-L 133.651551 285.102514 
-L 137.777785 283.055217 
-L 141.85112 284.422128 
-L 145.924454 279.026667 
-L 149.997788 291.030769 
-L 154.071122 290.752584 
-L 158.197357 288.458462 
-L 162.270691 286.381639 
-L 166.344025 286.555556 
-L 170.47026 289.750711 
-L 174.543594 284.030995 
-L 178.616928 282.4625 
-L 182.743163 282.152044 
-L 186.816497 287.997647 
-L 190.889831 277.44 
-L 194.963166 275.086897 
-L 199.0365 272.456 
-L 203.162735 270.898889 
-L 207.236069 264.636503 
-L 211.309403 256.933481 
-L 215.435638 254.486022 
-L 219.508972 254.850851 
-L 223.582306 252.754682 
-L 227.708541 246.550703 
-L 231.781875 240.88514 
-L 235.855209 233.232941 
-L 239.928543 233.2525 
-L 244.001877 217.9575 
-L 248.128112 232.277931 
-L 252.201446 224.470588 
-L 256.274781 213.812071 
-L 260.401015 211.78 
-L 264.474349 205.090108 
-L 268.547684 205.357872 
-L 272.673918 195.148 
-L 276.747252 196.844734 
-L 280.820587 193.60092 
-L 284.893921 191.190289 
-L 288.967255 185.689535 
-L 293.09349 188.027586 
-L 297.166824 181.493333 
-L 301.240158 184.010323 
-L 305.366393 180.072318 
-L 309.439727 172.09253 
-L 313.513061 160.317647 
-L 317.639296 167.472917 
-L 321.71263 162.286769 
-L 325.785964 160.861282 
-L 329.859298 168.488889 
-L 333.932633 168.767059 
-L 338.058867 157.01913 
-L 342.132201 160.514465 
-L 346.205536 159.149333 
-L 350.33177 148.011741 
-L 354.405105 148.825542 
-L 358.478439 148.533793 
-L 362.604673 153.657978 
-L 366.678008 133.961266 
-L 370.751342 142.129581 
-L 374.877576 140.963938 
-L 378.950911 133.939243 
-L 383.024245 124.959042 
-L 387.097579 129.313 
-L 391.170913 145.59645 
-L 395.297148 137.351959 
-L 399.370482 135.635556 
-L 403.443816 129.246834 
-L 407.570051 134.033814 
-L 411.643385 137.744277 
-L 415.716719 130.602178 
-L 419.842954 131.738987 
-L 423.916288 126.293617 
-L 427.989622 125.374154 
-L 432.062957 120.92 
-L 436.136291 120.379362 
-L 440.262525 126.106528 
-L 444.33586 121.249488 
-L 448.409194 124.68268 
-L 452.535429 117.930146 
-L 456.608763 124.864286 
-L 460.682097 123.348462 
-L 464.808332 112.769846 
-L 468.881666 111.68 
-L 472.955 117.748333 
-" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="m337a4558d7" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#p8b40560f1b)">
-     <use xlink:href="#m337a4558d7" x="68.055" y="207.175477" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="72.339936" y="212.891765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="76.41327" y="219.461667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="80.539505" y="223.925361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="84.612839" y="224.063765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="88.686173" y="226.127232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="92.759507" y="234.23358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="96.832842" y="241.210061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="100.959076" y="244.253913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="105.032411" y="252.80459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="109.105745" y="260.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="113.231979" y="269.046512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="117.305314" y="271.923696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="121.378648" y="280.977333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="125.504882" y="281.608431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="129.578217" y="277.481584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="133.651551" y="285.102514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="137.777785" y="283.055217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="141.85112" y="284.422128" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="145.924454" y="279.026667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="149.997788" y="291.030769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="154.071122" y="290.752584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="158.197357" y="288.458462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="162.270691" y="286.381639" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="166.344025" y="286.555556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="170.47026" y="289.750711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="174.543594" y="284.030995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="178.616928" y="282.4625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="182.743163" y="282.152044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="186.816497" y="287.997647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="190.889831" y="277.44" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="194.963166" y="275.086897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="199.0365" y="272.456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="203.162735" y="270.898889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="207.236069" y="264.636503" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="211.309403" y="256.933481" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="215.435638" y="254.486022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="219.508972" y="254.850851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="223.582306" y="252.754682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="227.708541" y="246.550703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="231.781875" y="240.88514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="235.855209" y="233.232941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="239.928543" y="233.2525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="244.001877" y="217.9575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="248.128112" y="232.277931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="252.201446" y="224.470588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="256.274781" y="213.812071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="260.401015" y="211.78" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="264.474349" y="205.090108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="268.547684" y="205.357872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="272.673918" y="195.148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="276.747252" y="196.844734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="280.820587" y="193.60092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="284.893921" y="191.190289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="288.967255" y="185.689535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="293.09349" y="188.027586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="297.166824" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="301.240158" y="184.010323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="305.366393" y="180.072318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="309.439727" y="172.09253" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="313.513061" y="160.317647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="317.639296" y="167.472917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="321.71263" y="162.286769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="325.785964" y="160.861282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="329.859298" y="168.488889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="333.932633" y="168.767059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="338.058867" y="157.01913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="342.132201" y="160.514465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="346.205536" y="159.149333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="350.33177" y="148.011741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="354.405105" y="148.825542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="358.478439" y="148.533793" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="362.604673" y="153.657978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="366.678008" y="133.961266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="370.751342" y="142.129581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="374.877576" y="140.963938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="378.950911" y="133.939243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="383.024245" y="124.959042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="387.097579" y="129.313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="391.170913" y="145.59645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="395.297148" y="137.351959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="399.370482" y="135.635556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="403.443816" y="129.246834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="407.570051" y="134.033814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="411.643385" y="137.744277" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="415.716719" y="130.602178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="419.842954" y="131.738987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="423.916288" y="126.293617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="427.989622" y="125.374154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="432.062957" y="120.92" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="436.136291" y="120.379362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="440.262525" y="126.106528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="444.33586" y="121.249488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="448.409194" y="124.68268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="452.535429" y="117.930146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="456.608763" y="124.864286" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="460.682097" y="123.348462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="464.808332" y="112.769846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="468.881666" y="111.68" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m337a4558d7" x="472.955" y="117.748333" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 68.1079 213.513711 
-L 72.392836 226.835957 
-L 76.519071 233.785301 
-L 80.592405 228.987826 
-L 84.665739 228.309333 
-L 88.791974 251.958427 
-L 92.865308 249.820552 
-L 96.938643 253.416687 
-L 101.011977 253.379012 
-L 105.085311 261.030194 
-L 109.211546 261.030194 
-L 113.28488 266.602038 
-L 117.358214 271.777568 
-L 121.484449 277.784204 
-L 125.557783 280.929756 
-L 129.631117 275.149565 
-L 133.704451 287.203114 
-L 137.777785 287.771034 
-L 141.90402 290.655641 
-L 145.977354 286.417391 
-L 150.050689 291.883333 
-L 154.176923 287.154444 
-L 158.250257 289.666667 
-L 162.323592 290.021333 
-L 166.449826 287.597778 
-L 170.52316 289.468471 
-L 174.596495 291.44 
-L 178.669829 289.606554 
-L 182.743163 281.465 
-L 186.869398 281.610331 
-L 190.942732 282.522081 
-L 195.016066 282.66597 
-L 199.142301 286.323053 
-L 203.215635 275.731622 
-L 207.288969 273.78425 
-L 211.362303 273.388902 
-L 215.435638 270.16 
-L 219.561872 267.410337 
-L 223.635206 259.864235 
-L 227.708541 262.017805 
-L 231.834775 257.297722 
-L 235.908109 248.749448 
-L 239.981444 253.44 
-L 244.107678 243.994286 
-L 248.181013 241.709565 
-L 252.254347 243.1344 
-L 256.327681 237.436981 
-L 260.401015 233.286897 
-L 264.52725 226.181333 
-L 268.600584 231.010256 
-L 272.673918 230.26 
-L 276.800153 217.612129 
-L 280.873487 213.119527 
-L 284.946821 212.0352 
-L 289.073056 212.97 
-L 293.14639 210.12 
-L 297.219724 209.572994 
-L 301.293059 207.029333 
-L 305.366393 207.284027 
-L 309.492627 195.712048 
-L 313.565962 196.583396 
-L 317.639296 194.880261 
-L 321.76553 194.896687 
-L 325.838865 187.284375 
-L 329.912199 178.603457 
-L 333.985533 188.38491 
-L 338.058867 180.535951 
-L 342.185102 187.833 
-L 346.258436 185.828148 
-L 350.33177 176.559294 
-L 354.458005 176.342697 
-L 358.531339 176.971921 
-L 362.604673 170.114444 
-L 366.730908 178.220403 
-L 370.804242 169.65 
-L 374.877576 165.30695 
-L 378.950911 170.467826 
-L 383.024245 163.925217 
-L 387.150479 158.499441 
-L 391.223814 155.845679 
-L 395.297148 161.877079 
-L 399.423383 153.5 
-L 403.496717 167.466067 
-L 407.570051 159.715342 
-L 411.643385 156.941839 
-L 415.716719 150.645581 
-L 419.842954 149.660368 
-L 423.916288 156.249412 
-L 427.989622 159.341695 
-L 432.115857 145.406 
-L 436.189191 144.38 
-L 440.262525 147.294937 
-L 444.38876 140.604359 
-L 448.462094 148.982222 
-L 452.535429 141.465202 
-L 456.608763 149.364706 
-L 460.682097 146.1584 
-L 464.808332 151.510864 
-L 468.881666 153.773333 
-L 472.955 134.4335 
-" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="mbe2357430f" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#p8b40560f1b)">
-     <use xlink:href="#mbe2357430f" x="68.1079" y="213.513711" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="72.392836" y="226.835957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="76.519071" y="233.785301" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="80.592405" y="228.987826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="84.665739" y="228.309333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="88.791974" y="251.958427" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="92.865308" y="249.820552" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="96.938643" y="253.416687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="101.011977" y="253.379012" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="105.085311" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="109.211546" y="261.030194" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="113.28488" y="266.602038" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="117.358214" y="271.777568" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="121.484449" y="277.784204" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="125.557783" y="280.929756" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="129.631117" y="275.149565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="133.704451" y="287.203114" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="137.777785" y="287.771034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="141.90402" y="290.655641" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="145.977354" y="286.417391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="150.050689" y="291.883333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="154.176923" y="287.154444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="158.250257" y="289.666667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="162.323592" y="290.021333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="166.449826" y="287.597778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="170.52316" y="289.468471" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="174.596495" y="291.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="178.669829" y="289.606554" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="182.743163" y="281.465" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="186.869398" y="281.610331" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="190.942732" y="282.522081" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="195.016066" y="282.66597" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="199.142301" y="286.323053" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="203.215635" y="275.731622" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="207.288969" y="273.78425" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="211.362303" y="273.388902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="215.435638" y="270.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="219.561872" y="267.410337" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="223.635206" y="259.864235" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="227.708541" y="262.017805" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="231.834775" y="257.297722" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="235.908109" y="248.749448" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="239.981444" y="253.44" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="244.107678" y="243.994286" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="248.181013" y="241.709565" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="252.254347" y="243.1344" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="256.327681" y="237.436981" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="260.401015" y="233.286897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="264.52725" y="226.181333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="268.600584" y="231.010256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="272.673918" y="230.26" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="276.800153" y="217.612129" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="280.873487" y="213.119527" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="284.946821" y="212.0352" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="289.073056" y="212.97" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="293.14639" y="210.12" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="297.219724" y="209.572994" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="301.293059" y="207.029333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="305.366393" y="207.284027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="309.492627" y="195.712048" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="313.565962" y="196.583396" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="317.639296" y="194.880261" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="321.76553" y="194.896687" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="325.838865" y="187.284375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="329.912199" y="178.603457" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="333.985533" y="188.38491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="338.058867" y="180.535951" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="342.185102" y="187.833" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="346.258436" y="185.828148" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="350.33177" y="176.559294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="354.458005" y="176.342697" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="358.531339" y="176.971921" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="362.604673" y="170.114444" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="366.730908" y="178.220403" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="370.804242" y="169.65" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="374.877576" y="165.30695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="378.950911" y="170.467826" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="383.024245" y="163.925217" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="387.150479" y="158.499441" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="391.223814" y="155.845679" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="395.297148" y="161.877079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="399.423383" y="153.5" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="403.496717" y="167.466067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="407.570051" y="159.715342" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="411.643385" y="156.941839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="415.716719" y="150.645581" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="419.842954" y="149.660368" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="423.916288" y="156.249412" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="427.989622" y="159.341695" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="432.115857" y="145.406" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="436.189191" y="144.38" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="440.262525" y="147.294937" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="444.38876" y="140.604359" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="448.462094" y="148.982222" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="452.535429" y="141.465202" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="456.608763" y="149.364706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="460.682097" y="146.1584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="464.808332" y="151.510864" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="468.881666" y="153.773333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#mbe2357430f" x="472.955" y="134.4335" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 68.055 237.827241 
-L 72.339936 234.649 
-L 76.41327 235.706667 
-L 80.539505 252.101972 
-L 84.612839 250.896 
-L 88.686173 250.190725 
-L 92.812408 259.52 
-L 96.885742 262.88 
-L 100.959076 267.522735 
-L 105.085311 271.575622 
-L 109.158645 269.618584 
-L 113.231979 277.423379 
-L 117.305314 276.474393 
-L 121.378648 277.633333 
-L 125.504882 284.146063 
-L 129.578217 280.985852 
-L 133.651551 280.456034 
-L 137.777785 283.675064 
-L 141.85112 283.495154 
-L 145.924454 286.033143 
-L 150.050689 288.922732 
-L 154.124023 287.374498 
-L 158.197357 289.732651 
-L 162.270691 291.931077 
-L 166.344025 293.908041 
-L 170.47026 289.982466 
-L 174.543594 289.872697 
-L 178.616928 287.915781 
-L 182.743163 282.981935 
-L 186.816497 285.248621 
-L 190.889831 283.342301 
-L 195.016066 283.213463 
-L 199.0894 281.767273 
-L 203.162735 280.485827 
-L 207.236069 278.672 
-L 211.309403 277.049032 
-L 215.435638 272.32125 
-L 219.508972 268.523077 
-L 223.582306 268.032 
-L 227.708541 264.458397 
-L 231.781875 270.556667 
-L 235.855209 268.246667 
-L 239.981444 253.413565 
-L 244.054778 260.132775 
-L 248.128112 252.846667 
-L 252.201446 246.596833 
-L 256.274781 242.8 
-L 260.401015 239.456 
-L 264.474349 242.169849 
-L 268.547684 232.57 
-L 272.673918 229.626667 
-L 276.747252 235.245037 
-L 280.820587 224.304425 
-L 284.946821 223.197241 
-L 289.020155 226.047471 
-L 293.09349 232.02569 
-L 297.219724 210.549289 
-L 301.293059 213.666667 
-L 305.366393 216.80872 
-L 309.439727 203.682167 
-L 313.513061 204.707149 
-L 317.639296 207.062883 
-L 321.71263 210.352511 
-L 325.785964 198.156923 
-L 329.912199 202.612756 
-L 333.985533 190.476667 
-L 338.058867 186.944978 
-L 342.185102 198.088557 
-L 346.258436 187.378966 
-L 350.33177 182.532623 
-L 354.405105 181.408522 
-L 358.478439 185.722655 
-L 362.604673 177.738912 
-L 366.678008 177.76 
-L 370.751342 185.828148 
-L 374.877576 170.421982 
-L 378.950911 176.769063 
-L 383.024245 170.910769 
-L 387.150479 165.008826 
-L 391.223814 170.2 
-L 395.297148 168.801223 
-L 399.370482 179.272277 
-L 403.443816 162.468313 
-L 407.570051 171.88 
-L 411.643385 165.166167 
-L 415.716719 156.642374 
-L 419.842954 166.822353 
-L 423.916288 162.613028 
-L 427.989622 164.855294 
-L 432.115857 165.413514 
-L 436.189191 165.20875 
-L 440.262525 151.206667 
-L 444.33586 157.172255 
-L 448.409194 154.036471 
-L 452.535429 155.039087 
-L 456.608763 153.979563 
-L 460.682097 152.143853 
-L 464.808332 158.798077 
-L 468.881666 147.185126 
-L 472.955 153.437928 
-" clip-path="url(#p8b40560f1b)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="mb0aa4e19a1" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#p8b40560f1b)">
-     <use xlink:href="#mb0aa4e19a1" x="68.055" y="237.827241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="72.339936" y="234.649" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="76.41327" y="235.706667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="80.539505" y="252.101972" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="84.612839" y="250.896" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="88.686173" y="250.190725" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="92.812408" y="259.52" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="96.885742" y="262.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="100.959076" y="267.522735" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="105.085311" y="271.575622" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="109.158645" y="269.618584" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="113.231979" y="277.423379" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="117.305314" y="276.474393" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="121.378648" y="277.633333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="125.504882" y="284.146063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="129.578217" y="280.985852" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="133.651551" y="280.456034" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="137.777785" y="283.675064" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="141.85112" y="283.495154" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="145.924454" y="286.033143" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="150.050689" y="288.922732" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="154.124023" y="287.374498" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="158.197357" y="289.732651" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="162.270691" y="291.931077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="166.344025" y="293.908041" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="170.47026" y="289.982466" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="174.543594" y="289.872697" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="178.616928" y="287.915781" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="182.743163" y="282.981935" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="186.816497" y="285.248621" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="190.889831" y="283.342301" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="195.016066" y="283.213463" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="199.0894" y="281.767273" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="203.162735" y="280.485827" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="207.236069" y="278.672" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="211.309403" y="277.049032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="215.435638" y="272.32125" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="219.508972" y="268.523077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="223.582306" y="268.032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="227.708541" y="264.458397" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="231.781875" y="270.556667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="235.855209" y="268.246667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="239.981444" y="253.413565" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="244.054778" y="260.132775" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="248.128112" y="252.846667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="252.201446" y="246.596833" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="256.274781" y="242.8" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="260.401015" y="239.456" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="264.474349" y="242.169849" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="268.547684" y="232.57" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="272.673918" y="229.626667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="276.747252" y="235.245037" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="280.820587" y="224.304425" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="284.946821" y="223.197241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="289.020155" y="226.047471" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="293.09349" y="232.02569" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="297.219724" y="210.549289" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="301.293059" y="213.666667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="305.366393" y="216.80872" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="309.439727" y="203.682167" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="313.513061" y="204.707149" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="317.639296" y="207.062883" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="321.71263" y="210.352511" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="325.785964" y="198.156923" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="329.912199" y="202.612756" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="333.985533" y="190.476667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="338.058867" y="186.944978" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="342.185102" y="198.088557" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="346.258436" y="187.378966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="350.33177" y="182.532623" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="354.405105" y="181.408522" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="358.478439" y="185.722655" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="362.604673" y="177.738912" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="366.678008" y="177.76" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="370.751342" y="185.828148" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="374.877576" y="170.421982" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="378.950911" y="176.769063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="383.024245" y="170.910769" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="387.150479" y="165.008826" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="391.223814" y="170.2" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="395.297148" y="168.801223" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="399.370482" y="179.272277" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="403.443816" y="162.468313" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="407.570051" y="171.88" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="411.643385" y="165.166167" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="415.716719" y="156.642374" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="419.842954" y="166.822353" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="423.916288" y="162.613028" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="427.989622" y="164.855294" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="432.115857" y="165.413514" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="436.189191" y="165.20875" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="440.262525" y="151.206667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="444.33586" y="157.172255" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="448.409194" y="154.036471" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="452.535429" y="155.039087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="456.608763" y="153.979563" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="460.682097" y="152.143853" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="464.808332" y="158.798077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="468.881666" y="147.185126" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#mb0aa4e19a1" x="472.955" y="153.437928" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_19">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#p8b40560f1b)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_20">
-    <path d="M 157.615452 318.04 
-L 157.615452 25.44 
-" clip-path="url(#p8b40560f1b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_13">
+    <path d="M 32.2596 94.537444 
+L 36.36 92.484706 
+L 40.44 95.503328 
+L 44.52 97.123361 
+L 48.6 99.724769 
+L 52.68 96.778824 
+L 56.76 99.651066 
+L 60.84 99.384706 
+L 64.92 99.112597 
+L 69 101.026805 
+L 73.08 100.50275 
+L 77.16 100.337868 
+L 81.24 99.227937 
+L 85.32 98.942745 
+L 89.4 96.26273 
+L 93.48 94.17015 
+L 97.56 91.333696 
+L 101.64 87.63209 
+L 105.72 84.066405 
+L 109.8 80.422748 
+L 113.88 76.17628 
+L 117.96 72.947704 
+L 122.04 70.055223 
+L 126.12 65.970379 
+L 130.2 64.468219 
+L 134.28 61.271396 
+L 138.36 58.165939 
+L 142.44 57.360271 
+L 146.52 54.856238 
+L 150.6 53.510183 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_14">
+    <path d="M 32.2596 89.813075 
+L 36.36 95.638324 
+L 40.44 94.69861 
+L 44.52 95.943112 
+L 48.6 98.264811 
+L 52.68 97.772348 
+L 56.76 100.810498 
+L 60.84 100.215798 
+L 64.92 100.500458 
+L 69 100.26645 
+L 73.08 101.143529 
+L 77.16 100.401089 
+L 81.24 100.781748 
+L 85.32 98.593863 
+L 89.4 99.414405 
+L 93.48 96.350252 
+L 97.56 94.972101 
+L 101.64 91.933808 
+L 105.72 88.856008 
+L 109.8 85.961335 
+L 113.88 83.676472 
+L 117.96 79.457873 
+L 122.04 77.091242 
+L 126.12 73.48011 
+L 130.2 71.172044 
+L 134.28 69.214757 
+L 138.36 65.531306 
+L 142.44 64.113448 
+L 146.52 61.812826 
+L 150.6 61.190588 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_18">
-    <!-- Takeshi - - deflated (minP power) -->
-    <g transform="translate(173.68375 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-54"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(44.583984 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(105.863281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(160.148438 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(221.671875 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(273.771484 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(337.150391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(364.933594 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(396.720703 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(432.804688 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(468.888672 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(500.675781 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(564.152344 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(625.675781 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(660.880859 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(688.664062 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(749.943359 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(789.152344 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(850.675781 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(914.152344 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(945.939453 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(984.953125 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1082.365234 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1110.148438 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1173.527344 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1233.830078 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1265.617188 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1329.09375 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1390.275391 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1472.0625 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1533.585938 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1574.699219 0)"/>
-    </g>
+   <g id="text_10">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 434.595 80.745625 
-L 487.6 80.745625 
-Q 489.2 80.745625 489.2 79.145625 
-L 489.2 31.04 
-Q 489.2 29.44 487.6 29.44 
-L 434.595 29.44 
-Q 432.995 29.44 432.995 31.04 
-L 432.995 79.145625 
-Q 432.995 80.745625 434.595 80.745625 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_19">
-     <!-- Cell type -->
-     <g transform="translate(438.992031 40.238438) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_21">
-     <path d="M 436.195 49.596875 
-L 444.195 49.596875 
-L 452.195 49.596875 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m337a4558d7" x="444.195" y="49.596875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- K562 -->
-     <g transform="translate(458.595 52.396875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4b" d="M 628 4666 
-L 1259 4666 
-L 1259 2694 
-L 3353 4666 
-L 4166 4666 
-L 1850 2491 
-L 4331 0 
-L 3500 0 
-L 1259 2247 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-35" transform="translate(65.576172 0)"/>
-      <use xlink:href="#DejaVuSans-36" transform="translate(129.199219 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(192.822266 0)"/>
-     </g>
-    </g>
-    <g id="line2d_22">
-     <path d="M 436.195 61.339375 
-L 444.195 61.339375 
-L 452.195 61.339375 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mbe2357430f" x="444.195" y="61.339375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- SKNSH -->
-     <g transform="translate(458.595 64.139375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4e" d="M 628 4666 
-L 1478 4666 
-L 3547 763 
-L 3547 4666 
-L 4159 4666 
-L 4159 0 
-L 3309 0 
-L 1241 3903 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-53"/>
-      <use xlink:href="#DejaVuSans-4b" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-4e" transform="translate(129.052734 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(203.857422 0)"/>
-      <use xlink:href="#DejaVuSans-48" transform="translate(267.333984 0)"/>
-     </g>
-    </g>
-    <g id="line2d_23">
-     <path d="M 436.195 73.081875 
-L 444.195 73.081875 
-L 452.195 73.081875 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mb0aa4e19a1" x="444.195" y="73.081875" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- HepG2 -->
-     <g transform="translate(458.595 75.881875) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-48"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(75.195312 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(136.71875 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(200.195312 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(277.685547 0)"/>
-     </g>
-    </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 95.51934 
+L 36.36 96.947488 
+L 40.44 96.788037 
+L 44.52 97.60455 
+L 48.6 98.565561 
+L 52.68 98.934343 
+L 56.76 98.585867 
+L 60.84 98.813719 
+L 64.92 100.058275 
+L 69 100.454759 
+L 73.08 101.426945 
+L 77.16 101.457843 
+L 81.24 100.157776 
+L 85.32 99.268165 
+L 89.4 98.909368 
+L 93.48 98.16438 
+L 97.56 95.313776 
+L 101.64 94.624601 
+L 105.72 91.933579 
+L 109.8 88.21226 
+L 113.88 85.524013 
+L 117.96 83.139179 
+L 122.04 79.066419 
+L 126.12 77.164936 
+L 130.2 73.265628 
+L 134.28 70.783932 
+L 138.36 67.846601 
+L 142.44 66.985815 
+L 146.52 65.086278 
+L 150.6 63.158129 
+" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
+  </g>
+  <g id="line2d_16">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_11">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Takeshi (unpublished)</text>
+  </g>
+  <g id="text_12">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter withheld</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p8b40560f1b">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="p92be05573a">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="360pt" viewBox="0 0 504 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="159.12pt" height="133.2pt" viewBox="0 0 159.12 133.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:12:23.366884</dc:date>
+    <dc:date>2026-08-16T20:37:59.711262</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,1927 +21,227 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 504 360 
-L 504 0 
+   <path d="M 0 133.2 
+L 159.12 133.2 
+L 159.12 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-L 493.2 25.44 
-L 47.81 25.44 
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+L 152.64 25.92 
+L 30.24 25.92 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <defs>
-       <path id="m0e2fd97e60" d="M 0 0 
-L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="51.814564" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_1"/>
      <g id="text_1">
-      <!-- 0.0 -->
-      <g transform="translate(43.863001 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="30.24" y="115.658477" transform="rotate(-0 30.24 115.658477)">0.5x</text>
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="104.715008" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_2"/>
      <g id="text_2">
-      <!-- 0.5 -->
-      <g transform="translate(96.763445 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="71.04" y="115.658477" transform="rotate(-0 71.04 115.658477)">1x</text>
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="157.615452" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_3"/>
      <g id="text_3">
-      <!-- 1.0 -->
-      <g transform="translate(149.66389 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="111.84" y="115.658477" transform="rotate(-0 111.84 115.658477)">2x</text>
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="210.515896" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
+     <g id="line2d_4"/>
      <g id="text_4">
-      <!-- 1.5 -->
-      <g transform="translate(202.564334 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="152.64" y="115.658477" transform="rotate(-0 152.64 115.658477)">4x</text>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="263.41634" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 2.0 -->
-      <g transform="translate(255.464778 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="316.316785" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 2.5 -->
-      <g transform="translate(308.365222 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="369.217229" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 3.0 -->
-      <g transform="translate(361.265666 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="422.117673" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 3.5 -->
-      <g transform="translate(414.166111 332.638438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m0e2fd97e60" x="475.018117" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 4.0 -->
-      <g transform="translate(467.066555 332.638438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_10">
-     <!-- FC (activity / minP) -->
-     <g transform="translate(222.91125 346.316563) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-50" d="M 1259 4147 
-L 1259 2394 
-L 2053 2394 
-Q 2494 2394 2734 2622 
-Q 2975 2850 2975 3272 
-Q 2975 3691 2734 3919 
-Q 2494 4147 2053 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2053 4666 
-Q 2838 4666 3239 4311 
-Q 3641 3956 3641 3272 
-Q 3641 2581 3239 2228 
-Q 2838 1875 2053 1875 
-L 1259 1875 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(127.34375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(198.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(259.423828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(314.404297 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(353.613281 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(381.396484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(440.576172 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(468.359375 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(507.568359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(566.748047 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(598.535156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(632.226562 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(664.013672 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(761.425781 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(789.208984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(852.587891 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(912.890625 0)"/>
-     </g>
+    <g id="text_5">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="91.44" y="123.918828" transform="rotate(-0 91.44 123.918828)">fold change vs minP</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_10">
-      <defs>
-       <path id="m6423196eb5" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="318.04" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_5">
+      <path d="M 30.24 108.72 
+L 152.64 108.72 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_11">
-      <!-- 0.0 -->
-      <g transform="translate(24.906875 321.839219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="111.189238" transform="rotate(-0 28.24 111.189238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_11">
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="259.52" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_7">
+      <path d="M 30.24 68.131765 
+L 152.64 68.131765 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_12">
-      <!-- 0.2 -->
-      <g transform="translate(24.906875 263.319219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_8"/>
+     <g id="text_7">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="70.601003" transform="rotate(-0 28.24 70.601003)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="201" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
+     <g id="line2d_9">
+      <path d="M 30.24 27.543529 
+L 152.64 27.543529 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="text_13">
-      <!-- 0.4 -->
-      <g transform="translate(24.906875 204.799219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-      </g>
+     <g id="line2d_10"/>
+     <g id="text_8">
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="28.24" y="30.012768" transform="rotate(-0 28.24 30.012768)">1</text>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="142.48" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.6 -->
-      <g transform="translate(24.906875 146.279219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="83.96" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.8 -->
-      <g transform="translate(24.906875 87.759219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m6423196eb5" x="47.81" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 1.0 -->
-      <g transform="translate(24.906875 29.239219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Power (TPR) -->
-     <g transform="translate(18.827188 201.887656) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(56.677734 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(117.859375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(199.646484 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(261.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(302.283203 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(334.070312 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(373.083984 0)"/>
-      <use xlink:href="#DejaVuSans-50" transform="translate(434.167969 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(494.470703 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(563.953125 0)"/>
-     </g>
+    <g id="text_9">
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="14.101211" y="67.32" transform="rotate(-90 14.101211 67.32)">power</text>
     </g>
    </g>
-   <g id="line2d_16">
-    <path d="M 68.055 74.255678 
-L 72.339936 81.769412 
-L 76.41327 81.521667 
-L 80.539505 90.897938 
-L 84.612839 88.435059 
-L 88.686173 107.764746 
-L 92.759507 111.775062 
-L 96.832842 116.989693 
-L 100.959076 127.779324 
-L 105.032411 129.688743 
-L 109.105745 148.08 
-L 113.231979 155.068605 
-L 117.305314 172.058043 
-L 121.378648 185.719778 
-L 125.504882 204.15549 
-L 129.578217 217.513069 
-L 133.651551 245.449617 
-L 137.777785 259.201957 
-L 141.85112 271.348511 
-L 145.924454 283.233987 
-L 149.997788 285.243077 
-L 154.071122 293.711461 
-L 158.197357 293.603077 
-L 162.270691 290.538798 
-L 166.344025 296.137778 
-L 170.47026 283.6491 
-L 174.543594 270.549948 
-L 178.616928 262.5125 
-L 182.743163 245.617459 
-L 186.816497 231.042353 
-L 190.889831 217.52 
-L 194.963166 208.206897 
-L 199.0365 192.376 
-L 203.162735 185.719778 
-L 207.236069 181.493333 
-L 211.309403 166.728619 
-L 215.435638 158.211183 
-L 219.508972 147.149149 
-L 223.582306 142.141734 
-L 227.708541 144.377946 
-L 231.781875 132.672179 
-L 235.855209 129.336471 
-L 239.928543 129.18 
-L 244.001877 110.56 
-L 248.128112 121.628046 
-L 252.201446 110.872941 
-L 256.274781 106.467692 
-L 260.401015 117.224 
-L 264.474349 102.837419 
-L 268.547684 96.099787 
-L 272.673918 95.664 
-L 276.747252 103.697515 
-L 280.820587 102.794023 
-L 284.893921 102.226358 
-L 288.967255 98.930233 
-L 293.09349 90.878621 
-L 297.166824 90.567097 
-L 301.240158 93.39871 
-L 305.366393 85.510199 
-L 309.439727 86.427711 
-L 313.513061 84.585882 
-L 317.639296 83.96 
-L 321.71263 79.758564 
-L 325.785964 86.210769 
-L 329.859298 90.079739 
-L 333.932633 92.722353 
-L 338.058867 85.777391 
-L 342.132201 82.487799 
-L 346.205536 80.768 
-L 350.33177 75.225672 
-L 354.405105 77.614458 
-L 358.478439 77.569885 
-L 362.604673 77.713483 
-L 366.678008 68.033671 
-L 370.751342 70.293653 
-L 374.877576 73.650777 
-L 378.950911 74.47027 
-L 383.024245 64.336527 
-L 387.097579 67.867 
-L 391.170913 77.380828 
-L 395.297148 67.670928 
-L 399.370482 64.453333 
-L 403.443816 61.904724 
-L 407.570051 70.385773 
-L 411.643385 67.046705 
-L 415.716719 65.998416 
-L 419.842954 74.700506 
-L 423.916288 67.773617 
-L 427.989622 66.854154 
-L 432.062957 72.324444 
-L 436.136291 67.46234 
-L 440.262525 61.219067 
-L 444.33586 64.634791 
-L 448.409194 63.749485 
-L 452.535429 64.263024 
-L 456.608763 63.955714 
-L 460.682097 65.391154 
-L 464.808332 58.451282 
-L 468.881666 60.688889 
-L 472.955 62.363333 
-" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-    <defs>
-     <path id="m625fdeae2f" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#p3bd2ef8389)">
-     <use xlink:href="#m625fdeae2f" x="68.055" y="74.255678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="72.339936" y="81.769412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="76.41327" y="81.521667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="80.539505" y="90.897938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="84.612839" y="88.435059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="88.686173" y="107.764746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="92.759507" y="111.775062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="96.832842" y="116.989693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="100.959076" y="127.779324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="105.032411" y="129.688743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="109.105745" y="148.08" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="113.231979" y="155.068605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="117.305314" y="172.058043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="121.378648" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="125.504882" y="204.15549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="129.578217" y="217.513069" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="133.651551" y="245.449617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="137.777785" y="259.201957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="141.85112" y="271.348511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="145.924454" y="283.233987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="149.997788" y="285.243077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="154.071122" y="293.711461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="158.197357" y="293.603077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="162.270691" y="290.538798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="166.344025" y="296.137778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="170.47026" y="283.6491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="174.543594" y="270.549948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="178.616928" y="262.5125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="182.743163" y="245.617459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="186.816497" y="231.042353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="190.889831" y="217.52" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="194.963166" y="208.206897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="199.0365" y="192.376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="203.162735" y="185.719778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="207.236069" y="181.493333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="211.309403" y="166.728619" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="215.435638" y="158.211183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="219.508972" y="147.149149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="223.582306" y="142.141734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="227.708541" y="144.377946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="231.781875" y="132.672179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="235.855209" y="129.336471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="239.928543" y="129.18" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="244.001877" y="110.56" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="248.128112" y="121.628046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="252.201446" y="110.872941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="256.274781" y="106.467692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="260.401015" y="117.224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="264.474349" y="102.837419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="268.547684" y="96.099787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="272.673918" y="95.664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="276.747252" y="103.697515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="280.820587" y="102.794023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="284.893921" y="102.226358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="288.967255" y="98.930233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="293.09349" y="90.878621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="297.166824" y="90.567097" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="301.240158" y="93.39871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="305.366393" y="85.510199" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="309.439727" y="86.427711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="313.513061" y="84.585882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="317.639296" y="83.96" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="321.71263" y="79.758564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="325.785964" y="86.210769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="329.859298" y="90.079739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="333.932633" y="92.722353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="338.058867" y="85.777391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="342.132201" y="82.487799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="346.205536" y="80.768" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="350.33177" y="75.225672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="354.405105" y="77.614458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="358.478439" y="77.569885" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="362.604673" y="77.713483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="366.678008" y="68.033671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="370.751342" y="70.293653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="374.877576" y="73.650777" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="378.950911" y="74.47027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="383.024245" y="64.336527" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="387.097579" y="67.867" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="391.170913" y="77.380828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="395.297148" y="67.670928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="399.370482" y="64.453333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="403.443816" y="61.904724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="407.570051" y="70.385773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="411.643385" y="67.046705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="415.716719" y="65.998416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="419.842954" y="74.700506" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="423.916288" y="67.773617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="427.989622" y="66.854154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="432.062957" y="72.324444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="436.136291" y="67.46234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="440.262525" y="61.219067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="444.33586" y="64.634791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="448.409194" y="63.749485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="452.535429" y="64.263024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="456.608763" y="63.955714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="460.682097" y="65.391154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="464.808332" y="58.451282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="468.881666" y="60.688889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m625fdeae2f" x="472.955" y="62.363333" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
+   <g id="line2d_11">
+    <path d="M 71.04 108.72 
+L 71.04 25.92 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_17">
-    <path d="M 68.1079 77.335094 
-L 72.392836 88.006596 
-L 76.519071 88.895422 
-L 80.592405 97.772174 
-L 84.665739 92.933067 
-L 88.791974 116.50764 
-L 92.865308 130.840663 
-L 96.938643 128.119264 
-L 101.011977 130.920494 
-L 105.085311 144.367742 
-L 109.211546 156.826839 
-L 113.28488 173.790064 
-L 117.358214 181.22973 
-L 121.484449 203.236433 
-L 125.557783 224.193902 
-L 129.631117 222.081739 
-L 133.704451 244.802395 
-L 137.777785 269.273333 
-L 141.90402 271.899231 
-L 145.977354 285.326957 
-L 150.050689 284.79 
-L 154.176923 294.306889 
-L 158.250257 294.277333 
-L 162.323592 290.730667 
-L 166.449826 292.917778 
-L 170.52316 282.583765 
-L 174.596495 276.189333 
-L 178.669829 263.818079 
-L 182.743163 259.1875 
-L 186.869398 252.156556 
-L 190.942732 239.224046 
-L 195.016066 228.949851 
-L 199.142301 221.10229 
-L 203.215635 203.767838 
-L 207.288969 193.685 
-L 211.362303 190.175491 
-L 215.435638 180.429333 
-L 219.561872 173.712584 
-L 223.635206 164.511059 
-L 227.708541 169.242195 
-L 231.834775 160.998987 
-L 235.908109 148.583313 
-L 239.981444 142.86 
-L 244.107678 153.228571 
-L 248.181013 141.843913 
-L 252.254347 129.995733 
-L 256.327681 129.230189 
-L 260.401015 129.69977 
-L 264.52725 124.746667 
-L 268.600584 130.475897 
-L 272.673918 110.14 
-L 276.800153 115.674065 
-L 280.873487 111.661775 
-L 284.946821 116.7312 
-L 289.073056 106.9025 
-L 293.14639 108.28 
-L 297.219724 108.188025 
-L 301.293059 103.112 
-L 305.366393 105.168591 
-L 309.492627 98.766265 
-L 313.565962 95.73761 
-L 317.639296 101.554248 
-L 321.76553 101.91092 
-L 325.838865 94.9325 
-L 329.912199 94.797037 
-L 333.985533 96.224671 
-L 338.058867 85.755092 
-L 342.185102 94.56675 
-L 346.258436 95.158272 
-L 350.33177 90.844706 
-L 354.458005 88.233933 
-L 358.531339 87.060397 
-L 362.604673 87.211111 
-L 366.730908 97.706309 
-L 370.804242 82.706 
-L 374.877576 75.659291 
-L 378.950911 89.048696 
-L 383.024245 85.777391 
-L 387.150479 74.806034 
-L 391.223814 86.127407 
-L 395.297148 83.631236 
-L 399.423383 83.96 
-L 403.496717 83.96 
-L 407.570051 77.947671 
-L 411.643385 82.614713 
-L 415.716719 79.877209 
-L 419.842954 79.292761 
-L 423.916288 83.96 
-L 427.989622 83.96 
-L 432.115857 74.08475 
-L 436.189191 80.16 
-L 440.262525 72.107848 
-L 444.38876 73.831538 
-L 448.462094 74.671111 
-L 452.535429 71.782428 
-L 456.608763 79.370196 
-L 460.682097 83.6256 
-L 464.808332 74.929136 
-L 468.881666 82.591111 
-L 472.955 75.182 
-" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-    <defs>
-     <path id="m279b9dd2f2" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #ff7f0e"/>
-    </defs>
-    <g clip-path="url(#p3bd2ef8389)">
-     <use xlink:href="#m279b9dd2f2" x="68.1079" y="77.335094" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="72.392836" y="88.006596" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="76.519071" y="88.895422" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="80.592405" y="97.772174" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="84.665739" y="92.933067" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="88.791974" y="116.50764" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="92.865308" y="130.840663" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="96.938643" y="128.119264" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="101.011977" y="130.920494" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="105.085311" y="144.367742" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="109.211546" y="156.826839" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="113.28488" y="173.790064" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="117.358214" y="181.22973" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="121.484449" y="203.236433" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="125.557783" y="224.193902" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="129.631117" y="222.081739" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="133.704451" y="244.802395" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="137.777785" y="269.273333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="141.90402" y="271.899231" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="145.977354" y="285.326957" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="150.050689" y="284.79" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="154.176923" y="294.306889" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="158.250257" y="294.277333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="162.323592" y="290.730667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="166.449826" y="292.917778" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="170.52316" y="282.583765" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="174.596495" y="276.189333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="178.669829" y="263.818079" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="182.743163" y="259.1875" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="186.869398" y="252.156556" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="190.942732" y="239.224046" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="195.016066" y="228.949851" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="199.142301" y="221.10229" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="203.215635" y="203.767838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="207.288969" y="193.685" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="211.362303" y="190.175491" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="215.435638" y="180.429333" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="219.561872" y="173.712584" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="223.635206" y="164.511059" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="227.708541" y="169.242195" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="231.834775" y="160.998987" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="235.908109" y="148.583313" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="239.981444" y="142.86" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="244.107678" y="153.228571" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="248.181013" y="141.843913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="252.254347" y="129.995733" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="256.327681" y="129.230189" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="260.401015" y="129.69977" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="264.52725" y="124.746667" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="268.600584" y="130.475897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="272.673918" y="110.14" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="276.800153" y="115.674065" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="280.873487" y="111.661775" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="284.946821" y="116.7312" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="289.073056" y="106.9025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="293.14639" y="108.28" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="297.219724" y="108.188025" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="301.293059" y="103.112" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="305.366393" y="105.168591" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="309.492627" y="98.766265" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="313.565962" y="95.73761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="317.639296" y="101.554248" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="321.76553" y="101.91092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="325.838865" y="94.9325" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="329.912199" y="94.797037" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="333.985533" y="96.224671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="338.058867" y="85.755092" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="342.185102" y="94.56675" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="346.258436" y="95.158272" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="350.33177" y="90.844706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="354.458005" y="88.233933" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="358.531339" y="87.060397" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="362.604673" y="87.211111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="366.730908" y="97.706309" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="370.804242" y="82.706" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="374.877576" y="75.659291" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="378.950911" y="89.048696" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="383.024245" y="85.777391" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="387.150479" y="74.806034" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="391.223814" y="86.127407" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="395.297148" y="83.631236" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="399.423383" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="403.496717" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="407.570051" y="77.947671" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="411.643385" y="82.614713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="415.716719" y="79.877209" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="419.842954" y="79.292761" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="423.916288" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="427.989622" y="83.96" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="432.115857" y="74.08475" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="436.189191" y="80.16" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="440.262525" y="72.107848" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="444.38876" y="73.831538" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="448.462094" y="74.671111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="452.535429" y="71.782428" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="456.608763" y="79.370196" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="460.682097" y="83.6256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="464.808332" y="74.929136" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="468.881666" y="82.591111" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m279b9dd2f2" x="472.955" y="75.182" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-    </g>
-   </g>
-   <g id="line2d_18">
-    <path d="M 68.055 85.221207 
-L 72.339936 89.812 
-L 76.41327 92.826667 
-L 80.539505 105.939343 
-L 84.612839 107.778667 
-L 88.686173 116.753816 
-L 92.812408 120.44318 
-L 96.885742 131.28 
-L 100.959076 146.731453 
-L 105.085311 157.04721 
-L 109.158645 168.373805 
-L 113.231979 178.821187 
-L 117.305314 190.608598 
-L 121.378648 208.524 
-L 125.504882 226.155656 
-L 129.578217 244.187249 
-L 133.651551 258.258793 
-L 137.777785 266.741617 
-L 141.85112 274.730044 
-L 145.924454 280.300571 
-L 150.050689 287.495415 
-L 154.124023 287.88559 
-L 158.197357 291.365767 
-L 162.270691 289.455231 
-L 166.344025 284.255258 
-L 170.47026 281.164384 
-L 174.543594 274.089295 
-L 178.616928 270.384473 
-L 182.743163 265.992258 
-L 186.816497 250.943793 
-L 190.889831 240.617522 
-L 195.016066 235.25561 
-L 199.0894 224.94 
-L 203.162735 207.22063 
-L 207.236069 216.162 
-L 211.309403 193.449032 
-L 215.435638 190.0275 
-L 219.508972 179.742735 
-L 223.582306 181.05 
-L 227.708541 164.455865 
-L 231.781875 166.093333 
-L 235.855209 160.96 
-L 239.981444 148.332 
-L 244.054778 151.97801 
-L 248.128112 139.143333 
-L 252.201446 136.628 
-L 256.274781 133.36 
-L 260.401015 137.185333 
-L 264.474349 125.71799 
-L 268.547684 121.176667 
-L 272.673918 120.44 
-L 276.747252 127.308148 
-L 280.820587 113.737876 
-L 284.946821 114.228966 
-L 289.020155 115.610895 
-L 293.09349 113.472241 
-L 297.219724 102.56887 
-L 301.293059 106.253333 
-L 305.366393 100.323412 
-L 309.439727 102.2475 
-L 313.513061 92.963077 
-L 317.639296 102.148649 
-L 321.71263 96.519087 
-L 325.785964 97.227692 
-L 329.912199 94.097323 
-L 333.985533 93.713333 
-L 338.058867 87.793188 
-L 342.185102 90.07403 
-L 346.258436 94.049655 
-L 350.33177 90.435574 
-L 354.405105 88.794261 
-L 358.478439 90.692389 
-L 362.604673 81.021757 
-L 366.678008 89.84 
-L 370.751342 93.592922 
-L 374.877576 87.914054 
-L 378.950911 85.560156 
-L 383.024245 89.172308 
-L 387.150479 81.487324 
-L 391.223814 77.24 
-L 395.297148 81.404541 
-L 399.370482 87.146733 
-L 403.443816 79.866008 
-L 407.570051 81.44 
-L 411.643385 79.835242 
-L 415.716719 72.736986 
-L 419.842954 84.697647 
-L 423.916288 88.255046 
-L 427.989622 84.697647 
-L 432.115857 76.315495 
-L 436.189191 78.2125 
-L 440.262525 72.153333 
-L 444.33586 78.481532 
-L 448.409194 78.058824 
-L 452.535429 79.951781 
-L 456.608763 77.315808 
-L 460.682097 70.806422 
-L 464.808332 82.553269 
-L 468.881666 75.72603 
-L 472.955 78.364462 
-" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-    <defs>
-     <path id="m9b7f166b95" d="M 0 1 
-C 0.265203 1 0.51958 0.894634 0.707107 0.707107 
-C 0.894634 0.51958 1 0.265203 1 0 
-C 1 -0.265203 0.894634 -0.51958 0.707107 -0.707107 
-C 0.51958 -0.894634 0.265203 -1 0 -1 
-C -0.265203 -1 -0.51958 -0.894634 -0.707107 -0.707107 
-C -0.894634 -0.51958 -1 -0.265203 -1 0 
-C -1 0.265203 -0.894634 0.51958 -0.707107 0.707107 
-C -0.51958 0.894634 -0.265203 1 0 1 
-z
-" style="stroke: #2ca02c"/>
-    </defs>
-    <g clip-path="url(#p3bd2ef8389)">
-     <use xlink:href="#m9b7f166b95" x="68.055" y="85.221207" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="72.339936" y="89.812" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="76.41327" y="92.826667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="80.539505" y="105.939343" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="84.612839" y="107.778667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="88.686173" y="116.753816" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="92.812408" y="120.44318" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="96.885742" y="131.28" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="100.959076" y="146.731453" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="105.085311" y="157.04721" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="109.158645" y="168.373805" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="113.231979" y="178.821187" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="117.305314" y="190.608598" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="121.378648" y="208.524" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="125.504882" y="226.155656" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="129.578217" y="244.187249" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="133.651551" y="258.258793" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="137.777785" y="266.741617" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="141.85112" y="274.730044" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="145.924454" y="280.300571" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="150.050689" y="287.495415" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="154.124023" y="287.88559" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="158.197357" y="291.365767" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="162.270691" y="289.455231" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="166.344025" y="284.255258" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="170.47026" y="281.164384" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="174.543594" y="274.089295" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="178.616928" y="270.384473" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="182.743163" y="265.992258" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="186.816497" y="250.943793" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="190.889831" y="240.617522" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="195.016066" y="235.25561" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="199.0894" y="224.94" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="203.162735" y="207.22063" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="207.236069" y="216.162" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="211.309403" y="193.449032" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="215.435638" y="190.0275" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="219.508972" y="179.742735" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="223.582306" y="181.05" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="227.708541" y="164.455865" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="231.781875" y="166.093333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="235.855209" y="160.96" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="239.981444" y="148.332" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="244.054778" y="151.97801" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="248.128112" y="139.143333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="252.201446" y="136.628" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="256.274781" y="133.36" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="260.401015" y="137.185333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="264.474349" y="125.71799" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="268.547684" y="121.176667" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="272.673918" y="120.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="276.747252" y="127.308148" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="280.820587" y="113.737876" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="284.946821" y="114.228966" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="289.020155" y="115.610895" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="293.09349" y="113.472241" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="297.219724" y="102.56887" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="301.293059" y="106.253333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="305.366393" y="100.323412" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="309.439727" y="102.2475" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="313.513061" y="92.963077" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="317.639296" y="102.148649" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="321.71263" y="96.519087" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="325.785964" y="97.227692" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="329.912199" y="94.097323" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="333.985533" y="93.713333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="338.058867" y="87.793188" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="342.185102" y="90.07403" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="346.258436" y="94.049655" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="350.33177" y="90.435574" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="354.405105" y="88.794261" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="358.478439" y="90.692389" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="362.604673" y="81.021757" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="366.678008" y="89.84" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="370.751342" y="93.592922" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="374.877576" y="87.914054" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="378.950911" y="85.560156" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="383.024245" y="89.172308" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="387.150479" y="81.487324" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="391.223814" y="77.24" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="395.297148" y="81.404541" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="399.370482" y="87.146733" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="403.443816" y="79.866008" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="407.570051" y="81.44" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="411.643385" y="79.835242" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="415.716719" y="72.736986" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="419.842954" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="423.916288" y="88.255046" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="427.989622" y="84.697647" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="432.115857" y="76.315495" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="436.189191" y="78.2125" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="440.262525" y="72.153333" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="444.33586" y="78.481532" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="448.409194" y="78.058824" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="452.535429" y="79.951781" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="456.608763" y="77.315808" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="460.682097" y="70.806422" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="464.808332" y="82.553269" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="468.881666" y="75.72603" style="fill: #2ca02c; stroke: #2ca02c"/>
-     <use xlink:href="#m9b7f166b95" x="472.955" y="78.364462" style="fill: #2ca02c; stroke: #2ca02c"/>
-    </g>
-   </g>
-   <g id="line2d_19">
-    <path d="M 47.81 83.96 
-L 493.2 83.96 
-" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #000000; stroke-width: 0.8"/>
-   </g>
-   <g id="line2d_20">
-    <path d="M 157.615452 318.04 
-L 157.615452 25.44 
-" clip-path="url(#p3bd2ef8389)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #808080; stroke-width: 0.8"/>
+   <g id="line2d_12">
+    <path d="M 30.24 43.778824 
+L 152.64 43.778824 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
-    <path d="M 47.81 318.04 
-L 47.81 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 30.24 25.92 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 493.2 318.04 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+    <path d="M 30.24 108.72 
+L 152.64 108.72 
+" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_5">
-    <path d="M 47.81 318.04 
-L 493.2 318.04 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_13">
+    <path d="M 32.2596 59.827505 
+L 36.36 61.459144 
+L 40.44 66.296116 
+L 44.52 68.441008 
+L 48.6 76.395676 
+L 52.68 80.602353 
+L 56.76 89.377169 
+L 60.84 95.441849 
+L 64.92 98.869372 
+L 69 101.769596 
+L 73.08 101.399177 
+L 77.16 100.053038 
+L 81.24 93.773221 
+L 85.32 84.836078 
+L 89.4 76.487666 
+L 93.48 70.195573 
+L 97.56 62.467586 
+L 101.64 58.87585 
+L 105.72 54.401917 
+L 109.8 51.36208 
+L 113.88 48.044854 
+L 117.96 47.809184 
+L 122.04 45.213267 
+L 126.12 43.758903 
+L 130.2 43.701696 
+L 134.28 41.337152 
+L 138.36 40.225859 
+L 142.44 39.067182 
+L 146.52 39.021816 
+L 150.6 37.913011 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="patch_6">
-    <path d="M 47.81 25.44 
-L 493.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   <g id="line2d_14">
+    <path d="M 32.2596 63.405034 
+L 36.36 65.737351 
+L 40.44 67.486043 
+L 44.52 75.38481 
+L 48.6 79.904478 
+L 52.68 83.101004 
+L 56.76 89.362534 
+L 60.84 96.736807 
+L 64.92 99.141856 
+L 69 102.001947 
+L 73.08 101.401232 
+L 77.16 100.132737 
+L 81.24 95.310185 
+L 85.32 89.555658 
+L 89.4 83.327604 
+L 93.48 75.128403 
+L 97.56 69.089748 
+L 101.64 65.782346 
+L 105.72 60.671037 
+L 109.8 56.416025 
+L 113.88 53.89005 
+L 117.96 51.305438 
+L 122.04 49.046275 
+L 126.12 47.520551 
+L 130.2 46.153722 
+L 134.28 45.408103 
+L 138.36 43.269274 
+L 142.44 43.211722 
+L 146.52 42.05832 
+L 150.6 42.034879 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_18">
-    <!-- Takeshi - - reporter (minP power) -->
-    <g transform="translate(174.012812 19.44) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-54"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(44.583984 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(105.863281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(160.148438 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(221.671875 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(273.771484 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(337.150391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(364.933594 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(396.720703 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(432.804688 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(468.888672 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(500.675781 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(539.539062 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(601.0625 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(664.539062 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(725.720703 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(766.833984 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(806.042969 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(867.566406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(908.679688 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(940.466797 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(979.480469 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1076.892578 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1104.675781 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1168.054688 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1228.357422 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1260.144531 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1323.621094 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1384.802734 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1466.589844 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1528.113281 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(1569.226562 0)"/>
-    </g>
+   <g id="text_10">
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 53.41 314.04 
-L 106.415 314.04 
-Q 108.015 314.04 108.015 312.44 
-L 108.015 264.334375 
-Q 108.015 262.734375 106.415 262.734375 
-L 53.41 262.734375 
-Q 51.81 262.734375 51.81 264.334375 
-L 51.81 312.44 
-Q 51.81 314.04 53.41 314.04 
-z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_19">
-     <!-- Cell type -->
-     <g transform="translate(57.807031 273.532812) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-43"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(69.824219 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(131.347656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(159.130859 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(186.914062 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(218.701172 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(257.910156 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(317.089844 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(380.566406 0)"/>
-     </g>
-    </g>
-    <g id="line2d_21">
-     <path d="M 55.01 282.89125 
-L 63.01 282.89125 
-L 71.01 282.89125 
-" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m625fdeae2f" x="63.01" y="282.89125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- K562 -->
-     <g transform="translate(77.41 285.69125) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-4b" d="M 628 4666 
-L 1259 4666 
-L 1259 2694 
-L 3353 4666 
-L 4166 4666 
-L 1850 2491 
-L 4331 0 
-L 3500 0 
-L 1259 2247 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-35" transform="translate(65.576172 0)"/>
-      <use xlink:href="#DejaVuSans-36" transform="translate(129.199219 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(192.822266 0)"/>
-     </g>
-    </g>
-    <g id="line2d_22">
-     <path d="M 55.01 294.63375 
-L 63.01 294.63375 
-L 71.01 294.63375 
-" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m279b9dd2f2" x="63.01" y="294.63375" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- SKNSH -->
-     <g transform="translate(77.41 297.43375) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4e" d="M 628 4666 
-L 1478 4666 
-L 3547 763 
-L 3547 4666 
-L 4159 4666 
-L 4159 0 
-L 3309 0 
-L 1241 3903 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-53"/>
-      <use xlink:href="#DejaVuSans-4b" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-4e" transform="translate(129.052734 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(203.857422 0)"/>
-      <use xlink:href="#DejaVuSans-48" transform="translate(267.333984 0)"/>
-     </g>
-    </g>
-    <g id="line2d_23">
-     <path d="M 55.01 306.37625 
-L 63.01 306.37625 
-L 71.01 306.37625 
-" style="fill: none; stroke: #2ca02c; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m9b7f166b95" x="63.01" y="306.37625" style="fill: #2ca02c; stroke: #2ca02c"/>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- HepG2 -->
-     <g transform="translate(77.41 309.17625) scale(0.08 -0.08)">
-      <defs>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-48"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(75.195312 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(136.71875 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(200.195312 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(277.685547 0)"/>
-     </g>
-    </g>
+   <g id="line2d_15">
+    <path d="M 32.2596 65.09713 
+L 36.36 66.86218 
+L 40.44 71.946081 
+L 44.52 75.777847 
+L 48.6 82.03508 
+L 52.68 87.536277 
+L 56.76 92.74323 
+L 60.84 96.383011 
+L 64.92 98.578382 
+L 69 100.834286 
+L 73.08 100.913865 
+L 77.16 98.568188 
+L 81.24 95.580279 
+L 85.32 90.266418 
+L 89.4 84.931387 
+L 93.48 77.696121 
+L 97.56 72.044037 
+L 101.64 66.387285 
+L 105.72 61.943063 
+L 109.8 57.909157 
+L 113.88 54.817306 
+L 117.96 52.186387 
+L 122.04 48.929446 
+L 126.12 47.379885 
+L 130.2 46.060541 
+L 134.28 44.987406 
+L 138.36 43.867541 
+L 142.44 43.094853 
+L 146.52 42.442315 
+L 150.6 42.012289 
+" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
+  </g>
+  <g id="line2d_16">
+   <path d="M 30.24 17.64 
+L 36.36 17.64 
+" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+  </g>
+  <g id="text_11">
+   <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Takeshi (unpublished)</text>
+  </g>
+  <g id="text_12">
+   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter used</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p3bd2ef8389">
-   <rect x="47.81" y="25.44" width="445.39" height="292.6"/>
+  <clipPath id="pb5df15ee01">
+   <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
Re-plots manuscript Figure 3 panel A, and fixes a silent text-rendering bug that had been putting code names in the figure.

## The bug: text was baked to glyph paths

`replot_overlay_ct.py` never set `svg.fonttype: "none"` and never imported `scMPRAforge` (whose `__init__` sets it), so its SVGs contained **zero `<text>` elements**. Three consequences, all live in the manuscript:

1. The `dataset_names` transform, correctly wired in the manifest, was a **silent no-op** against paths. Figure 3A printed "Shendure" / "Cohen" / "Seelig" while panel B directly below read "Lalanne et al." / "Zhao et al." / "Yin et al." Same figure, same page.
2. Text was not editable, which the docx export path needs.
3. Font sizes could not be adjusted downstream.

Fixed, and the citation-form names are now written directly into the titles as well, so the panel does not depend on a transform to be correct. `<text>` counts go 0 -> 8..14 per SVG.

Related: the script used seaborn `tab10`, which is not in `figure_styling.PALETTE_PLACEHOLDER`, so the manuscript's global Okabe-Ito remap was passing it through unchanged. The panel was off-palette as well as unlabelled.

## Sizing

Drawn at 2.21 x 1.85 in, the true `0.32\textwidth` display size, with fixed margins in inches so the three plot areas align in the tabular. Type scale matches Fig 4B exactly (7 pt body, 7.5 axis labels and titles, 6.5 ticks, 6 annotations). No `bbox_inches="tight"`, which would crop each panel to its own contents and break the row alignment, since only the left panel carries tick labels.

## X axis: shared, log2, 0.5x to 4x

Fold change is a ratio, so the axis is log2 with ticks at 0.5x / 1x / 2x / 4x - a 2x activation and a 2x repression then sit equidistant from 1x.

Shared rather than per-panel because the panel's claim is that the three designs need different effect sizes: Zhao reaches 80% power at 1.06-1.18x, Lalanne at 1.30-1.79x, Yin at 2.19-2.43x. Per-panel ranges would draw those three thresholds at the same width and destroy the comparison.

Zhao's simulation stops at 1.60x, so the rest of its panel carries a light tint labelled "not simulated" rather than ambiguous white space. That band is derived from the data, so no other panel gets one.

## Legend removed

A 10-entry boxed "Cell Type" legend is not fixable by shrinking, and a shared legend is impossible because no two datasets share cell types. Replaced with Fig 4B's device: reference cell type solid, the rest of the dataset as a translucent band in the same hue, and two direct labels per panel (reference plus the weakest cell type) with leaders landing on a dot at that curve's interpolated 80% crossing - so the dashed 80% rule does double duty.

Colour encodes the reporter condition, using the same Okabe-Ito pair as Fig 4B and `fpr_dumbbell.py` (`#0072b2` reporter, `#d55e00` none), keyed by a short coloured rule in each subtitle so nothing depends on having read Fig 4 first. Validated with `scripts/validate_palette.js --pairs all`: six of six checks pass, worst CVD dE 21.9, normal-vision 31.2.

## Binning and asserts

Fixed *width* in log2 (0.1) rather than fixed bin count, so a bin is the same multiplicative step in every dataset. Bins whose centre falls outside an arm's simulated range are dropped, so a curve ends where its simulation ended. Asserts cover per-dataset cell-type counts (10/4/2/3, actual values in the message), positive fold change, power in [0,1], no cell type disagreeing on bin count, and a 200-draw floor per kept bin (thinnest actual is 615).

## Worth knowing

- **The V is asymmetric**: repression is consistently harder to detect than the reciprocal activation (Yin K562 0.54 at 2x against 0.22 at 0.5x; Lalanne Cardiomyocytes 0.91 against 0.75). Folding to `|log2 FC|`, as Fig 3B's axis does, would hide this, so both arms stay here.
- **Zhao's curve is a narrow spike, not a V** - all four cell types above 0.95 by 1.3x in both directions. Its panel is mostly empty, and the shared axis is what makes that emptiness meaningful.
- **Lalanne's deflated arm has almost no repressive limb**, and four of ten cell types never reach 80% anywhere in the window. Not a manuscript panel, but a sharper statement of the reporter's contribution than Fig 4 currently makes.
- Two stale files, `cohen_power_mwu_overlay_ct.svg` and `shendure_power_mwu_overlay_ct.svg`, are left from an older `DATASETS` config. Nothing produces or references them. Left untouched.
