### PR TITLE
Drop condition key from Fig 3A

### DIFF
--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.404709</dc:date>
+    <dc:date>2026-08-16T22:21:42.393763</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 152.64 108.72
 L 152.64 25.92 
 L 99.6 25.92 
 z
-" clip-path="url(#pc69d595cd2)" style="fill: #c9c9c9; opacity: 0.22"/>
+" clip-path="url(#p6021fe16fe)" style="fill: #c9c9c9; opacity: 0.22"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -79,7 +79,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_6">
@@ -90,7 +90,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_7">
@@ -101,7 +101,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_8">
@@ -119,12 +119,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_4">
     <path d="M 30.24 108.72 
@@ -154,7 +154,7 @@ L 85.32 43.5609
 L 89.4 38.859037 
 L 93.48 35.978893 
 L 97.56 33.868445 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 32.182185 
@@ -174,7 +174,7 @@ L 85.32 39.872993
 L 89.4 35.872658 
 L 93.48 33.952198 
 L 97.56 32.562075 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_15">
     <path d="M 32.2596 33.900205 
@@ -194,7 +194,7 @@ L 85.32 43.256846
 L 89.4 38.361636 
 L 93.48 34.680096 
 L 97.56 32.722028 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_11">
     <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="97.6" y="49.337417" transform="rotate(-0 97.6 49.337417)">80%</text>
@@ -217,7 +217,7 @@ L 85.32 29.685436
 L 89.4 28.942563 
 L 93.48 28.44549 
 L 97.56 28.303309 
-" clip-path="url(#pc69d595cd2)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#p6021fe16fe)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="line2d_17">
@@ -233,7 +233,7 @@ L 36.36 17.64
   </g>
  </g>
  <defs>
-  <clipPath id="pc69d595cd2">
+  <clipPath id="p6021fe16fe">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/cohen/output/overlay_ct/cohen_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.370159</dc:date>
+    <dc:date>2026-08-16T22:21:42.355097</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 152.64 108.72
 L 152.64 25.92 
 L 99.6 25.92 
 z
-" clip-path="url(#p0b1cd83206)" style="fill: #c9c9c9; opacity: 0.22"/>
+" clip-path="url(#p5af522ea88)" style="fill: #c9c9c9; opacity: 0.22"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -79,7 +79,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
     </g>
@@ -87,7 +87,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
     </g>
@@ -95,7 +95,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
     </g>
@@ -107,12 +107,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_4">
     <path d="M 30.24 108.72 
@@ -142,7 +142,7 @@ L 85.32 36.53287
 L 89.4 33.332478 
 L 93.48 31.769154 
 L 97.56 30.927561 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 29.476303 
@@ -162,7 +162,7 @@ L 85.32 33.663263
 L 89.4 31.675558 
 L 93.48 30.676656 
 L 97.56 30.382706 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_15">
     <path d="M 32.2596 30.206461 
@@ -182,7 +182,7 @@ L 85.32 35.301192
 L 89.4 32.375075 
 L 93.48 31.293787 
 L 97.56 30.382706 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_16">
     <path d="M 32.2596 28.187787 
@@ -202,7 +202,7 @@ L 85.32 28.767476
 L 89.4 28.21051 
 L 93.48 28.113189 
 L 97.56 28.02339 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_6">
     <path d="M 57.863412 62.025522 
@@ -214,9 +214,9 @@ Q 65.454632 53.81874 73.045852 45.611957
    </g>
    <g id="line2d_17">
     <path d="M 74.741489 43.778824 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
     <defs>
-     <path id="m528ccd0fbb" d="M 0 1.6 
+     <path id="mfd7c29eb8a" d="M 0 1.6 
 C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
 C 1.431414 0.831328 1.6 0.424325 1.6 0 
 C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
@@ -228,8 +228,8 @@ C -0.831328 1.431414 -0.424325 1.6 0 1.6
 z
 " style="stroke: #ffffff; stroke-width: 0.8"/>
     </defs>
-    <g clip-path="url(#p0b1cd83206)">
-     <use xlink:href="#m528ccd0fbb" x="74.741489" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
+    <g clip-path="url(#p5af522ea88)">
+     <use xlink:href="#mfd7c29eb8a" x="74.741489" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
    <g id="patch_7">
@@ -242,26 +242,18 @@ Q 83.787967 61.252866 81.245442 46.241408
    </g>
    <g id="line2d_18">
     <path d="M 80.828348 43.778824 
-" clip-path="url(#p0b1cd83206)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
-    <g clip-path="url(#p0b1cd83206)">
-     <use xlink:href="#m528ccd0fbb" x="80.828348" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
+" clip-path="url(#p5af522ea88)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#p5af522ea88)">
+     <use xlink:href="#mfd7c29eb8a" x="80.828348" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
-  </g>
-  <g id="line2d_19">
-   <path d="M 30.24 17.64 
-L 36.36 17.64 
-" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
   </g>
   <g id="text_9">
    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Zhao et al.</text>
   </g>
-  <g id="text_10">
-   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter used</text>
-  </g>
  </g>
  <defs>
-  <clipPath id="p0b1cd83206">
+  <clipPath id="p5af522ea88">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/replot_overlay_ct.py
+++ b/analyses/simulation/activity_power/replot_overlay_ct.py
@@ -335,16 +335,25 @@ def draw_annotations(ax, curve, dataset, condition, color):
                 markeredgecolor="white", markeredgewidth=0.8, zorder=6)
 
 
-def draw_title(fig, dataset, condition, color):
-    """Dataset above, condition below, with a key stub for the curve colour.
+def draw_title(fig, dataset, condition, color, role=None):
+    """Dataset name, plus a condition key on the standalone panels only.
 
     Indented to the left edge of the axes rather than the figure: the
     manuscript overlays a bold panel letter on the top-left corner of the row
     via \\panel{}, and a flush-left title lands under it.
+
+    The manuscript row (``role`` set) carries no condition key. Each of those
+    three panels shows its dataset's only empirical regime -- Lalanne et al.
+    and Zhao et al. ran a transfection reporter, Yin et al. did not -- so the
+    label restates the dataset rather than distinguishing anything. On the
+    standalone panels the condition is a real contrast, a withheld reporter
+    against a used one, and the key stays.
     """
     x = LEFT_IN / FIG_W
     fig.text(x, 1 - 0.11 / FIG_H, DISPLAY_NAME[dataset],
              ha="left", va="center", fontsize=7.5, color=INK)
+    if role is not None:
+        return
     fig.add_artist(Line2D(
         [x, x + 0.085 / FIG_W], [1 - 0.245 / FIG_H] * 2,
         color=color, lw=1.6, solid_capstyle="round",
@@ -394,7 +403,7 @@ def plot_overlay(curve, dataset, condition, out_path):
     if role in (None, "middle"):
         ax.set_xlabel("fold change vs minP", color=INK, labelpad=1)
 
-    draw_title(fig, dataset, condition, color)
+    draw_title(fig, dataset, condition, color, role)
     fig.subplots_adjust(
         left=LEFT_IN / FIG_W, right=1 - RIGHT_IN / FIG_W,
         top=1 - TOP_IN / FIG_H, bottom=BOTTOM_IN / FIG_H,

--- a/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/seelig/output/overlay_ct/seelig_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.681475</dc:date>
+    <dc:date>2026-08-16T22:21:42.684425</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -68,7 +68,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
     </g>
@@ -76,7 +76,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
     </g>
@@ -84,7 +84,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
     </g>
@@ -92,12 +92,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 30.24 108.72 
@@ -140,7 +140,7 @@ L 138.36 30.708563
 L 142.44 29.40098 
 L 146.52 28.65659 
 L 150.6 28.248655 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 86.451495 
@@ -173,7 +173,7 @@ L 138.36 28.236817
 L 142.44 27.850205 
 L 146.52 27.663745 
 L 150.6 27.572984 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_5">
     <path d="M 102.348389 38.300196 
@@ -185,9 +185,9 @@ Q 108.543145 40.604135 114.737902 42.908075
    </g>
    <g id="line2d_15">
     <path d="M 117.079142 43.778824 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
     <defs>
-     <path id="ma6d37ea53c" d="M 0 1.6 
+     <path id="mc9b20b4bfc" d="M 0 1.6 
 C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
 C 1.431414 0.831328 1.6 0.424325 1.6 0 
 C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
@@ -199,8 +199,8 @@ C -0.831328 1.431414 -0.424325 1.6 0 1.6
 z
 " style="stroke: #ffffff; stroke-width: 0.8"/>
     </defs>
-    <g clip-path="url(#pdadaa41ff0)">
-     <use xlink:href="#ma6d37ea53c" x="117.079142" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
+    <g clip-path="url(#pab7717bdd3)">
+     <use xlink:href="#mc9b20b4bfc" x="117.079142" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
    <g id="patch_6">
@@ -213,26 +213,18 @@ Q 129.968486 58.781953 124.22955 46.056794
    </g>
    <g id="line2d_16">
     <path d="M 123.202205 43.778824 
-" clip-path="url(#pdadaa41ff0)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
-    <g clip-path="url(#pdadaa41ff0)">
-     <use xlink:href="#ma6d37ea53c" x="123.202205" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
+" clip-path="url(#pab7717bdd3)" style="fill: none; stroke: #d55e00; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#pab7717bdd3)">
+     <use xlink:href="#mc9b20b4bfc" x="123.202205" y="43.778824" style="fill: #d55e00; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
-  </g>
-  <g id="line2d_17">
-   <path d="M 30.24 17.64 
-L 36.36 17.64 
-" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
   </g>
   <g id="text_7">
    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Yin et al.</text>
   </g>
-  <g id="text_8">
-   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">no transfection reporter</text>
-  </g>
  </g>
  <defs>
-  <clipPath id="pdadaa41ff0">
+  <clipPath id="pab7717bdd3">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.563284</dc:date>
+    <dc:date>2026-08-16T22:21:42.555617</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -71,7 +71,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_6">
@@ -82,7 +82,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_7">
@@ -93,7 +93,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_8">
@@ -107,12 +107,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 30.24 108.72 
@@ -155,7 +155,7 @@ L 138.36 88.167807
 L 142.44 84.574643 
 L 146.52 81.087201 
 L 150.6 80.930391 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 107.476167 
@@ -188,7 +188,7 @@ L 138.36 52.291672
 L 142.44 48.713619 
 L 146.52 46.538547 
 L 150.6 44.46779 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_15">
     <path d="M 32.2596 104.115961 
@@ -221,7 +221,7 @@ L 138.36 41.183708
 L 142.44 38.65728 
 L 146.52 37.157476 
 L 150.6 36.062955 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_16">
     <path d="M 32.2596 105.818373 
@@ -254,7 +254,7 @@ L 138.36 48.19357
 L 142.44 44.78455 
 L 146.52 42.125029 
 L 150.6 40.75278 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_17">
     <path d="M 32.2596 107.859037 
@@ -287,7 +287,7 @@ L 138.36 73.553588
 L 142.44 70.432907 
 L 146.52 68.657083 
 L 150.6 63.899346 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_18">
     <path d="M 32.2596 94.977527 
@@ -320,7 +320,7 @@ L 138.36 30.7991
 L 142.44 30.106997 
 L 146.52 29.575337 
 L 150.6 29.104957 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_19">
     <path d="M 32.2596 94.317723 
@@ -353,7 +353,7 @@ L 138.36 30.623537
 L 142.44 29.793864 
 L 146.52 29.562328 
 L 150.6 29.478627 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_20">
     <path d="M 32.2596 106.097376 
@@ -386,7 +386,7 @@ L 138.36 50.222073
 L 142.44 47.500749 
 L 146.52 43.798151 
 L 150.6 41.148021 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_21">
     <path d="M 32.2596 98.191171 
@@ -419,7 +419,7 @@ L 138.36 33.128934
 L 142.44 32.149997 
 L 146.52 31.257106 
 L 150.6 31.107105 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_10">
     <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
@@ -455,7 +455,7 @@ L 138.36 32.220863
 L 142.44 31.595873 
 L 146.52 30.695771 
 L 150.6 30.262599 
-" clip-path="url(#p0e167e066b)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#p48a4742999)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="line2d_23">
@@ -471,7 +471,7 @@ L 36.36 17.64
   </g>
  </g>
  <defs>
-  <clipPath id="p0e167e066b">
+  <clipPath id="p48a4742999">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/shendure/output/overlay_ct/shendure_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.485308</dc:date>
+    <dc:date>2026-08-16T22:21:42.477874</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -68,7 +68,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_5">
@@ -79,7 +79,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_6">
@@ -90,7 +90,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_7">
@@ -104,12 +104,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 30.24 108.72 
@@ -152,7 +152,7 @@ L 138.36 27.918912
 L 142.44 27.674635 
 L 146.52 27.625526 
 L 150.6 27.622533 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 31.471423 
@@ -185,7 +185,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_15">
     <path d="M 32.2596 29.603231 
@@ -218,7 +218,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_16">
     <path d="M 32.2596 30.997847 
@@ -251,7 +251,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.554339 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_17">
     <path d="M 32.2596 40.580963 
@@ -284,7 +284,7 @@ L 138.36 27.563647
 L 142.44 27.563114 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_18">
     <path d="M 32.2596 27.543529 
@@ -317,7 +317,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_19">
     <path d="M 32.2596 27.739924 
@@ -350,7 +350,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_20">
     <path d="M 32.2596 31.415023 
@@ -383,7 +383,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_21">
     <path d="M 32.2596 28.025766 
@@ -416,7 +416,7 @@ L 138.36 27.543529
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_9">
     <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
@@ -452,7 +452,7 @@ L 138.36 27.552865
 L 142.44 27.543529 
 L 146.52 27.543529 
 L 150.6 27.543529 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="patch_5">
     <path d="M 79.598181 38.988716 
@@ -464,9 +464,9 @@ Q 82.575137 40.748753 85.552093 42.50879
    </g>
    <g id="line2d_23">
     <path d="M 87.700249 43.778824 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
     <defs>
-     <path id="m76c2ed5d30" d="M 0 1.6 
+     <path id="m5d2f3c56b1" d="M 0 1.6 
 C 0.424325 1.6 0.831328 1.431414 1.131371 1.131371 
 C 1.431414 0.831328 1.6 0.424325 1.6 0 
 C 1.6 -0.424325 1.431414 -0.831328 1.131371 -1.131371 
@@ -478,8 +478,8 @@ C -0.831328 1.431414 -0.424325 1.6 0 1.6
 z
 " style="stroke: #ffffff; stroke-width: 0.8"/>
     </defs>
-    <g clip-path="url(#p02b69f2398)">
-     <use xlink:href="#m76c2ed5d30" x="87.700249" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
+    <g clip-path="url(#pc4d79ce837)">
+     <use xlink:href="#m5d2f3c56b1" x="87.700249" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
    <g id="patch_6">
@@ -492,26 +492,18 @@ Q 113.515227 62.840033 106.15943 46.066606
    </g>
    <g id="line2d_24">
     <path d="M 105.156149 43.778824 
-" clip-path="url(#p02b69f2398)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
-    <g clip-path="url(#p02b69f2398)">
-     <use xlink:href="#m76c2ed5d30" x="105.156149" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
+" clip-path="url(#pc4d79ce837)" style="fill: none; stroke: #0072b2; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#pc4d79ce837)">
+     <use xlink:href="#m5d2f3c56b1" x="105.156149" y="43.778824" style="fill: #0072b2; stroke: #ffffff; stroke-width: 0.8"/>
     </g>
    </g>
-  </g>
-  <g id="line2d_25">
-   <path d="M 30.24 17.64 
-L 36.36 17.64 
-" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
   </g>
   <g id="text_12">
    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="30.24" y="9.868535" transform="rotate(-0 30.24 9.868535)">Lalanne et al.</text>
   </g>
-  <g id="text_13">
-   <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="38.52" y="19.32873" transform="rotate(-0 38.52 19.32873)">reporter used</text>
-  </g>
  </g>
  <defs>
-  <clipPath id="p02b69f2398">
+  <clipPath id="pc4d79ce837">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_deflated_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.739343</dc:date>
+    <dc:date>2026-08-16T22:21:42.744069</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -71,7 +71,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_6">
@@ -82,7 +82,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_7">
@@ -93,7 +93,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_8">
@@ -107,12 +107,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 30.24 108.72 
@@ -155,7 +155,7 @@ L 138.36 58.165939
 L 142.44 57.360271 
 L 146.52 54.856238 
 L 150.6 53.510183 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 89.813075 
@@ -188,7 +188,7 @@ L 138.36 65.531306
 L 142.44 64.113448 
 L 146.52 61.812826 
 L 150.6 61.190588 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_10">
     <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
@@ -224,7 +224,7 @@ L 138.36 67.846601
 L 142.44 66.985815 
 L 146.52 65.086278 
 L 150.6 63.158129 
-" clip-path="url(#p92be05573a)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#p74ca573b48)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="line2d_16">
@@ -240,7 +240,7 @@ L 36.36 17.64
   </g>
  </g>
  <defs>
-  <clipPath id="p92be05573a">
+  <clipPath id="p74ca573b48">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
+++ b/analyses/simulation/activity_power/takeshi/output/overlay_ct/takeshi_power_reporter_overlay_ct.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T20:37:59.711262</dc:date>
+    <dc:date>2026-08-16T22:21:42.714503</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -71,7 +71,7 @@ z
      <g id="line2d_5">
       <path d="M 30.24 108.72 
 L 152.64 108.72 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_6">
@@ -82,7 +82,7 @@ L 152.64 108.72
      <g id="line2d_7">
       <path d="M 30.24 68.131765 
 L 152.64 68.131765 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_7">
@@ -93,7 +93,7 @@ L 152.64 68.131765
      <g id="line2d_9">
       <path d="M 30.24 27.543529 
 L 152.64 27.543529 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_8">
@@ -107,12 +107,12 @@ L 152.64 27.543529
    <g id="line2d_11">
     <path d="M 71.04 108.72 
 L 71.04 25.92 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
     <path d="M 30.24 43.778824 
 L 152.64 43.778824 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 30.24 108.72 
@@ -155,7 +155,7 @@ L 138.36 40.225859
 L 142.44 39.067182 
 L 146.52 39.021816 
 L 150.6 37.913011 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_14">
     <path d="M 32.2596 63.405034 
@@ -188,7 +188,7 @@ L 138.36 43.269274
 L 142.44 43.211722 
 L 146.52 42.05832 
 L 150.6 42.034879 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_10">
     <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #666666" x="150.64" y="49.337417" transform="rotate(-0 150.64 49.337417)">80%</text>
@@ -224,7 +224,7 @@ L 138.36 43.867541
 L 142.44 43.094853 
 L 146.52 42.442315 
 L 150.6 42.012289 
-" clip-path="url(#pb5df15ee01)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pfe260ce05d)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="line2d_16">
@@ -240,7 +240,7 @@ L 36.36 17.64
   </g>
  </g>
  <defs>
-  <clipPath id="pb5df15ee01">
+  <clipPath id="pfe260ce05d">
    <rect x="30.24" y="25.92" width="122.4" height="82.8"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
Drops the condition key ("reporter used" / "no transfection reporter") from the three panels that form manuscript Fig 3A.

Each of those panels shows its dataset's only empirical regime -- Lalanne et al. and Zhao et al. ran a transfection reporter, Yin et al. did not -- so the label restates the dataset name rather than distinguishing anything. The figure caption already states the conditions.

The key is kept on the standalone panels (`*_deflated_overlay_ct.svg` for Lalanne and Zhao, and both takeshi arms), where the condition is a real contrast: a withheld reporter against a used one, on the same dataset. Those are not manuscript figures.

Implementation is a `role` argument to `draw_title`, keyed off the existing `ROW_ROLE` map that already identifies exactly the three manuscript panels. The curve colour still encodes the condition; only the in-panel key is removed.

Verified: the three manuscript SVGs contain no condition string, and `shendure_power_deflated_overlay_ct.svg` still carries "reporter withheld".
