### PR TITLE
Fig 4 titles: dataset names only

### DIFF
--- a/analyses/simulation/activity_power/main_figs_power_at_fc.py
+++ b/analyses/simulation/activity_power/main_figs_power_at_fc.py
@@ -73,20 +73,20 @@ DATASETS = {
         "reporter": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu.parquet",
         "deflated": SCRIPT_DIR / "output/cohen_power_df_2026-08-13_mwu_deflated.parquet",
         "ref_display": "Rod",
-        "title": "Zhao et al. (episomal, CRE reporter)",
+        "title": "Zhao et al.",
         "n_cell_types": 4,
     },
     "shendure": {
         "reporter": SCRIPT_DIR / "shendure/output/power_df_mwu_2026-08-13.parquet",
         "deflated": SCRIPT_DIR / "shendure/output/power_df_mwu_deflated_2026-08-13.parquet",
         "ref_display": "Pluripotent",
-        "title": "Lalanne et al. (piggyBac, oBC reporter)",
+        "title": "Lalanne et al.",
         "n_cell_types": 10,
     },
     "seelig": {
         "deflated": SCRIPT_DIR / "seelig/output/seelig_power_df_deflated.parquet",
         "ref_display": "HepG2",
-        "title": "Yin et al. (episomal, no reporter)",
+        "title": "Yin et al.",
         "n_cell_types": 2,
     },
 }
@@ -583,7 +583,7 @@ def fig_b_slope_discrete(mpows):
         ax.set_ylim(0, 1.02)
         ax.set_yticks([0, 0.5, 1.0], ["0", "0.5", "1"])
         ax.axhline(0.8, color=MUTED, ls="--", lw=0.7, zorder=1)
-        ax.set_title(DATASETS[name]["title"].split(" (")[0], loc="left", color=INK, pad=4)
+        ax.set_title(DATASETS[name]["title"], loc="left", color=INK, pad=4)
         ax.set_xlabel("fold change", color=INK)
         style_axes(ax, grid_axis="y")
 

--- a/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
+++ b/analyses/simulation/activity_power/output/fig_a_reporter_dumbbell.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:35:04.501253</dc:date>
+    <dc:date>2026-08-16T23:53:31.310027</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 80.64 76.32 
 L 80.64 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
     </g>
@@ -50,7 +50,7 @@ L 80.64 28.8
      <g id="line2d_3">
       <path d="M 120.6 76.32 
 L 120.6 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
     </g>
@@ -58,7 +58,7 @@ L 120.6 28.8
      <g id="line2d_5">
       <path d="M 160.56 76.32 
 L 160.56 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
     </g>
@@ -66,7 +66,7 @@ L 160.56 28.8
      <g id="line2d_7">
       <path d="M 200.52 76.32 
 L 200.52 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
     </g>
@@ -74,7 +74,7 @@ L 200.52 28.8
      <g id="line2d_9">
       <path d="M 240.48 76.32 
 L 240.48 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
     </g>
@@ -95,7 +95,7 @@ L 240.48 28.8
     <g id="ytick_3">
      <g id="line2d_13"/>
      <g id="text_3">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="49.089492" transform="rotate(-0 78.64 49.089492)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="78.64" y="49.089238" transform="rotate(-0 78.64 49.089238)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
@@ -108,21 +108,21 @@ L 240.48 28.8
    <g id="line2d_15">
     <path d="M 208.512 76.32 
 L 208.512 28.8 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 225.547297 70.38 
 L 233.078013 70.38 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 228.174773 58.5 
 L 233.890199 58.5 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 229.134452 46.62 
 L 234.593964 46.62 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 238.987165 34.74 
 L 239.562973 34.74 
-" clip-path="url(#pfc72eab142)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#pa9230b7db0)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
    </g>
    <g id="patch_3">
     <path d="M 80.64 76.32 
@@ -136,7 +136,7 @@ L 240.48 76.32
    </g>
    <g id="PathCollection_1">
     <defs>
-     <path id="m775593de40" d="M 0 2.54951 
+     <path id="m7f35400103" d="M 0 2.54951 
 C 0.676138 2.54951 1.324674 2.280877 1.802776 1.802776 
 C 2.280877 1.324674 2.54951 0.676138 2.54951 0 
 C 2.54951 -0.676138 2.280877 -1.324674 1.802776 -1.802776 
@@ -149,15 +149,15 @@ z
 " style="stroke: #ffffff"/>
     </defs>
     <g>
-     <use xlink:href="#m775593de40" x="225.547297" y="70.38" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="228.174773" y="58.5" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="229.134452" y="46.62" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="238.987165" y="34.74" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="225.547297" y="70.38" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="228.174773" y="58.5" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="229.134452" y="46.62" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="238.987165" y="34.74" style="fill: #d55e00; stroke: #ffffff"/>
     </g>
    </g>
    <g id="PathCollection_2">
     <defs>
-     <path id="mf02a5bacda" d="M 0 2.54951 
+     <path id="m5e56865ea7" d="M 0 2.54951 
 C 0.676138 2.54951 1.324674 2.280877 1.802776 1.802776 
 C 2.280877 1.324674 2.54951 0.676138 2.54951 0 
 C 2.54951 -0.676138 2.280877 -1.324674 1.802776 -1.802776 
@@ -170,14 +170,14 @@ z
 " style="stroke: #ffffff"/>
     </defs>
     <g>
-     <use xlink:href="#mf02a5bacda" x="233.078013" y="70.38" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="233.890199" y="58.5" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="234.593964" y="46.62" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="239.562973" y="34.74" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="233.078013" y="70.38" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="233.890199" y="58.5" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="234.593964" y="46.62" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="239.562973" y="34.74" style="fill: #0072b2; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_5">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="24.8" transform="rotate(-0 80.64 24.8)">Zhao et al. (episomal, CRE reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="24.8" transform="rotate(-0 80.64 24.8)">Zhao et al.</text>
    </g>
   </g>
   <g id="axes_2">
@@ -194,59 +194,59 @@ z
      <g id="line2d_16">
       <path d="M 80.64 216.72 
 L 80.64 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_17"/>
      <g id="text_6">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="80.64" y="223.658984" transform="rotate(-0 80.64 223.658984)">0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="80.64" y="223.658477" transform="rotate(-0 80.64 223.658477)">0</text>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_18">
       <path d="M 120.6 216.72 
 L 120.6 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_19"/>
      <g id="text_7">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="120.6" y="223.658984" transform="rotate(-0 120.6 223.658984)">0.25</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="120.6" y="223.658477" transform="rotate(-0 120.6 223.658477)">0.25</text>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_20">
       <path d="M 160.56 216.72 
 L 160.56 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21"/>
      <g id="text_8">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="223.658984" transform="rotate(-0 160.56 223.658984)">0.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="223.658477" transform="rotate(-0 160.56 223.658477)">0.5</text>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_22">
       <path d="M 200.52 216.72 
 L 200.52 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23"/>
      <g id="text_9">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="200.52" y="223.658984" transform="rotate(-0 200.52 223.658984)">0.75</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="200.52" y="223.658477" transform="rotate(-0 200.52 223.658477)">0.75</text>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_24">
       <path d="M 240.48 216.72 
 L 240.48 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_25"/>
      <g id="text_10">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="240.48" y="223.658984" transform="rotate(-0 240.48 223.658984)">1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="240.48" y="223.658477" transform="rotate(-0 240.48 223.658477)">1</text>
      </g>
     </g>
     <g id="text_11">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="234.709609" transform="rotate(-0 160.56 234.709609)">power at 1.5-fold change</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="160.56" y="234.918828" transform="rotate(-0 160.56 234.918828)">power at 1.5-fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_4">
@@ -314,39 +314,39 @@ L 240.48 97.92
    <g id="line2d_36">
     <path d="M 208.512 216.72 
 L 208.512 97.92 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 86.135547 210.78 
 L 157.711698 210.78 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 88.794499 198.9 
 L 183.103054 198.9 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 94.378073 187.02 
 L 212.653839 187.02 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 96.253714 175.14 
 L 217.830857 175.14 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 95.695148 163.26 
 L 217.877927 163.26 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 100.757027 151.38 
 L 226.584734 151.38 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 110.585693 139.5 
 L 234.957547 139.5 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 112.37081 127.62 
 L 235.314519 127.62 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 116.560522 115.74 
 L 236.400997 115.74 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
     <path d="M 113.7032 103.86 
 L 236.5136 103.86 
-" clip-path="url(#pcfc45feb06)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
+" clip-path="url(#p27d2198da1)" style="fill: none; stroke: #c9c9c9; stroke-width: 1.8"/>
    </g>
    <g id="patch_6">
     <path d="M 80.64 216.72 
@@ -360,63 +360,63 @@ L 240.48 216.72
    </g>
    <g id="PathCollection_3">
     <g>
-     <use xlink:href="#m775593de40" x="86.135547" y="210.78" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="88.794499" y="198.9" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="94.378073" y="187.02" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="96.253714" y="175.14" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="95.695148" y="163.26" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="100.757027" y="151.38" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="110.585693" y="139.5" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="112.37081" y="127.62" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="116.560522" y="115.74" style="fill: #d55e00; stroke: #ffffff"/>
-     <use xlink:href="#m775593de40" x="113.7032" y="103.86" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="86.135547" y="210.78" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="88.794499" y="198.9" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="94.378073" y="187.02" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="96.253714" y="175.14" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="95.695148" y="163.26" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="100.757027" y="151.38" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="110.585693" y="139.5" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="112.37081" y="127.62" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="116.560522" y="115.74" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="113.7032" y="103.86" style="fill: #d55e00; stroke: #ffffff"/>
     </g>
    </g>
    <g id="PathCollection_4">
     <g>
-     <use xlink:href="#mf02a5bacda" x="157.711698" y="210.78" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="183.103054" y="198.9" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="212.653839" y="187.02" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="217.830857" y="175.14" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="217.877927" y="163.26" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="226.584734" y="151.38" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="234.957547" y="139.5" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="235.314519" y="127.62" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="236.400997" y="115.74" style="fill: #0072b2; stroke: #ffffff"/>
-     <use xlink:href="#mf02a5bacda" x="236.5136" y="103.86" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="157.711698" y="210.78" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="183.103054" y="198.9" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="212.653839" y="187.02" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="217.830857" y="175.14" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="217.877927" y="163.26" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="226.584734" y="151.38" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="234.957547" y="139.5" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="235.314519" y="127.62" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="236.400997" y="115.74" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="236.5136" y="103.86" style="fill: #0072b2; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_22">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="211.512" y="212.435625" transform="rotate(-0 211.512 212.435625)">80%</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="211.512" y="212.338594" transform="rotate(-0 211.512 212.338594)">80%</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="93.92" transform="rotate(-0 80.64 93.92)">Lalanne et al. (piggyBac, oBC reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="80.64" y="93.92" transform="rotate(-0 80.64 93.92)">Lalanne et al.</text>
    </g>
   </g>
   <g id="legend_1">
    <g id="PathCollection_5">
     <g>
-     <use xlink:href="#m775593de40" x="118.796559" y="3.475374" style="fill: #d55e00; stroke: #ffffff"/>
+     <use xlink:href="#m7f35400103" x="118.790466" y="3.475374" style="fill: #d55e00; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_24">
-    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="126.271559" y="5.181624" transform="rotate(-0 126.271559 5.181624)">without reporter</text>
+    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="126.265466" y="5.181624" transform="rotate(-0 126.265466 5.181624)">without reporter</text>
    </g>
    <g id="PathCollection_6">
     <g>
-     <use xlink:href="#mf02a5bacda" x="192.292262" y="3.475374" style="fill: #0072b2; stroke: #ffffff"/>
+     <use xlink:href="#m5e56865ea7" x="192.289216" y="3.475374" style="fill: #0072b2; stroke: #ffffff"/>
     </g>
    </g>
    <g id="text_25">
-    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="199.767262" y="5.181624" transform="rotate(-0 199.767262 5.181624)">with reporter</text>
+    <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="199.764216" y="5.181624" transform="rotate(-0 199.764216 5.181624)">with reporter</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfc72eab142">
+  <clipPath id="pa9230b7db0">
    <rect x="80.64" y="28.8" width="159.84" height="47.52"/>
   </clipPath>
-  <clipPath id="pcfc45feb06">
+  <clipPath id="p27d2198da1">
    <rect x="80.64" y="97.92" width="159.84" height="118.8"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
+++ b/analyses/simulation/activity_power/output/fig_b_dataset_bars.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="430.98875pt" height="395.088203pt" viewBox="0 0 430.98875 395.088203" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="426.46625pt" height="395.056133pt" viewBox="0 0 426.46625 395.056133" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:35:04.815506</dc:date>
+    <dc:date>2026-08-16T23:53:31.640268</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,18 +21,18 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 395.088203 
-L 430.98875 395.088203 
-L 430.98875 0 
+   <path d="M 0 395.056133 
+L 426.46625 395.056133 
+L 426.46625 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 83.705234 96.598828 
-L 418.620234 96.598828 
-L 418.620234 18.898828 
+    <path d="M 83.705234 96.478008 
+L 414.097734 96.478008 
+L 414.097734 18.898828 
 L 83.705234 18.898828 
 z
 " style="fill: #ffffff"/>
@@ -40,49 +40,49 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 83.705234 96.598828 
+      <path d="M 83.705234 96.478008 
 L 83.705234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 150.688234 96.598828 
-L 150.688234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 149.783734 96.478008 
+L 149.783734 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 217.671234 96.598828 
-L 217.671234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 215.862234 96.478008 
+L 215.862234 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 284.654234 96.598828 
-L 284.654234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 281.940734 96.478008 
+L 281.940734 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 351.637234 96.598828 
-L 351.637234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 348.019234 96.478008 
+L 348.019234 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 418.620234 96.598828 
-L 418.620234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 414.097734 96.478008 
+L 414.097734 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
     </g>
@@ -91,73 +91,73 @@ L 418.620234 18.898828
     <g id="ytick_1">
      <g id="line2d_13"/>
      <g id="text_1">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="31.581957" transform="rotate(-0 81.705234 31.581957)">Bipolar</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="31.566075" transform="rotate(-0 81.705234 31.566075)">Bipolar</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_14"/>
      <g id="text_2">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="50.672866" transform="rotate(-0 81.705234 50.672866)">Mueller glia</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="50.627298" transform="rotate(-0 81.705234 50.627298)">Mueller glia</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_15"/>
      <g id="text_3">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="69.763775" transform="rotate(-0 81.705234 69.763775)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="69.688268" transform="rotate(-0 81.705234 69.688268)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_16"/>
      <g id="text_4">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="88.854684" transform="rotate(-0 81.705234 88.854684)">Rod</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="88.749745" transform="rotate(-0 81.705234 88.749745)">Rod</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 83.705234 22.430646 
-L 403.110748 22.430646 
-L 403.110748 35.794283 
-L 83.705234 35.794283 
+    <path d="M 83.705234 22.425154 
+L 398.797679 22.425154 
+L 398.797679 35.768011 
+L 83.705234 35.768011 
 z
-" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+" clip-path="url(#p77ab6adb18)" style="fill: #0072b2"/>
    </g>
    <g id="patch_4">
-    <path d="M 83.705234 41.521555 
-L 404.812531 41.521555 
-L 404.812531 54.885192 
-L 83.705234 54.885192 
+    <path d="M 83.705234 41.486378 
+L 400.476483 41.486378 
+L 400.476483 54.829234 
+L 83.705234 54.829234 
 z
-" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+" clip-path="url(#p77ab6adb18)" style="fill: #0072b2"/>
    </g>
    <g id="patch_5">
-    <path d="M 83.705234 60.612464 
-L 406.28714 60.612464 
-L 406.28714 73.976101 
-L 83.705234 73.976101 
+    <path d="M 83.705234 60.547601 
+L 401.931179 60.547601 
+L 401.931179 73.890458 
+L 83.705234 73.890458 
 z
-" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+" clip-path="url(#p77ab6adb18)" style="fill: #0072b2"/>
    </g>
    <g id="patch_6">
-    <path d="M 83.705234 79.703374 
-L 416.698774 79.703374 
-L 416.698774 93.06701 
-L 83.705234 93.06701 
+    <path d="M 83.705234 79.608825 
+L 412.20222 79.608825 
+L 412.20222 92.951681 
+L 83.705234 92.951681 
 z
-" clip-path="url(#p569d85fbd7)" style="fill: #0072b2"/>
+" clip-path="url(#p77ab6adb18)" style="fill: #0072b2"/>
    </g>
    <g id="line2d_17">
-    <path d="M 351.637234 96.598828 
-L 351.637234 18.898828 
-" clip-path="url(#p569d85fbd7)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 348.019234 96.478008 
+L 348.019234 18.898828 
+" clip-path="url(#p77ab6adb18)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_7">
-    <path d="M 83.705234 96.598828 
+    <path d="M 83.705234 96.478008 
 L 83.705234 18.898828 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 83.705234 96.598828 
-L 418.620234 96.598828 
+    <path d="M 83.705234 96.478008 
+L 414.097734 96.478008 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_5">
@@ -166,59 +166,59 @@ L 418.620234 96.598828
   </g>
   <g id="axes_2">
    <g id="patch_9">
-    <path d="M 83.705234 310.168828 
-L 418.620234 310.168828 
-L 418.620234 115.918828 
-L 83.705234 115.918828 
+    <path d="M 83.705234 309.745957 
+L 414.097734 309.745957 
+L 414.097734 115.798008 
+L 83.705234 115.798008 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
-      <path d="M 83.705234 310.168828 
-L 83.705234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 83.705234 309.745957 
+L 83.705234 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_19"/>
     </g>
     <g id="xtick_8">
      <g id="line2d_20">
-      <path d="M 150.688234 310.168828 
-L 150.688234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 149.783734 309.745957 
+L 149.783734 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21"/>
     </g>
     <g id="xtick_9">
      <g id="line2d_22">
-      <path d="M 217.671234 310.168828 
-L 217.671234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 215.862234 309.745957 
+L 215.862234 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23"/>
     </g>
     <g id="xtick_10">
      <g id="line2d_24">
-      <path d="M 284.654234 310.168828 
-L 284.654234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 281.940734 309.745957 
+L 281.940734 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_25"/>
     </g>
     <g id="xtick_11">
      <g id="line2d_26">
-      <path d="M 351.637234 310.168828 
-L 351.637234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 348.019234 309.745957 
+L 348.019234 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_27"/>
     </g>
     <g id="xtick_12">
      <g id="line2d_28">
-      <path d="M 418.620234 310.168828 
-L 418.620234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 414.097734 309.745957 
+L 414.097734 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_29"/>
     </g>
@@ -227,302 +227,302 @@ L 418.620234 115.918828
     <g id="ytick_5">
      <g id="line2d_30"/>
      <g id="text_6">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="133.589703" transform="rotate(-0 81.705234 133.589703)">Cardiomyocytes</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="133.445245" transform="rotate(-0 81.705234 133.445245)">Cardiomyocytes</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_31"/>
      <g id="text_7">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="151.794951" transform="rotate(-0 81.705234 151.794951)">Haematoendothelial</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="151.622185" transform="rotate(-0 81.705234 151.622185)">Haematoendothelial</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_32"/>
      <g id="text_8">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="170.000199" transform="rotate(-0 81.705234 170.000199)">Epiblast/prim. streak</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="169.799125" transform="rotate(-0 81.705234 169.799125)">Epiblast/prim. streak</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33"/>
      <g id="text_9">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="188.205448" transform="rotate(-0 81.705234 188.205448)">Neuroectoderm rostral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="187.976065" transform="rotate(-0 81.705234 187.976065)">Neuroectoderm rostral</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_34"/>
      <g id="text_10">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="206.410696" transform="rotate(-0 81.705234 206.410696)">ExE endoderm visceral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="206.153005" transform="rotate(-0 81.705234 206.153005)">ExE endoderm visceral</text>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_35"/>
      <g id="text_11">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="224.615944" transform="rotate(-0 81.705234 224.615944)">ExE endoderm parietal</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="224.329945" transform="rotate(-0 81.705234 224.329945)">ExE endoderm parietal</text>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_36"/>
      <g id="text_12">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="242.821193" transform="rotate(-0 81.705234 242.821193)">Surface ectoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="242.506885" transform="rotate(-0 81.705234 242.506885)">Surface ectoderm</text>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37"/>
      <g id="text_13">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="261.026441" transform="rotate(-0 81.705234 261.026441)">Pluripotent</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="260.683824" transform="rotate(-0 81.705234 260.683824)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_38"/>
      <g id="text_14">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="279.23169" transform="rotate(-0 81.705234 279.23169)">Neuroectoderm brain</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="278.860764" transform="rotate(-0 81.705234 278.860764)">Neuroectoderm brain</text>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39"/>
      <g id="text_15">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="297.436938" transform="rotate(-0 81.705234 297.436938)">Mesoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="297.037704" transform="rotate(-0 81.705234 297.037704)">Mesoderm</text>
      </g>
     </g>
    </g>
    <g id="patch_10">
-    <path d="M 83.705234 124.748374 
-L 245.194647 124.748374 
-L 245.194647 137.492047 
-L 83.705234 137.492047 
+    <path d="M 83.705234 124.613824 
+L 243.013987 124.613824 
+L 243.013987 137.337682 
+L 83.705234 137.337682 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_11">
-    <path d="M 83.705234 142.953622 
-L 298.397512 142.953622 
-L 298.397512 155.697296 
-L 83.705234 155.697296 
+    <path d="M 83.705234 142.790764 
+L 295.49843 142.790764 
+L 295.49843 155.514622 
+L 83.705234 155.514622 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_12">
-    <path d="M 83.705234 161.15887 
-L 360.315689 161.15887 
-L 360.315689 173.902544 
-L 83.705234 173.902544 
+    <path d="M 83.705234 160.967704 
+L 356.5805 160.967704 
+L 356.5805 173.691562 
+L 83.705234 173.691562 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_13">
-    <path d="M 83.705234 179.364119 
-L 371.163167 179.364119 
-L 371.163167 192.107793 
-L 83.705234 192.107793 
+    <path d="M 83.705234 179.144644 
+L 367.2815 179.144644 
+L 367.2815 191.868501 
+L 83.705234 191.868501 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_14">
-    <path d="M 83.705234 197.569367 
-L 371.261794 197.569367 
-L 371.261794 210.313041 
-L 83.705234 210.313041 
+    <path d="M 83.705234 197.321583 
+L 367.378795 197.321583 
+L 367.378795 210.045441 
+L 83.705234 210.045441 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_15">
-    <path d="M 83.705234 215.774615 
-L 389.505288 215.774615 
-L 389.505288 228.518289 
-L 83.705234 228.518289 
+    <path d="M 83.705234 215.498523 
+L 385.37594 215.498523 
+L 385.37594 228.222381 
+L 83.705234 228.222381 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_16">
-    <path d="M 83.705234 233.979864 
-L 407.048962 233.979864 
-L 407.048962 246.723538 
-L 83.705234 246.723538 
+    <path d="M 83.705234 233.675463 
+L 402.682714 233.675463 
+L 402.682714 246.399321 
+L 83.705234 246.399321 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_17">
-    <path d="M 83.705234 252.185112 
-L 407.79693 252.185112 
-L 407.79693 264.928786 
-L 83.705234 264.928786 
+    <path d="M 83.705234 251.852403 
+L 403.420582 251.852403 
+L 403.420582 264.576261 
+L 83.705234 264.576261 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_18">
-    <path d="M 83.705234 270.39036 
-L 410.073442 270.39036 
-L 410.073442 283.134034 
-L 83.705234 283.134034 
+    <path d="M 83.705234 270.029343 
+L 405.666353 270.029343 
+L 405.666353 282.753201 
+L 83.705234 282.753201 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="patch_19">
-    <path d="M 83.705234 288.595609 
-L 410.309381 288.595609 
-L 410.309381 301.339283 
-L 83.705234 301.339283 
+    <path d="M 83.705234 288.206283 
+L 405.899106 288.206283 
+L 405.899106 300.930141 
+L 83.705234 300.930141 
 z
-" clip-path="url(#p9bbc121112)" style="fill: #0072b2"/>
+" clip-path="url(#p8d967ccd4c)" style="fill: #0072b2"/>
    </g>
    <g id="line2d_40">
-    <path d="M 351.637234 310.168828 
-L 351.637234 115.918828 
-" clip-path="url(#p9bbc121112)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 348.019234 309.745957 
+L 348.019234 115.798008 
+" clip-path="url(#p8d967ccd4c)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_20">
-    <path d="M 83.705234 310.168828 
-L 83.705234 115.918828 
+    <path d="M 83.705234 309.745957 
+L 83.705234 115.798008 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_21">
-    <path d="M 83.705234 310.168828 
-L 418.620234 310.168828 
+    <path d="M 83.705234 309.745957 
+L 414.097734 309.745957 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="109.918828" transform="rotate(-0 83.705234 109.918828)">Lalanne et al., with reporter</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="109.798008" transform="rotate(-0 83.705234 109.798008)">Lalanne et al., with reporter</text>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_22">
-    <path d="M 83.705234 368.338828 
-L 418.620234 368.338828 
-L 418.620234 329.488828 
-L 83.705234 329.488828 
+    <path d="M 83.705234 367.855547 
+L 414.097734 367.855547 
+L 414.097734 329.065957 
+L 83.705234 329.065957 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
-      <path d="M 83.705234 368.338828 
-L 83.705234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 83.705234 367.855547 
+L 83.705234 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_42"/>
      <g id="text_17">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="375.277812" transform="rotate(-0 83.705234 375.277812)">0.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="374.794023" transform="rotate(-0 83.705234 374.794023)">0.0</text>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_43">
-      <path d="M 150.688234 368.338828 
-L 150.688234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 149.783734 367.855547 
+L 149.783734 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_44"/>
      <g id="text_18">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="150.688234" y="375.277812" transform="rotate(-0 150.688234 375.277812)">0.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="149.783734" y="374.794023" transform="rotate(-0 149.783734 374.794023)">0.2</text>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_45">
-      <path d="M 217.671234 368.338828 
-L 217.671234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 215.862234 367.855547 
+L 215.862234 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_46"/>
      <g id="text_19">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="217.671234" y="375.277812" transform="rotate(-0 217.671234 375.277812)">0.4</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="215.862234" y="374.794023" transform="rotate(-0 215.862234 374.794023)">0.4</text>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_47">
-      <path d="M 284.654234 368.338828 
-L 284.654234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 281.940734 367.855547 
+L 281.940734 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_48"/>
      <g id="text_20">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="284.654234" y="375.277812" transform="rotate(-0 284.654234 375.277812)">0.6</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="281.940734" y="374.794023" transform="rotate(-0 281.940734 374.794023)">0.6</text>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_49">
-      <path d="M 351.637234 368.338828 
-L 351.637234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 348.019234 367.855547 
+L 348.019234 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_50"/>
      <g id="text_21">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="351.637234" y="375.277812" transform="rotate(-0 351.637234 375.277812)">0.8</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="348.019234" y="374.794023" transform="rotate(-0 348.019234 374.794023)">0.8</text>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_51">
-      <path d="M 418.620234 368.338828 
-L 418.620234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 414.097734 367.855547 
+L 414.097734 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_52"/>
      <g id="text_22">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="418.620234" y="375.277812" transform="rotate(-0 418.620234 375.277812)">1.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="414.097734" y="374.794023" transform="rotate(-0 414.097734 374.794023)">1.0</text>
      </g>
     </g>
     <g id="text_23">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="251.162734" y="386.328437" transform="rotate(-0 251.162734 386.328437)">power at 1.5-fold change</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="248.901484" y="386.054375" transform="rotate(-0 248.901484 386.054375)">power at 1.5-fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_6">
     <g id="ytick_15">
      <g id="line2d_53"/>
      <g id="text_24">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="340.99562" transform="rotate(-0 81.705234 340.99562)">K562</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="340.558442" transform="rotate(-0 81.705234 340.558442)">K562</text>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_54"/>
      <g id="text_25">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="361.771021" transform="rotate(-0 81.705234 361.771021)">HepG2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="361.301538" transform="rotate(-0 81.705234 361.301538)">HepG2</text>
      </g>
     </g>
    </g>
    <g id="patch_23">
-    <path d="M 83.705234 331.254737 
-L 140.0357 331.254737 
-L 140.0357 345.797518 
-L 83.705234 345.797518 
+    <path d="M 83.705234 330.82912 
+L 139.275046 330.82912 
+L 139.275046 345.349288 
+L 83.705234 345.349288 
 z
-" clip-path="url(#p83578693a3)" style="fill: #d55e00"/>
+" clip-path="url(#p14e7e18e08)" style="fill: #d55e00"/>
    </g>
    <g id="patch_24">
-    <path d="M 83.705234 352.030138 
-L 162.822897 352.030138 
-L 162.822897 366.572919 
-L 83.705234 366.572919 
+    <path d="M 83.705234 351.572216 
+L 161.754538 351.572216 
+L 161.754538 366.092384 
+L 83.705234 366.092384 
 z
-" clip-path="url(#p83578693a3)" style="fill: #d55e00"/>
+" clip-path="url(#p14e7e18e08)" style="fill: #d55e00"/>
    </g>
    <g id="line2d_55">
-    <path d="M 351.637234 368.338828 
-L 351.637234 329.488828 
-" clip-path="url(#p83578693a3)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 348.019234 367.855547 
+L 348.019234 329.065957 
+" clip-path="url(#p14e7e18e08)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_25">
-    <path d="M 83.705234 368.338828 
-L 83.705234 329.488828 
+    <path d="M 83.705234 367.855547 
+L 83.705234 329.065957 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_26">
-    <path d="M 83.705234 368.338828 
-L 418.620234 368.338828 
+    <path d="M 83.705234 367.855547 
+L 414.097734 367.855547 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="323.488828" transform="rotate(-0 83.705234 323.488828)">Yin et al., without reporter</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="323.065957" transform="rotate(-0 83.705234 323.065957)">Yin et al., without reporter</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p569d85fbd7">
-   <rect x="83.705234" y="18.898828" width="334.915" height="77.7"/>
+  <clipPath id="p77ab6adb18">
+   <rect x="83.705234" y="18.898828" width="330.3925" height="77.57918"/>
   </clipPath>
-  <clipPath id="p9bbc121112">
-   <rect x="83.705234" y="115.918828" width="334.915" height="194.25"/>
+  <clipPath id="p8d967ccd4c">
+   <rect x="83.705234" y="115.798008" width="330.3925" height="193.947949"/>
   </clipPath>
-  <clipPath id="p83578693a3">
-   <rect x="83.705234" y="329.488828" width="334.915" height="38.85"/>
+  <clipPath id="p14e7e18e08">
+   <rect x="83.705234" y="329.065957" width="330.3925" height="38.78959"/>
   </clipPath>
  </defs>
 </svg>

--- a/analyses/simulation/activity_power/output/fig_b_slope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_slope.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:35:04.589667</dc:date>
+    <dc:date>2026-08-16T23:53:31.412760</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -65,48 +65,48 @@ z
      <g id="line2d_8">
       <path d="M 28.8 105.12 
 L 192.96 105.12 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_9"/>
      <g id="text_1">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="107.589492" transform="rotate(-0 26.8 107.589492)">0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="107.589238" transform="rotate(-0 26.8 107.589238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
       <path d="M 28.8 62.767059 
 L 192.96 62.767059 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_11"/>
      <g id="text_2">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="65.236551" transform="rotate(-0 26.8 65.236551)">0.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="65.236297" transform="rotate(-0 26.8 65.236297)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
       <path d="M 28.8 20.414118 
 L 192.96 20.414118 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_13"/>
      <g id="text_3">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="22.88361" transform="rotate(-0 26.8 22.88361)">1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="22.883356" transform="rotate(-0 26.8 22.883356)">1</text>
      </g>
     </g>
     <g id="text_4">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.903203" y="61.92" transform="rotate(-90 10.903203 61.92)">power</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.661211" y="61.92" transform="rotate(-90 10.661211 61.92)">power</text>
     </g>
    </g>
    <g id="line2d_14">
     <path d="M 28.8 37.355294 
 L 192.96 37.355294 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="line2d_15">
     <path d="M 165.6 105.12 
 L 165.6 18.72 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="patch_3">
     <path d="M 28.8 105.12 
@@ -139,7 +139,7 @@ L 164.232 28.109619
 L 172.44 28.191384 
 L 180.648 26.873295 
 L 188.856 26.503295 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_17">
     <path d="M 32.7672 100.279664 
@@ -162,7 +162,7 @@ L 164.232 26.429063
 L 172.44 26.340536 
 L 180.648 25.278416 
 L 188.856 25.538673 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_18">
     <path d="M 32.7672 101.104721 
@@ -185,7 +185,7 @@ L 164.232 27.201625
 L 172.44 27.118753 
 L 180.648 24.942947 
 L 188.856 25.960695 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_19">
     <path d="M 32.7672 97.627863 
@@ -208,7 +208,7 @@ L 164.232 23.95737
 L 172.44 24.272606 
 L 180.648 23.757025 
 L 188.856 24.152028 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_20">
     <path d="M 32.7672 99.014576 
@@ -231,7 +231,7 @@ L 164.232 23.669914
 L 172.44 23.886161 
 L 180.648 23.041957 
 L 188.856 23.609429 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_21">
     <path d="M 32.7672 98.904568 
@@ -254,16 +254,16 @@ L 164.232 24.111378
 L 172.44 23.826298 
 L 180.648 23.265603 
 L 188.856 23.307984 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_5">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="22.73292" transform="rotate(-0 192.856 22.73292)">Rod</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="22.636123" transform="rotate(-0 192.856 22.636123)">Rod</text>
    </g>
    <g id="text_6">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="167.6" y="16.472188" transform="rotate(-0 167.6 16.472188)">1.5x</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="167.6" y="16.278594" transform="rotate(-0 167.6 16.278594)">1.5x</text>
    </g>
    <g id="text_7">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="14.72" transform="rotate(-0 28.8 14.72)">Zhao et al. (episomal, CRE reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="14.72" transform="rotate(-0 28.8 14.72)">Zhao et al.</text>
    </g>
    <g id="line2d_22">
     <path d="M 32.7672 82.733445 
@@ -286,7 +286,7 @@ L 164.232 21.186679
 L 172.44 21.192334 
 L 180.648 21.196878 
 L 188.856 21.37874 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="line2d_23">
     <path d="M 32.7672 68.762475 
@@ -309,7 +309,7 @@ L 164.232 20.910765
 L 172.44 20.833157 
 L 180.648 20.861409 
 L 188.856 21.077295 
-" clip-path="url(#p93484b0ab7)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pb10a360899)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
   </g>
   <g id="axes_2">
@@ -325,47 +325,47 @@ z
     <g id="xtick_8">
      <g id="line2d_24"/>
      <g id="text_8">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="28.8" y="220.058984" transform="rotate(-0 28.8 220.058984)">1.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="28.8" y="220.058477" transform="rotate(-0 28.8 220.058477)">1.0</text>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_25"/>
      <g id="text_9">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="56.16" y="220.058984" transform="rotate(-0 56.16 220.058984)">1.1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="56.16" y="220.058477" transform="rotate(-0 56.16 220.058477)">1.1</text>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_26"/>
      <g id="text_10">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.52" y="220.058984" transform="rotate(-0 83.52 220.058984)">1.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.52" y="220.058477" transform="rotate(-0 83.52 220.058477)">1.2</text>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_27"/>
      <g id="text_11">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="220.058984" transform="rotate(-0 110.88 220.058984)">1.3</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="220.058477" transform="rotate(-0 110.88 220.058477)">1.3</text>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_28"/>
      <g id="text_12">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="138.24" y="220.058984" transform="rotate(-0 138.24 220.058984)">1.4</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="138.24" y="220.058477" transform="rotate(-0 138.24 220.058477)">1.4</text>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_29"/>
      <g id="text_13">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="165.6" y="220.058984" transform="rotate(-0 165.6 220.058984)">1.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="165.6" y="220.058477" transform="rotate(-0 165.6 220.058477)">1.5</text>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_30"/>
      <g id="text_14">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="192.96" y="220.058984" transform="rotate(-0 192.96 220.058984)">1.6</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="192.96" y="220.058477" transform="rotate(-0 192.96 220.058477)">1.6</text>
      </g>
     </g>
     <g id="text_15">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="231.109609" transform="rotate(-0 110.88 231.109609)">fold change</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="110.88" y="231.318828" transform="rotate(-0 110.88 231.318828)">fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_4">
@@ -373,48 +373,48 @@ z
      <g id="line2d_31">
       <path d="M 28.8 213.12 
 L 192.96 213.12 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_32"/>
      <g id="text_16">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="215.589492" transform="rotate(-0 26.8 215.589492)">0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="215.589238" transform="rotate(-0 26.8 215.589238)">0</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_33">
       <path d="M 28.8 170.767059 
 L 192.96 170.767059 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_34"/>
      <g id="text_17">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="173.236551" transform="rotate(-0 26.8 173.236551)">0.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="173.236297" transform="rotate(-0 26.8 173.236297)">0.5</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_35">
       <path d="M 28.8 128.414118 
 L 192.96 128.414118 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_36"/>
      <g id="text_18">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="130.88361" transform="rotate(-0 26.8 130.88361)">1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="26.8" y="130.883356" transform="rotate(-0 26.8 130.883356)">1</text>
      </g>
     </g>
     <g id="text_19">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.903203" y="169.92" transform="rotate(-90 10.903203 169.92)">power</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="10.661211" y="169.92" transform="rotate(-90 10.661211 169.92)">power</text>
     </g>
    </g>
    <g id="line2d_37">
     <path d="M 28.8 145.355294 
 L 192.96 145.355294 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="line2d_38">
     <path d="M 165.6 213.12 
 L 165.6 126.72 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
     <path d="M 28.8 213.12 
@@ -447,7 +447,7 @@ L 164.232 211.256471
 L 172.44 209.621279 
 L 180.648 209.693695 
 L 188.856 208.312369 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_40">
     <path d="M 32.7672 211.727575 
@@ -470,7 +470,7 @@ L 164.232 206.16598
 L 172.44 205.507665 
 L 180.648 203.632941 
 L 188.856 204.464464 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_41">
     <path d="M 32.7672 211.467202 
@@ -493,7 +493,7 @@ L 164.232 204.04437
 L 172.44 200.832194 
 L 180.648 200.691193 
 L 188.856 199.69359 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_42">
     <path d="M 32.7672 211.849412 
@@ -516,7 +516,7 @@ L 164.232 206.424685
 L 172.44 203.510093 
 L 180.648 204.240487 
 L 188.856 201.060179 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_43">
     <path d="M 32.7672 211.841421 
@@ -539,7 +539,7 @@ L 164.232 210.139608
 L 172.44 209.914913 
 L 180.648 206.767059 
 L 188.856 208.513189 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_44">
     <path d="M 32.7672 210.159406 
@@ -562,7 +562,7 @@ L 164.232 197.283683
 L 172.44 194.45181 
 L 180.648 192.046829 
 L 188.856 190.720788 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_45">
     <path d="M 32.7672 210.991711 
@@ -585,7 +585,7 @@ L 164.232 192.518167
 L 172.44 193.327338 
 L 180.648 190.559311 
 L 188.856 189.495607 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_46">
     <path d="M 32.7672 210.861176 
@@ -608,7 +608,7 @@ L 164.232 205.768169
 L 172.44 205.060605 
 L 180.648 203.270479 
 L 188.856 201.878659 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_47">
     <path d="M 32.7672 210.42236 
@@ -631,7 +631,7 @@ L 164.232 197.934921
 L 172.44 195.312513 
 L 180.648 195.69479 
 L 188.856 193.534825 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_48">
     <path d="M 32.7672 211.066524 
@@ -654,7 +654,7 @@ L 164.232 170.936471
 L 172.44 172.608491 
 L 180.648 164.771024 
 L 188.856 161.151797 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_49">
     <path d="M 32.7672 208.633296 
@@ -677,7 +677,7 @@ L 164.232 144.319589
 L 172.44 139.459466 
 L 180.648 137.825882 
 L 188.856 138.031379 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_50">
     <path d="M 32.7672 207.583128 
@@ -700,7 +700,7 @@ L 164.232 135.847491
 L 172.44 134.30354 
 L 180.648 133.084816 
 L 188.856 131.507113 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_51">
     <path d="M 32.7672 210.049412 
@@ -723,7 +723,7 @@ L 164.232 139.775865
 L 172.44 135.250031 
 L 180.648 137.176795 
 L 188.856 134.348315 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_52">
     <path d="M 32.7672 209.603907 
@@ -746,7 +746,7 @@ L 164.232 162.923922
 L 172.44 157.565151 
 L 180.648 152.848507 
 L 188.856 149.219071 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_53">
     <path d="M 32.7672 209.25478 
@@ -769,7 +769,7 @@ L 164.232 130.25555
 L 172.44 129.812176 
 L 180.648 129.736356 
 L 188.856 129.335604 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_54">
     <path d="M 32.7672 208.437765 
@@ -792,7 +792,7 @@ L 164.232 131.393722
 L 172.44 129.83986 
 L 180.648 129.818996 
 L 188.856 128.9581 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_55">
     <path d="M 32.7672 209.893109 
@@ -815,7 +815,7 @@ L 164.232 139.12222
 L 172.44 138.118287 
 L 180.648 136.490725 
 L 188.856 134.588939 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="line2d_56">
     <path d="M 32.7672 209.019588 
@@ -838,24 +838,24 @@ L 164.232 130.996614
 L 172.44 130.050481 
 L 180.648 129.963025 
 L 188.856 130.176783 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
    <g id="text_20">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="131.119196" transform="rotate(-0 192.856 131.119196)">Pluripotent</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="192.856" y="131.022399" transform="rotate(-0 192.856 131.022399)">Pluripotent</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="30.8" y="142.107482" transform="rotate(-0 30.8 142.107482)">80%</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #666666" x="30.8" y="141.913888" transform="rotate(-0 30.8 141.913888)">80%</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 159.334101)">with</text>
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 166.280742)">reporter</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 159.681328)">with</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 166.384453)">reporter</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 206.695494)">without</text>
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 213.642134)">reporter</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 207.000064)">without</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #1a1a1a" transform="translate(207.1872 213.745845)">reporter</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="122.72" transform="rotate(-0 28.8 122.72)">Lalanne et al. (piggyBac, oBC reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="28.8" y="122.72" transform="rotate(-0 28.8 122.72)">Lalanne et al.</text>
    </g>
    <g id="line2d_57">
     <path d="M 32.7672 211.13526 
@@ -878,7 +878,7 @@ L 164.232 195.753522
 L 172.44 194.671346 
 L 180.648 193.412917 
 L 188.856 191.081478 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #d55e00; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="line2d_58">
     <path d="M 32.7672 210.142889 
@@ -901,7 +901,7 @@ L 164.232 130.682392
 L 172.44 130.352303 
 L 180.648 129.797071 
 L 188.856 129.463571 
-" clip-path="url(#p20b52322a5)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
+" clip-path="url(#pab20210e35)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: round"/>
    </g>
    <g id="line2d_59">
     <path d="M 196.2432 161.151797 
@@ -916,10 +916,10 @@ L 204.4512 208.513189
   </g>
  </g>
  <defs>
-  <clipPath id="p93484b0ab7">
+  <clipPath id="pb10a360899">
    <rect x="28.8" y="18.72" width="164.16" height="86.4"/>
   </clipPath>
-  <clipPath id="p20b52322a5">
+  <clipPath id="pab20210e35">
    <rect x="28.8" y="126.72" width="164.16" height="86.4"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_slope_discrete.svg
+++ b/analyses/simulation/activity_power/output/fig_b_slope_discrete.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:35:04.760458</dc:date>
+    <dc:date>2026-08-16T23:53:31.584676</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -41,23 +41,23 @@ z
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="36.298803" y="110.906984" transform="rotate(-0 36.298803 110.906984)">1.1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="36.298803" y="110.906477" transform="rotate(-0 36.298803 110.906477)">1.1</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="64.681214" y="110.906984" transform="rotate(-0 64.681214 110.906984)">1.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="64.681214" y="110.906477" transform="rotate(-0 64.681214 110.906477)">1.2</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="93.063626" y="110.906984" transform="rotate(-0 93.063626 110.906984)">1.3</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="93.063626" y="110.906477" transform="rotate(-0 93.063626 110.906477)">1.3</text>
      </g>
     </g>
     <g id="text_4">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="67.519455" y="121.957609" transform="rotate(-0 67.519455 121.957609)">fold change</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="67.519455" y="122.166828" transform="rotate(-0 67.519455 122.166828)">fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
@@ -65,43 +65,43 @@ z
      <g id="line2d_4">
       <path d="M 29.2032 103.968 
 L 105.835711 103.968 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_5"/>
      <g id="text_5">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="106.437492" transform="rotate(-0 27.2032 106.437492)">0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="106.437238" transform="rotate(-0 27.2032 106.437238)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_6">
       <path d="M 29.2032 63.732706 
 L 105.835711 63.732706 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_7"/>
      <g id="text_6">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="66.202198" transform="rotate(-0 27.2032 66.202198)">0.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="66.201944" transform="rotate(-0 27.2032 66.201944)">0.5</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_8">
       <path d="M 29.2032 23.497412 
 L 105.835711 23.497412 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_9"/>
      <g id="text_7">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="25.966904" transform="rotate(-0 27.2032 25.966904)">1</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="27.2032" y="25.96665" transform="rotate(-0 27.2032 25.96665)">1</text>
      </g>
     </g>
     <g id="text_8">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="11.306403" y="62.928" transform="rotate(-90 11.306403 62.928)">power</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="11.064411" y="62.928" transform="rotate(-90 11.064411 62.928)">power</text>
     </g>
    </g>
    <g id="line2d_10">
     <path d="M 29.2032 39.591529 
 L 105.835711 39.591529 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_3">
     <path d="M 29.2032 103.968 
@@ -117,9 +117,9 @@ L 105.835711 103.968
     <path d="M 36.298803 57.065956 
 L 64.681214 37.658187 
 L 93.063626 31.314555 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
     <defs>
-     <path id="maa2de6941a" d="M 0 1.25 
+     <path id="ma356297190" d="M 0 1.25 
 C 0.331504 1.25 0.649475 1.118292 0.883883 0.883883 
 C 1.118292 0.649475 1.25 0.331504 1.25 0 
 C 1.25 -0.331504 1.118292 -0.649475 0.883883 -0.883883 
@@ -131,36 +131,36 @@ C -0.649475 1.118292 -0.331504 1.25 0 1.25
 z
 " style="stroke: #0072b2; stroke-opacity: 0.45"/>
     </defs>
-    <g clip-path="url(#paac861e7da)">
-     <use xlink:href="#maa2de6941a" x="36.298803" y="57.065956" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="64.681214" y="37.658187" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="93.063626" y="31.314555" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+    <g clip-path="url(#p4cd60f419a)">
+     <use xlink:href="#ma356297190" x="36.298803" y="57.065956" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="64.681214" y="37.658187" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="93.063626" y="31.314555" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_12">
     <path d="M 36.298803 50.480801 
 L 64.681214 32.869794 
 L 93.063626 28.914163 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#paac861e7da)">
-     <use xlink:href="#maa2de6941a" x="36.298803" y="50.480801" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="64.681214" y="32.869794" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="93.063626" y="28.914163" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p4cd60f419a)">
+     <use xlink:href="#ma356297190" x="36.298803" y="50.480801" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="64.681214" y="32.869794" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="93.063626" y="28.914163" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_13">
     <path d="M 36.298803 56.912806 
 L 64.681214 36.814058 
 L 93.063626 30.151248 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#paac861e7da)">
-     <use xlink:href="#maa2de6941a" x="36.298803" y="56.912806" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="64.681214" y="36.814058" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="93.063626" y="30.151248" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p4cd60f419a)">
+     <use xlink:href="#ma356297190" x="36.298803" y="56.912806" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="64.681214" y="36.814058" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="93.063626" y="30.151248" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="text_9">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="96.063626" y="26.149911" transform="rotate(-0 96.063626 26.149911)">Rod</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="96.063626" y="26.053114" transform="rotate(-0 96.063626 26.053114)">Rod</text>
    </g>
    <g id="text_10">
     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="29.2032" y="17.888" transform="rotate(-0 29.2032 17.888)">Zhao et al.</text>
@@ -169,9 +169,9 @@ L 93.063626 30.151248
     <path d="M 36.298803 27.630257 
 L 64.681214 25.29833 
 L 93.063626 24.494286 
-" clip-path="url(#paac861e7da)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
+" clip-path="url(#p4cd60f419a)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
     <defs>
-     <path id="maf6df414e7" d="M 0 1.75 
+     <path id="md935411636" d="M 0 1.75 
 C 0.464105 1.75 0.909265 1.565609 1.237437 1.237437 
 C 1.565609 0.909265 1.75 0.464105 1.75 0 
 C 1.75 -0.464105 1.565609 -0.909265 1.237437 -1.237437 
@@ -183,10 +183,10 @@ C -0.909265 1.565609 -0.464105 1.75 0 1.75
 z
 " style="stroke: #0072b2"/>
     </defs>
-    <g clip-path="url(#paac861e7da)">
-     <use xlink:href="#maf6df414e7" x="36.298803" y="27.630257" style="fill: #0072b2; stroke: #0072b2"/>
-     <use xlink:href="#maf6df414e7" x="64.681214" y="25.29833" style="fill: #0072b2; stroke: #0072b2"/>
-     <use xlink:href="#maf6df414e7" x="93.063626" y="24.494286" style="fill: #0072b2; stroke: #0072b2"/>
+    <g clip-path="url(#p4cd60f419a)">
+     <use xlink:href="#md935411636" x="36.298803" y="27.630257" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#md935411636" x="64.681214" y="25.29833" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#md935411636" x="93.063626" y="24.494286" style="fill: #0072b2; stroke: #0072b2"/>
     </g>
    </g>
   </g>
@@ -203,23 +203,23 @@ z
     <g id="xtick_4">
      <g id="line2d_15"/>
      <g id="text_11">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="139.752692" y="110.906984" transform="rotate(-0 139.752692 110.906984)">1.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="139.752692" y="110.906477" transform="rotate(-0 139.752692 110.906477)">1.2</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_16"/>
      <g id="text_12">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="168.135104" y="110.906984" transform="rotate(-0 168.135104 110.906984)">1.5</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="168.135104" y="110.906477" transform="rotate(-0 168.135104 110.906477)">1.5</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_17"/>
      <g id="text_13">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="196.517515" y="110.906984" transform="rotate(-0 196.517515 110.906984)">2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="196.517515" y="110.906477" transform="rotate(-0 196.517515 110.906477)">2</text>
      </g>
     </g>
     <g id="text_14">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="170.973345" y="121.957609" transform="rotate(-0 170.973345 121.957609)">fold change</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="170.973345" y="122.166828" transform="rotate(-0 170.973345 122.166828)">fold change</text>
     </g>
    </g>
    <g id="matplotlib.axis_4">
@@ -227,7 +227,7 @@ z
      <g id="line2d_18">
       <path d="M 132.657089 103.968 
 L 209.2896 103.968 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_19"/>
     </g>
@@ -235,7 +235,7 @@ L 209.2896 103.968
      <g id="line2d_20">
       <path d="M 132.657089 63.732706 
 L 209.2896 63.732706 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21"/>
     </g>
@@ -243,7 +243,7 @@ L 209.2896 63.732706
      <g id="line2d_22">
       <path d="M 132.657089 23.497412 
 L 209.2896 23.497412 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23"/>
     </g>
@@ -251,7 +251,7 @@ L 209.2896 23.497412
    <g id="line2d_24">
     <path d="M 132.657089 39.591529 
 L 209.2896 39.591529 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_6">
     <path d="M 132.657089 103.968 
@@ -267,103 +267,103 @@ L 209.2896 103.968
     <path d="M 139.752692 92.900654 
 L 168.135104 65.166668 
 L 196.517515 30.59382 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="92.900654" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="65.166668" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="30.59382" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="92.900654" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="65.166668" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="30.59382" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_26">
     <path d="M 139.752692 84.297412 
 L 168.135104 37.506343 
 L 196.517515 24.139038 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="84.297412" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="37.506343" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="24.139038" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="84.297412" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="37.506343" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="24.139038" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_27">
     <path d="M 139.752692 76.934753 
 L 168.135104 30.492909 
 L 196.517515 23.588403 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="76.934753" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="30.492909" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="23.588403" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="76.934753" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="30.492909" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="23.588403" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_28">
     <path d="M 139.752692 80.683907 
 L 168.135104 34.876304 
 L 196.517515 24.078808 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="80.683907" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="34.876304" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="24.078808" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="80.683907" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="34.876304" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="24.078808" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_29">
     <path d="M 139.752692 90.310148 
 L 168.135104 52.383527 
 L 196.517515 26.495768 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="90.310148" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="52.383527" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="26.495768" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="90.310148" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="52.383527" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="26.495768" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_30">
     <path d="M 139.752692 64.356137 
 L 168.135104 25.494275 
 L 196.517515 23.520619 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="64.356137" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="25.494275" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="23.520619" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="64.356137" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="25.494275" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="23.520619" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_31">
     <path d="M 139.752692 62.193865 
 L 168.135104 25.550964 
 L 196.517515 23.519937 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="62.193865" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="25.550964" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="23.519937" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="62.193865" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="25.550964" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="23.519937" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_32">
     <path d="M 139.752692 79.980834 
 L 168.135104 34.900001 
 L 196.517515 24.086774 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="79.980834" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="34.900001" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="24.086774" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="79.980834" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="34.900001" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="24.086774" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="line2d_33">
     <path d="M 139.752692 65.719634 
 L 168.135104 26.277661 
 L 196.517515 23.64306 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maa2de6941a" x="139.752692" y="65.719634" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="168.135104" y="26.277661" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
-     <use xlink:href="#maa2de6941a" x="196.517515" y="23.64306" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-opacity: 0.45; stroke-width: 0.8; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#ma356297190" x="139.752692" y="65.719634" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="168.135104" y="26.277661" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
+     <use xlink:href="#ma356297190" x="196.517515" y="23.64306" style="fill: #0072b2; fill-opacity: 0.45; stroke: #0072b2; stroke-opacity: 0.45"/>
     </g>
    </g>
    <g id="text_15">
-    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="199.517515" y="25.231258" transform="rotate(-0 199.517515 25.231258)">Pluripotent</text>
+    <text style="font-size: 6px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="199.517515" y="25.134462" transform="rotate(-0 199.517515 25.134462)">Pluripotent</text>
    </g>
    <g id="text_16">
     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1a1a1a" x="132.657089" y="17.888" transform="rotate(-0 132.657089 17.888)">Lalanne et al.</text>
@@ -372,20 +372,20 @@ L 196.517515 23.64306
     <path d="M 139.752692 67.679678 
 L 168.135104 26.097945 
 L 196.517515 23.575633 
-" clip-path="url(#p8fe9f60d45)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
-    <g clip-path="url(#p8fe9f60d45)">
-     <use xlink:href="#maf6df414e7" x="139.752692" y="67.679678" style="fill: #0072b2; stroke: #0072b2"/>
-     <use xlink:href="#maf6df414e7" x="168.135104" y="26.097945" style="fill: #0072b2; stroke: #0072b2"/>
-     <use xlink:href="#maf6df414e7" x="196.517515" y="23.575633" style="fill: #0072b2; stroke: #0072b2"/>
+" clip-path="url(#p5960ae255d)" style="fill: none; stroke: #0072b2; stroke-width: 1.6; stroke-linecap: square"/>
+    <g clip-path="url(#p5960ae255d)">
+     <use xlink:href="#md935411636" x="139.752692" y="67.679678" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#md935411636" x="168.135104" y="26.097945" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#md935411636" x="196.517515" y="23.575633" style="fill: #0072b2; stroke: #0072b2"/>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="paac861e7da">
+  <clipPath id="p4cd60f419a">
    <rect x="29.2032" y="21.888" width="76.632511" height="82.08"/>
   </clipPath>
-  <clipPath id="p8fe9f60d45">
+  <clipPath id="p5960ae255d">
    <rect x="132.657089" y="21.888" width="76.632511" height="82.08"/>
   </clipPath>
  </defs>

--- a/analyses/simulation/activity_power/output/fig_b_telescope.svg
+++ b/analyses/simulation/activity_power/output/fig_b_telescope.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="466.98875pt" height="431.088203pt" viewBox="0 0 466.98875 431.088203" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="462.46625pt" height="431.117305pt" viewBox="0 0 462.46625 431.117305" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-16T17:35:04.890827</dc:date>
+    <dc:date>2026-08-16T23:53:31.714076</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,18 +21,18 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 431.088203 
-L 466.98875 431.088203 
-L 466.98875 0 
+   <path d="M 0 431.117305 
+L 462.46625 431.117305 
+L 462.46625 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 83.705234 105.598828 
-L 454.620234 105.598828 
-L 454.620234 18.898828 
+    <path d="M 83.705234 105.493447 
+L 450.097734 105.493447 
+L 450.097734 18.898828 
 L 83.705234 18.898828 
 z
 " style="fill: #ffffff"/>
@@ -40,49 +40,49 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 83.705234 105.598828 
+      <path d="M 83.705234 105.493447 
 L 83.705234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 157.888234 105.598828 
-L 157.888234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 156.983734 105.493447 
+L 156.983734 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 232.071234 105.598828 
-L 232.071234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 230.262234 105.493447 
+L 230.262234 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 306.254234 105.598828 
-L 306.254234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 303.540734 105.493447 
+L 303.540734 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 380.437234 105.598828 
-L 380.437234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 376.819234 105.493447 
+L 376.819234 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 454.620234 105.598828 
-L 454.620234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 450.097734 105.493447 
+L 450.097734 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
     </g>
@@ -91,233 +91,233 @@ L 454.620234 18.898828
     <g id="ytick_1">
      <g id="line2d_13"/>
      <g id="text_1">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="33.191048" transform="rotate(-0 81.705234 33.191048)">Bipolar</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="33.176677" transform="rotate(-0 81.705234 33.176677)">Bipolar</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_14"/>
      <g id="text_2">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="54.209229" transform="rotate(-0 81.705234 54.209229)">Mueller glia</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="54.169312" transform="rotate(-0 81.705234 54.169312)">Mueller glia</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_15"/>
      <g id="text_3">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="75.227411" transform="rotate(-0 81.705234 75.227411)">Interneuron</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="75.161693" transform="rotate(-0 81.705234 75.161693)">Interneuron</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_16"/>
      <g id="text_4">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="96.245593" transform="rotate(-0 81.705234 96.245593)">Rod</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="96.154582" transform="rotate(-0 81.705234 96.154582)">Rod</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 83.705234 22.839737 
-L 418.588492 22.839737 
-L 418.588492 38.603374 
-L 83.705234 38.603374 
+    <path d="M 83.705234 22.834947 
+L 414.50532 22.834947 
+L 414.50532 38.579423 
+L 83.705234 38.579423 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_4">
-    <path d="M 83.705234 43.857919 
-L 423.950546 43.857919 
-L 423.950546 59.621555 
-L 83.705234 59.621555 
+    <path d="M 83.705234 43.827582 
+L 419.801996 43.827582 
+L 419.801996 59.572058 
+L 83.705234 59.572058 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_5">
-    <path d="M 83.705234 64.876101 
-L 429.652672 64.876101 
-L 429.652672 80.639737 
-L 83.705234 80.639737 
+    <path d="M 83.705234 64.820217 
+L 425.434597 64.820217 
+L 425.434597 80.564693 
+L 83.705234 80.564693 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_6">
-    <path d="M 83.705234 85.894283 
-L 450.025317 85.894283 
-L 450.025317 101.657919 
-L 83.705234 101.657919 
+    <path d="M 83.705234 85.812852 
+L 445.558842 85.812852 
+L 445.558842 101.557328 
+L 83.705234 101.557328 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #b2d5e8"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_7">
-    <path d="M 83.705234 22.839737 
-L 389.348637 22.839737 
-L 389.348637 38.603374 
-L 83.705234 38.603374 
+    <path d="M 83.705234 22.834947 
+L 385.621982 22.834947 
+L 385.621982 38.579423 
+L 83.705234 38.579423 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #66aad1"/>
    </g>
    <g id="patch_8">
-    <path d="M 83.705234 43.857919 
-L 393.239502 43.857919 
-L 393.239502 59.621555 
-L 83.705234 59.621555 
+    <path d="M 83.705234 43.827582 
+L 389.465406 43.827582 
+L 389.465406 59.572058 
+L 83.705234 59.572058 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #66aad1"/>
    </g>
    <g id="patch_9">
-    <path d="M 83.705234 64.876101 
-L 411.41989 64.876101 
-L 411.41989 80.639737 
-L 83.705234 80.639737 
+    <path d="M 83.705234 64.820217 
+L 407.424124 64.820217 
+L 407.424124 80.564693 
+L 83.705234 80.564693 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #66aad1"/>
    </g>
    <g id="patch_10">
-    <path d="M 83.705234 85.894283 
-L 446.319221 85.894283 
-L 446.319221 101.657919 
-L 83.705234 101.657919 
+    <path d="M 83.705234 85.812852 
+L 441.897934 85.812852 
+L 441.897934 101.557328 
+L 83.705234 101.557328 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #66aad1"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #66aad1"/>
    </g>
    <g id="patch_11">
-    <path d="M 83.705234 22.839737 
-L 299.891943 22.839737 
-L 299.891943 38.603374 
-L 83.705234 38.603374 
+    <path d="M 83.705234 22.834947 
+L 297.256018 22.834947 
+L 297.256018 38.579423 
+L 83.705234 38.579423 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #1980ba"/>
    </g>
    <g id="patch_12">
-    <path d="M 83.705234 43.857919 
-L 300.597862 43.857919 
-L 300.597862 59.621555 
-L 83.705234 59.621555 
+    <path d="M 83.705234 43.827582 
+L 297.953329 43.827582 
+L 297.953329 59.572058 
+L 83.705234 59.572058 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #1980ba"/>
    </g>
    <g id="patch_13">
-    <path d="M 83.705234 64.876101 
-L 330.245056 64.876101 
-L 330.245056 80.639737 
-L 83.705234 80.639737 
+    <path d="M 83.705234 64.820217 
+L 327.23904 64.820217 
+L 327.23904 80.564693 
+L 83.705234 80.564693 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #1980ba"/>
    </g>
    <g id="patch_14">
-    <path d="M 83.705234 85.894283 
-L 435.570612 85.894283 
-L 435.570612 101.657919 
-L 83.705234 101.657919 
+    <path d="M 83.705234 85.812852 
+L 431.280381 85.812852 
+L 431.280381 101.557328 
+L 83.705234 101.557328 
 z
-" clip-path="url(#ped2729ea74)" style="fill: #1980ba"/>
+" clip-path="url(#p93c34e9e88)" style="fill: #1980ba"/>
    </g>
    <g id="line2d_17">
-    <path d="M 380.437234 105.598828 
-L 380.437234 18.898828 
-" clip-path="url(#ped2729ea74)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 376.819234 105.493447 
+L 376.819234 18.898828 
+" clip-path="url(#p93c34e9e88)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_15">
-    <path d="M 83.705234 105.598828 
+    <path d="M 83.705234 105.493447 
 L 83.705234 18.898828 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_16">
-    <path d="M 83.705234 105.598828 
-L 454.620234 105.598828 
+    <path d="M 83.705234 105.493447 
+L 450.097734 105.493447 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_5">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="12.898828" transform="rotate(-0 83.705234 12.898828)">Zhao et al. (episomal, CRE reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="12.898828" transform="rotate(-0 83.705234 12.898828)">Zhao et al.</text>
    </g>
    <g id="legend_1">
     <g id="patch_17">
-     <path d="M 334.986719 98.397031 
-L 342.786719 98.397031 
-L 342.786719 93.847031 
-L 334.986719 93.847031 
+     <path d="M 330.464219 98.081924 
+L 338.264219 98.081924 
+L 338.264219 93.531924 
+L 330.464219 93.531924 
 z
 " style="fill: #b2d5e8"/>
     </g>
     <g id="text_6">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="98.397031" transform="rotate(-0 345.386719 98.397031)">FC=1.3</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="340.864219" y="98.081924" transform="rotate(-0 340.864219 98.081924)">FC=1.3</text>
     </g>
     <g id="patch_18">
-     <path d="M 374.647891 98.397031 
-L 382.447891 98.397031 
-L 382.447891 93.847031 
-L 374.647891 93.847031 
+     <path d="M 370.125391 98.081924 
+L 377.925391 98.081924 
+L 377.925391 93.531924 
+L 370.125391 93.531924 
 z
 " style="fill: #66aad1"/>
     </g>
     <g id="text_7">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="98.397031" transform="rotate(-0 385.047891 98.397031)">FC=1.2</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="380.525391" y="98.081924" transform="rotate(-0 380.525391 98.081924)">FC=1.2</text>
     </g>
     <g id="patch_19">
-     <path d="M 414.309063 98.397031 
-L 422.109063 98.397031 
-L 422.109063 93.847031 
-L 414.309063 93.847031 
+     <path d="M 409.786563 98.081924 
+L 417.586563 98.081924 
+L 417.586563 93.531924 
+L 409.786563 93.531924 
 z
 " style="fill: #1980ba"/>
     </g>
     <g id="text_8">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="98.397031" transform="rotate(-0 424.709063 98.397031)">FC=1.1</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.186563" y="98.081924" transform="rotate(-0 420.186563 98.081924)">FC=1.1</text>
     </g>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_20">
-    <path d="M 83.705234 341.668828 
-L 454.620234 341.668828 
-L 454.620234 124.918828 
-L 83.705234 124.918828 
+    <path d="M 83.705234 341.299995 
+L 450.097734 341.299995 
+L 450.097734 124.813447 
+L 83.705234 124.813447 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_7">
      <g id="line2d_18">
-      <path d="M 83.705234 341.668828 
-L 83.705234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 83.705234 341.299995 
+L 83.705234 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_19"/>
     </g>
     <g id="xtick_8">
      <g id="line2d_20">
-      <path d="M 157.888234 341.668828 
-L 157.888234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 156.983734 341.299995 
+L 156.983734 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21"/>
     </g>
     <g id="xtick_9">
      <g id="line2d_22">
-      <path d="M 232.071234 341.668828 
-L 232.071234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 230.262234 341.299995 
+L 230.262234 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23"/>
     </g>
     <g id="xtick_10">
      <g id="line2d_24">
-      <path d="M 306.254234 341.668828 
-L 306.254234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 303.540734 341.299995 
+L 303.540734 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_25"/>
     </g>
     <g id="xtick_11">
      <g id="line2d_26">
-      <path d="M 380.437234 341.668828 
-L 380.437234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 376.819234 341.299995 
+L 376.819234 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_27"/>
     </g>
     <g id="xtick_12">
      <g id="line2d_28">
-      <path d="M 454.620234 341.668828 
-L 454.620234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 450.097734 341.299995 
+L 450.097734 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_29"/>
     </g>
@@ -326,564 +326,564 @@ L 454.620234 124.918828
     <g id="ytick_5">
      <g id="line2d_30"/>
      <g id="text_9">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="144.819264" transform="rotate(-0 81.705234 144.819264)">Cardiomyocytes</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="144.692697" transform="rotate(-0 81.705234 144.692697)">Cardiomyocytes</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_31"/>
      <g id="text_10">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="165.029055" transform="rotate(-0 81.705234 165.029055)">Haematoendothelial</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="164.877923" transform="rotate(-0 81.705234 164.877923)">Haematoendothelial</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_32"/>
      <g id="text_11">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="185.238845" transform="rotate(-0 81.705234 185.238845)">Epiblast/prim. streak</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="185.063149" transform="rotate(-0 81.705234 185.063149)">Epiblast/prim. streak</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33"/>
      <g id="text_12">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="205.448635" transform="rotate(-0 81.705234 205.448635)">Neuroectoderm rostral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="205.248375" transform="rotate(-0 81.705234 205.248375)">Neuroectoderm rostral</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_34"/>
      <g id="text_13">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="225.658425" transform="rotate(-0 81.705234 225.658425)">ExE endoderm visceral</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="225.4336" transform="rotate(-0 81.705234 225.4336)">ExE endoderm visceral</text>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_35"/>
      <g id="text_14">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="245.868215" transform="rotate(-0 81.705234 245.868215)">Surface ectoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="245.618826" transform="rotate(-0 81.705234 245.618826)">Surface ectoderm</text>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_36"/>
      <g id="text_15">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="266.078006" transform="rotate(-0 81.705234 266.078006)">ExE endoderm parietal</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="265.804052" transform="rotate(-0 81.705234 265.804052)">ExE endoderm parietal</text>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37"/>
      <g id="text_16">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="286.287796" transform="rotate(-0 81.705234 286.287796)">Pluripotent</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="285.989278" transform="rotate(-0 81.705234 285.989278)">Pluripotent</text>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_38"/>
      <g id="text_17">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="306.497586" transform="rotate(-0 81.705234 306.497586)">Mesoderm</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="306.174504" transform="rotate(-0 81.705234 306.174504)">Mesoderm</text>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39"/>
      <g id="text_18">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="326.707376" transform="rotate(-0 81.705234 326.707376)">Neuroectoderm brain</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="326.35973" transform="rotate(-0 81.705234 326.35973)">Neuroectoderm brain</text>
      </g>
     </g>
    </g>
    <g id="patch_21">
-    <path d="M 83.705234 134.771101 
-L 421.910592 134.771101 
-L 421.910592 149.928444 
-L 83.705234 149.928444 
+    <path d="M 83.705234 134.653745 
+L 417.786915 134.653745 
+L 417.786915 149.792664 
+L 83.705234 149.792664 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_22">
-    <path d="M 83.705234 154.980891 
-L 440.79984 154.980891 
-L 440.79984 170.138234 
-L 83.705234 170.138234 
+    <path d="M 83.705234 154.838971 
+L 436.445849 154.838971 
+L 436.445849 169.97789 
+L 83.705234 169.97789 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_23">
-    <path d="M 83.705234 175.190681 
-L 451.662773 175.190681 
-L 451.662773 190.348024 
-L 83.705234 190.348024 
+    <path d="M 83.705234 175.024197 
+L 447.176332 175.024197 
+L 447.176332 190.163116 
+L 83.705234 190.163116 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_24">
-    <path d="M 83.705234 195.400471 
-L 451.903674 195.400471 
-L 451.903674 210.557814 
-L 83.705234 210.557814 
+    <path d="M 83.705234 195.209423 
+L 447.414296 195.209423 
+L 447.414296 210.348342 
+L 83.705234 210.348342 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_25">
-    <path d="M 83.705234 215.610262 
-L 451.940389 215.610262 
-L 451.940389 230.767604 
-L 83.705234 230.767604 
+    <path d="M 83.705234 215.394649 
+L 447.450564 215.394649 
+L 447.450564 230.533568 
+L 83.705234 230.533568 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_26">
-    <path d="M 83.705234 235.820052 
-L 453.948895 235.820052 
-L 453.948895 250.977395 
-L 83.705234 250.977395 
+    <path d="M 83.705234 235.579874 
+L 449.434581 235.579874 
+L 449.434581 250.718794 
+L 83.705234 250.718794 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_27">
-    <path d="M 83.705234 256.029842 
-L 454.200825 256.029842 
-L 454.200825 271.187185 
-L 83.705234 271.187185 
+    <path d="M 83.705234 255.7651 
+L 449.683439 255.7651 
+L 449.683439 270.90402 
+L 83.705234 270.90402 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_28">
-    <path d="M 83.705234 276.239632 
-L 454.259685 276.239632 
-L 454.259685 291.396975 
-L 83.705234 291.396975 
+    <path d="M 83.705234 275.950326 
+L 449.741581 275.950326 
+L 449.741581 291.089246 
+L 83.705234 291.089246 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_29">
-    <path d="M 83.705234 296.449423 
-L 454.513265 296.449423 
-L 454.513265 311.606765 
-L 83.705234 311.606765 
+    <path d="M 83.705234 296.135552 
+L 449.99207 296.135552 
+L 449.99207 311.274472 
+L 83.705234 311.274472 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_30">
-    <path d="M 83.705234 316.659213 
-L 454.516409 316.659213 
-L 454.516409 331.816555 
-L 83.705234 331.816555 
+    <path d="M 83.705234 316.320778 
+L 449.995175 316.320778 
+L 449.995175 331.459697 
+L 83.705234 331.459697 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #b2d5e8"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #b2d5e8"/>
    </g>
    <g id="patch_31">
-    <path d="M 83.705234 134.771101 
-L 262.553138 134.771101 
-L 262.553138 149.928444 
-L 83.705234 149.928444 
+    <path d="M 83.705234 134.653745 
+L 260.372478 134.653745 
+L 260.372478 149.792664 
+L 83.705234 149.792664 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_32">
-    <path d="M 83.705234 154.980891 
-L 321.474776 154.980891 
-L 321.474776 170.138234 
-L 83.705234 170.138234 
+    <path d="M 83.705234 154.838971 
+L 318.575695 154.838971 
+L 318.575695 169.97789 
+L 83.705234 169.97789 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_33">
-    <path d="M 83.705234 175.190681 
-L 390.048535 175.190681 
-L 390.048535 190.348024 
-L 83.705234 190.348024 
+    <path d="M 83.705234 175.024197 
+L 386.313347 175.024197 
+L 386.313347 190.163116 
+L 83.705234 190.163116 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_34">
-    <path d="M 83.705234 195.400471 
-L 402.062009 195.400471 
-L 402.062009 210.557814 
-L 83.705234 210.557814 
+    <path d="M 83.705234 195.209423 
+L 398.180342 195.209423 
+L 398.180342 210.348342 
+L 83.705234 210.348342 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_35">
-    <path d="M 83.705234 215.610262 
-L 402.171237 215.610262 
-L 402.171237 230.767604 
-L 83.705234 230.767604 
+    <path d="M 83.705234 215.394649 
+L 398.288238 215.394649 
+L 398.288238 230.533568 
+L 83.705234 230.533568 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_36">
-    <path d="M 83.705234 235.820052 
-L 441.805166 235.820052 
-L 441.805166 250.977395 
-L 83.705234 250.977395 
+    <path d="M 83.705234 235.579874 
+L 437.438918 235.579874 
+L 437.438918 250.718794 
+L 83.705234 250.718794 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_37">
-    <path d="M 83.705234 256.029842 
-L 422.375724 256.029842 
-L 422.375724 271.187185 
-L 83.705234 271.187185 
+    <path d="M 83.705234 255.7651 
+L 418.246375 255.7651 
+L 418.246375 270.90402 
+L 83.705234 270.90402 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_38">
-    <path d="M 83.705234 276.239632 
-L 442.633534 276.239632 
-L 442.633534 291.396975 
-L 83.705234 291.396975 
+    <path d="M 83.705234 275.950326 
+L 438.257185 275.950326 
+L 438.257185 291.089246 
+L 83.705234 291.089246 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_39">
-    <path d="M 83.705234 296.449423 
-L 445.416047 296.449423 
-L 445.416047 311.606765 
-L 83.705234 311.606765 
+    <path d="M 83.705234 296.135552 
+L 441.005772 296.135552 
+L 441.005772 311.274472 
+L 83.705234 311.274472 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_40">
-    <path d="M 83.705234 316.659213 
-L 445.154748 316.659213 
-L 445.154748 331.816555 
-L 83.705234 331.816555 
+    <path d="M 83.705234 316.320778 
+L 440.747659 316.320778 
+L 440.747659 331.459697 
+L 83.705234 331.459697 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #66aad1"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #66aad1"/>
    </g>
    <g id="patch_41">
-    <path d="M 83.705234 134.771101 
-L 134.718216 134.771101 
-L 134.718216 149.928444 
-L 83.705234 149.928444 
+    <path d="M 83.705234 134.653745 
+L 134.096224 134.653745 
+L 134.096224 149.792664 
+L 83.705234 149.792664 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_42">
-    <path d="M 83.705234 154.980891 
-L 146.658698 154.980891 
-L 146.658698 170.138234 
-L 83.705234 170.138234 
+    <path d="M 83.705234 154.838971 
+L 145.891117 154.838971 
+L 145.891117 169.97789 
+L 83.705234 169.97789 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_43">
-    <path d="M 83.705234 175.190681 
-L 174.373345 175.190681 
-L 174.373345 190.348024 
-L 83.705234 190.348024 
+    <path d="M 83.705234 175.024197 
+L 173.267845 175.024197 
+L 173.267845 190.163116 
+L 83.705234 190.163116 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_44">
-    <path d="M 83.705234 195.400471 
-L 194.269849 195.400471 
-L 194.269849 210.557814 
-L 83.705234 210.557814 
+    <path d="M 83.705234 195.209423 
+L 192.921755 195.209423 
+L 192.921755 210.348342 
+L 83.705234 210.348342 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_45">
-    <path d="M 83.705234 215.610262 
-L 191.02916 215.610262 
-L 191.02916 230.767604 
-L 83.705234 230.767604 
+    <path d="M 83.705234 215.394649 
+L 189.720579 215.394649 
+L 189.720579 230.533568 
+L 83.705234 230.533568 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_46">
-    <path d="M 83.705234 235.820052 
-L 260.004339 235.820052 
-L 260.004339 250.977395 
-L 83.705234 250.977395 
+    <path d="M 83.705234 235.579874 
+L 257.854756 235.579874 
+L 257.854756 250.718794 
+L 83.705234 250.718794 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_47">
-    <path d="M 83.705234 256.029842 
-L 208.310223 256.029842 
-L 208.310223 271.187185 
-L 83.705234 271.187185 
+    <path d="M 83.705234 255.7651 
+L 206.790937 255.7651 
+L 206.790937 270.90402 
+L 83.705234 270.90402 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_48">
-    <path d="M 83.705234 276.239632 
-L 250.969863 276.239632 
-L 250.969863 291.396975 
-L 83.705234 291.396975 
+    <path d="M 83.705234 275.950326 
+L 248.930436 275.950326 
+L 248.930436 291.089246 
+L 83.705234 291.089246 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_49">
-    <path d="M 83.705234 296.449423 
-L 266.289138 296.449423 
-L 266.289138 311.606765 
-L 83.705234 311.606765 
+    <path d="M 83.705234 296.135552 
+L 264.062925 296.135552 
+L 264.062925 311.274472 
+L 83.705234 311.274472 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="patch_50">
-    <path d="M 83.705234 316.659213 
-L 276.25575 316.659213 
-L 276.25575 331.816555 
-L 83.705234 331.816555 
+    <path d="M 83.705234 316.320778 
+L 273.908016 316.320778 
+L 273.908016 331.459697 
+L 83.705234 331.459697 
 z
-" clip-path="url(#p5620c45f01)" style="fill: #1980ba"/>
+" clip-path="url(#pf7e3ce25ba)" style="fill: #1980ba"/>
    </g>
    <g id="line2d_40">
-    <path d="M 380.437234 341.668828 
-L 380.437234 124.918828 
-" clip-path="url(#p5620c45f01)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 376.819234 341.299995 
+L 376.819234 124.813447 
+" clip-path="url(#pf7e3ce25ba)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_51">
-    <path d="M 83.705234 341.668828 
-L 83.705234 124.918828 
+    <path d="M 83.705234 341.299995 
+L 83.705234 124.813447 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_52">
-    <path d="M 83.705234 341.668828 
-L 454.620234 341.668828 
+    <path d="M 83.705234 341.299995 
+L 450.097734 341.299995 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="118.918828" transform="rotate(-0 83.705234 118.918828)">Lalanne et al. (piggyBac, oBC reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="118.813447" transform="rotate(-0 83.705234 118.813447)">Lalanne et al.</text>
    </g>
    <g id="legend_2">
     <g id="patch_53">
-     <path d="M 334.986719 334.467031 
-L 342.786719 334.467031 
-L 342.786719 329.917031 
-L 334.986719 329.917031 
+     <path d="M 330.464219 333.888472 
+L 338.264219 333.888472 
+L 338.264219 329.338472 
+L 330.464219 329.338472 
 z
 " style="fill: #b2d5e8"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="334.467031" transform="rotate(-0 345.386719 334.467031)">FC=2.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="340.864219" y="333.888472" transform="rotate(-0 340.864219 333.888472)">FC=2.0</text>
     </g>
     <g id="patch_54">
-     <path d="M 374.647891 334.467031 
-L 382.447891 334.467031 
-L 382.447891 329.917031 
-L 374.647891 329.917031 
+     <path d="M 370.125391 333.888472 
+L 377.925391 333.888472 
+L 377.925391 329.338472 
+L 370.125391 329.338472 
 z
 " style="fill: #66aad1"/>
     </g>
     <g id="text_21">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="334.467031" transform="rotate(-0 385.047891 334.467031)">FC=1.5</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="380.525391" y="333.888472" transform="rotate(-0 380.525391 333.888472)">FC=1.5</text>
     </g>
     <g id="patch_55">
-     <path d="M 414.309063 334.467031 
-L 422.109063 334.467031 
-L 422.109063 329.917031 
-L 414.309063 329.917031 
+     <path d="M 409.786563 333.888472 
+L 417.586563 333.888472 
+L 417.586563 329.338472 
+L 409.786563 329.338472 
 z
 " style="fill: #1980ba"/>
     </g>
     <g id="text_22">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="334.467031" transform="rotate(-0 424.709063 334.467031)">FC=1.2</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.186563" y="333.888472" transform="rotate(-0 420.186563 333.888472)">FC=1.2</text>
     </g>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_56">
-    <path d="M 83.705234 404.338828 
-L 454.620234 404.338828 
-L 454.620234 360.988828 
-L 83.705234 360.988828 
+    <path d="M 83.705234 403.917305 
+L 450.097734 403.917305 
+L 450.097734 360.619995 
+L 83.705234 360.619995 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_13">
      <g id="line2d_41">
-      <path d="M 83.705234 404.338828 
-L 83.705234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 83.705234 403.917305 
+L 83.705234 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_42"/>
      <g id="text_23">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="411.277812" transform="rotate(-0 83.705234 411.277812)">0.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="83.705234" y="410.855781" transform="rotate(-0 83.705234 410.855781)">0.0</text>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_43">
-      <path d="M 157.888234 404.338828 
-L 157.888234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 156.983734 403.917305 
+L 156.983734 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_44"/>
      <g id="text_24">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="157.888234" y="411.277812" transform="rotate(-0 157.888234 411.277812)">0.2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="156.983734" y="410.855781" transform="rotate(-0 156.983734 410.855781)">0.2</text>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_45">
-      <path d="M 232.071234 404.338828 
-L 232.071234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 230.262234 403.917305 
+L 230.262234 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_46"/>
      <g id="text_25">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="232.071234" y="411.277812" transform="rotate(-0 232.071234 411.277812)">0.4</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="230.262234" y="410.855781" transform="rotate(-0 230.262234 410.855781)">0.4</text>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_47">
-      <path d="M 306.254234 404.338828 
-L 306.254234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 303.540734 403.917305 
+L 303.540734 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_48"/>
      <g id="text_26">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="306.254234" y="411.277812" transform="rotate(-0 306.254234 411.277812)">0.6</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="303.540734" y="410.855781" transform="rotate(-0 303.540734 410.855781)">0.6</text>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_49">
-      <path d="M 380.437234 404.338828 
-L 380.437234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 376.819234 403.917305 
+L 376.819234 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_50"/>
      <g id="text_27">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="380.437234" y="411.277812" transform="rotate(-0 380.437234 411.277812)">0.8</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="376.819234" y="410.855781" transform="rotate(-0 376.819234 410.855781)">0.8</text>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_51">
-      <path d="M 454.620234 404.338828 
-L 454.620234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 450.097734 403.917305 
+L 450.097734 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke: #c9c9c9; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_52"/>
      <g id="text_28">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="454.620234" y="411.277812" transform="rotate(-0 454.620234 411.277812)">1.0</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1a1a1a" x="450.097734" y="410.855781" transform="rotate(-0 450.097734 410.855781)">1.0</text>
      </g>
     </g>
     <g id="text_29">
-     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="269.162734" y="422.328438" transform="rotate(-0 269.162734 422.328438)">power</text>
+     <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="266.901484" y="422.115547" transform="rotate(-0 266.901484 422.115547)">power</text>
     </g>
    </g>
    <g id="matplotlib.axis_6">
     <g id="ytick_15">
      <g id="line2d_53"/>
      <g id="text_30">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="373.87358" transform="rotate(-0 81.705234 373.87358)">K562</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="373.491834" transform="rotate(-0 81.705234 373.491834)">K562</text>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_54"/>
      <g id="text_31">
-      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="396.393061" transform="rotate(-0 81.705234 396.393061)">HepG2</text>
+      <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1a1a1a" x="81.705234" y="395.983943" transform="rotate(-0 81.705234 395.983943)">HepG2</text>
      </g>
     </g>
    </g>
    <g id="patch_57">
-    <path d="M 83.705234 362.959283 
-L 434.768244 362.959283 
-L 434.768244 379.848893 
-L 83.705234 379.848893 
+    <path d="M 83.705234 362.588055 
+L 430.487796 362.588055 
+L 430.487796 379.457136 
+L 83.705234 379.457136 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #f2cfb2"/>
+" clip-path="url(#pde7c07066e)" style="fill: #f2cfb2"/>
    </g>
    <g id="patch_58">
-    <path d="M 83.705234 385.478763 
-L 449.03325 385.478763 
-L 449.03325 402.368374 
-L 83.705234 402.368374 
+    <path d="M 83.705234 385.080164 
+L 444.578871 385.080164 
+L 444.578871 401.949245 
+L 83.705234 401.949245 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #f2cfb2"/>
+" clip-path="url(#pde7c07066e)" style="fill: #f2cfb2"/>
    </g>
    <g id="patch_59">
-    <path d="M 83.705234 362.959283 
-L 283.906695 362.959283 
-L 283.906695 379.848893 
-L 83.705234 379.848893 
+    <path d="M 83.705234 362.588055 
+L 281.465674 362.588055 
+L 281.465674 379.457136 
+L 83.705234 379.457136 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #e69e66"/>
+" clip-path="url(#pde7c07066e)" style="fill: #e69e66"/>
    </g>
    <g id="patch_60">
-    <path d="M 83.705234 385.478763 
-L 331.988502 385.478763 
-L 331.988502 402.368374 
-L 83.705234 402.368374 
+    <path d="M 83.705234 385.080164 
+L 328.961228 385.080164 
+L 328.961228 401.949245 
+L 83.705234 401.949245 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #e69e66"/>
+" clip-path="url(#pde7c07066e)" style="fill: #e69e66"/>
    </g>
    <g id="patch_61">
-    <path d="M 83.705234 362.959283 
-L 146.09066 362.959283 
-L 146.09066 379.848893 
-L 83.705234 379.848893 
+    <path d="M 83.705234 362.588055 
+L 145.330005 362.588055 
+L 145.330005 379.457136 
+L 83.705234 379.457136 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #d96e19"/>
+" clip-path="url(#pde7c07066e)" style="fill: #d96e19"/>
    </g>
    <g id="patch_62">
-    <path d="M 83.705234 385.478763 
-L 171.327252 385.478763 
-L 171.327252 402.368374 
-L 83.705234 402.368374 
+    <path d="M 83.705234 385.080164 
+L 170.258892 385.080164 
+L 170.258892 401.949245 
+L 83.705234 401.949245 
 z
-" clip-path="url(#p1ecbf345b6)" style="fill: #d96e19"/>
+" clip-path="url(#pde7c07066e)" style="fill: #d96e19"/>
    </g>
    <g id="line2d_55">
-    <path d="M 380.437234 404.338828 
-L 380.437234 360.988828 
-" clip-path="url(#p1ecbf345b6)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
+    <path d="M 376.819234 403.917305 
+L 376.819234 360.619995 
+" clip-path="url(#pde7c07066e)" style="fill: none; stroke-dasharray: 2.59,1.12; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.7"/>
    </g>
    <g id="patch_63">
-    <path d="M 83.705234 404.338828 
-L 83.705234 360.988828 
+    <path d="M 83.705234 403.917305 
+L 83.705234 360.619995 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_64">
-    <path d="M 83.705234 404.338828 
-L 454.620234 404.338828 
+    <path d="M 83.705234 403.917305 
+L 450.097734 403.917305 
 " style="fill: none; stroke: #c9c9c9; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_32">
-    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="354.988828" transform="rotate(-0 83.705234 354.988828)">Yin et al. (episomal, no reporter)</text>
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="83.705234" y="354.619995" transform="rotate(-0 83.705234 354.619995)">Yin et al.</text>
    </g>
    <g id="legend_3">
     <g id="patch_65">
-     <path d="M 334.986719 397.137031 
-L 342.786719 397.137031 
-L 342.786719 392.587031 
-L 334.986719 392.587031 
+     <path d="M 330.464219 396.505781 
+L 338.264219 396.505781 
+L 338.264219 391.955781 
+L 330.464219 391.955781 
 z
 " style="fill: #f2cfb2"/>
     </g>
     <g id="text_33">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="345.386719" y="397.137031" transform="rotate(-0 345.386719 397.137031)">FC=3.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="340.864219" y="396.505781" transform="rotate(-0 340.864219 396.505781)">FC=3.0</text>
     </g>
     <g id="patch_66">
-     <path d="M 374.647891 397.137031 
-L 382.447891 397.137031 
-L 382.447891 392.587031 
-L 374.647891 392.587031 
+     <path d="M 370.125391 396.505781 
+L 377.925391 396.505781 
+L 377.925391 391.955781 
+L 370.125391 391.955781 
 z
 " style="fill: #e69e66"/>
     </g>
     <g id="text_34">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="385.047891" y="397.137031" transform="rotate(-0 385.047891 397.137031)">FC=2.0</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="380.525391" y="396.505781" transform="rotate(-0 380.525391 396.505781)">FC=2.0</text>
     </g>
     <g id="patch_67">
-     <path d="M 414.309063 397.137031 
-L 422.109063 397.137031 
-L 422.109063 392.587031 
-L 414.309063 392.587031 
+     <path d="M 409.786563 396.505781 
+L 417.586563 396.505781 
+L 417.586563 391.955781 
+L 409.786563 391.955781 
 z
 " style="fill: #d96e19"/>
     </g>
     <g id="text_35">
-     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="424.709063" y="397.137031" transform="rotate(-0 424.709063 397.137031)">FC=1.5</text>
+     <text style="font-size: 6.5px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="420.186563" y="396.505781" transform="rotate(-0 420.186563 396.505781)">FC=1.5</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="ped2729ea74">
-   <rect x="83.705234" y="18.898828" width="370.915" height="86.7"/>
+  <clipPath id="p93c34e9e88">
+   <rect x="83.705234" y="18.898828" width="366.3925" height="86.594619"/>
   </clipPath>
-  <clipPath id="p5620c45f01">
-   <rect x="83.705234" y="124.918828" width="370.915" height="216.75"/>
+  <clipPath id="pf7e3ce25ba">
+   <rect x="83.705234" y="124.813447" width="366.3925" height="216.486548"/>
   </clipPath>
-  <clipPath id="p1ecbf345b6">
-   <rect x="83.705234" y="360.988828" width="370.915" height="43.35"/>
+  <clipPath id="pde7c07066e">
+   <rect x="83.705234" y="360.619995" width="366.3925" height="43.29731"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
Drops the assay descriptors from the Figure 4 panel titles, leaving just the dataset names.

- `Zhao et al. (episomal, CRE reporter)` -> `Zhao et al.`
- `Lalanne et al. (piggyBac, oBC reporter)` -> `Lalanne et al.`
- `Yin et al. (episomal, no reporter)` -> `Yin et al.`

Applied at the `DATASETS[...]["title"]` source, so it lands on **both** 4A and 4B. They read from the same field and sit side by side under one caption; changing only 4B would leave the two panels with mismatched titles.

`fig_b_slope_discrete` was already stripping the parenthetical itself with `.split(" (")[0]`, which is now redundant and removed.

Also regenerates the two non-manuscript outputs (`fig_b_dataset_bars`, `fig_b_telescope`), which share the same titles.

Verified: no occurrence of `episomal`, `piggyBac` or `oBC` in either manuscript SVG.

Note the descriptors are now unrepresented anywhere in the figure. Whether the caption should pick them up is a separate call - Fig 4's caption is still a stub.
