### PR TITLE
Fix baked text in the collision-rate figure

### DIFF
--- a/analyses/supplementary/estimated_percent_conflict.ipynb
+++ b/analyses/supplementary/estimated_percent_conflict.ipynb
@@ -12,7 +12,7 @@
    "id": "f2c80aac",
    "metadata": {},
    "outputs": [],
-   "source": "percent_collision = {\n    \"Cohen\":    0.11689209661257542,\n    \"Shendure\": 0.05304031883524153,\n    \"Seelig\":   7.630123998189407,\n}"
+   "source": "percent_collision = {\n    \"Zhao et al.\":    0.11689209661257542,\n    \"Lalanne et al.\": 0.05304031883524153,\n    \"Yin et al.\":     7.630123998189407,\n}"
   },
   {
    "cell_type": "code",
@@ -20,7 +20,7 @@
    "id": "7fb25eb7",
    "metadata": {},
    "outputs": [],
-   "source": "import pandas as pd\nimport seaborn as sns\nimport matplotlib.pyplot as plt\n\ncollision_df = (\n    pd.DataFrame(\n        {\"method\": list(percent_collision.keys()), \"collision_rate\": list(percent_collision.values())}\n    )\n    .dropna(subset=[\"collision_rate\"])\n    .sort_values(\"collision_rate\", ascending=False)\n)\n\nsns.set_theme(style=\"whitegrid\")\nfig, ax = plt.subplots(figsize=(4, 3))\nsns.barplot(data=collision_df, x=\"method\", y=\"collision_rate\", ax=ax, color=\"#4C78A8\")\nax.set_xlabel(\"\")\nax.set_ylabel(\"\")\nax.set_title(\"Estimated collision rate (fraction of total transfection events)\")\nax.set_ylim(0, max(collision_df[\"collision_rate\"].max() * 1.15, 0.01))\nfor container in ax.containers:\n    ax.bar_label(container, fmt=\"%.1f%%\", labels=[f\"{v:.3f}%\" for v in collision_df[\"collision_rate\"]])\nfig.tight_layout()\nout_svg = \"./estimated_percent_conflict_collision_rate.svg\"\nfig.savefig(out_svg, format=\"svg\", bbox_inches=\"tight\")\nout_svg\n"
+   "source": "import pandas as pd\nimport seaborn as sns\nimport matplotlib.pyplot as plt\n\n# keep SVG text as <text> elements so labels stay editable downstream\nplt.rcParams[\"svg.fonttype\"] = \"none\"\n\ncollision_df = (\n    pd.DataFrame(\n        {\"method\": list(percent_collision.keys()), \"collision_rate\": list(percent_collision.values())}\n    )\n    .dropna(subset=[\"collision_rate\"])\n    .sort_values(\"collision_rate\", ascending=False)\n)\n\nsns.set_theme(style=\"whitegrid\")\nfig, ax = plt.subplots(figsize=(4, 3))\nsns.barplot(data=collision_df, x=\"method\", y=\"collision_rate\", ax=ax, color=\"#4C78A8\")\nax.set_xlabel(\"\")\nax.set_ylabel(\"\")\nax.set_title(\"Estimated collision rate (fraction of total transfection events)\")\nax.set_ylim(0, max(collision_df[\"collision_rate\"].max() * 1.15, 0.01))\nfor container in ax.containers:\n    ax.bar_label(container, fmt=\"%.1f%%\", labels=[f\"{v:.3f}%\" for v in collision_df[\"collision_rate\"]])\nfig.tight_layout()\nout_svg = \"./estimated_percent_conflict_collision_rate.svg\"\nfig.savefig(out_svg, format=\"svg\", bbox_inches=\"tight\")\nout_svg\n"
   }
  ],
  "metadata": {

--- a/analyses/supplementary/estimated_percent_conflict_collision_rate.svg
+++ b/analyses/supplementary/estimated_percent_conflict_collision_rate.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="381.500625pt" height="204.804062pt" viewBox="0 0 381.500625 204.804062" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="331.858125pt" height="204.48pt" viewBox="0 0 331.858125 204.48" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-04-01T14:34:38.703069</dc:date>
+    <dc:date>2026-08-17T14:54:33.436010</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,1047 +21,161 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 204.804062 
-L 381.500625 204.804062 
-L 381.500625 0 
+   <path d="M 0 204.48 
+L 331.858125 204.48 
+L 331.858125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 67.970312 177.458125 
-L 313.530312 177.458125 
-L 313.530312 22.318125 
-L 67.970312 22.318125 
+    <path d="M 42.519063 177.456758 
+L 289.339062 177.456758 
+L 289.339062 21.936328 
+L 42.519063 21.936328 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="text_1">
-      <!-- Seelig -->
-      <g style="fill: #262626" transform="translate(92.089323 195.316406) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-67" d="M 2906 1791 
-Q 2906 2416 2648 2759 
-Q 2391 3103 1925 3103 
-Q 1463 3103 1205 2759 
-Q 947 2416 947 1791 
-Q 947 1169 1205 825 
-Q 1463 481 1925 481 
-Q 2391 481 2648 825 
-Q 2906 1169 2906 1791 
-z
-M 3481 434 
-Q 3481 -459 3084 -895 
-Q 2688 -1331 1869 -1331 
-Q 1566 -1331 1297 -1286 
-Q 1028 -1241 775 -1147 
-L 775 -588 
-Q 1028 -725 1275 -790 
-Q 1522 -856 1778 -856 
-Q 2344 -856 2625 -561 
-Q 2906 -266 2906 331 
-L 2906 616 
-Q 2728 306 2450 153 
-Q 2172 0 1784 0 
-Q 1141 0 747 490 
-Q 353 981 353 1791 
-Q 353 2603 747 3093 
-Q 1141 3584 1784 3584 
-Q 2172 3584 2450 3431 
-Q 2728 3278 2906 2969 
-L 2906 3500 
-L 3481 3500 
-L 3481 434 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-53"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(125 0)"/>
-       <use xlink:href="#DejaVuSans-6c" transform="translate(186.523438 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(214.306641 0)"/>
-       <use xlink:href="#DejaVuSans-67" transform="translate(242.089844 0)"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="83.655729" y="194.965059" transform="rotate(-0 83.655729 194.965059)">Yin et al.</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="text_2">
-      <!-- Cohen -->
-      <g style="fill: #262626" transform="translate(173.188984 195.316406) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-43"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(69.824219 0)"/>
-       <use xlink:href="#DejaVuSans-68" transform="translate(131.005859 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(194.384766 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(255.908203 0)"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="165.929062" y="194.965059" transform="rotate(-0 165.929062 194.965059)">Zhao et al.</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="text_3">
-      <!-- Shendure -->
-      <g style="fill: #262626" transform="translate(246.257786 195.316406) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-64" d="M 2906 2969 
-L 2906 4863 
-L 3481 4863 
-L 3481 0 
-L 2906 0 
-L 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-z
-M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-53"/>
-       <use xlink:href="#DejaVuSans-68" transform="translate(63.476562 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(126.855469 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(188.378906 0)"/>
-       <use xlink:href="#DejaVuSans-64" transform="translate(251.757812 0)"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(315.234375 0)"/>
-       <use xlink:href="#DejaVuSans-72" transform="translate(378.613281 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(417.476562 0)"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="248.202396" y="194.965059" transform="rotate(-0 248.202396 194.965059)">Lalanne et al.</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_1">
-      <path d="M 67.970312 177.458125 
-L 313.530312 177.458125 
-" clip-path="url(#paf02782328)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
+      <path d="M 42.519063 177.456758 
+L 289.339062 177.456758 
+" clip-path="url(#p1c4d473445)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
      </g>
      <g id="text_4">
-      <!-- 0 -->
-      <g style="fill: #262626" transform="translate(51.471562 181.637266) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: end; fill: #262626" x="33.019063" y="181.460908" transform="rotate(-0 33.019063 181.460908)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_2">
-      <path d="M 67.970312 142.097141 
-L 313.530312 142.097141 
-" clip-path="url(#paf02782328)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
+      <path d="M 42.519063 142.009062 
+L 289.339062 142.009062 
+" clip-path="url(#p1c4d473445)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
      </g>
      <g id="text_5">
-      <!-- 2 -->
-      <g style="fill: #262626" transform="translate(51.471562 146.276281) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: end; fill: #262626" x="33.019063" y="146.013213" transform="rotate(-0 33.019063 146.013213)">2</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_3">
-      <path d="M 67.970312 106.736156 
-L 313.530312 106.736156 
-" clip-path="url(#paf02782328)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
+      <path d="M 42.519063 106.561367 
+L 289.339062 106.561367 
+" clip-path="url(#p1c4d473445)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
      </g>
      <g id="text_6">
-      <!-- 4 -->
-      <g style="fill: #262626" transform="translate(51.471562 110.915297) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-34"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: end; fill: #262626" x="33.019063" y="110.565517" transform="rotate(-0 33.019063 110.565517)">4</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_4">
-      <path d="M 67.970312 71.375172 
-L 313.530312 71.375172 
-" clip-path="url(#paf02782328)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
+      <path d="M 42.519063 71.113671 
+L 289.339062 71.113671 
+" clip-path="url(#p1c4d473445)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
      </g>
      <g id="text_7">
-      <!-- 6 -->
-      <g style="fill: #262626" transform="translate(51.471562 75.554312) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-36"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: end; fill: #262626" x="33.019063" y="75.117822" transform="rotate(-0 33.019063 75.117822)">6</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_5">
-      <path d="M 67.970312 36.014187 
-L 313.530312 36.014187 
-" clip-path="url(#paf02782328)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
+      <path d="M 42.519063 35.665976 
+L 289.339062 35.665976 
+" clip-path="url(#p1c4d473445)" style="fill: none; stroke: #cccccc; stroke-linecap: round"/>
      </g>
      <g id="text_8">
-      <!-- 8 -->
-      <g style="fill: #262626" transform="translate(51.471562 40.193328) scale(0.11 -0.11)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-38"/>
-      </g>
+      <text style="font-size: 11px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: end; fill: #262626" x="33.019063" y="39.670126" transform="rotate(-0 33.019063 39.670126)">8</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 76.155646 177.458125 
-L 141.638312 177.458125 
-L 141.638312 42.553777 
-L 76.155646 42.553777 
+    <path d="M 50.746396 177.456758 
+L 116.565062 177.456758 
+L 116.565062 42.221602 
+L 50.746396 42.221602 
 z
-" clip-path="url(#paf02782328)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1c4d473445)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 158.008979 177.458125 
-L 223.491646 177.458125 
-L 223.491646 175.391415 
-L 158.008979 175.391415 
+    <path d="M 133.019729 177.456758 
+L 198.838396 177.456758 
+L 198.838396 175.38498 
+L 133.019729 175.38498 
 z
-" clip-path="url(#paf02782328)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1c4d473445)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 239.862312 177.458125 
-L 305.344979 177.458125 
-L 305.344979 176.520346 
-L 239.862312 176.520346 
+    <path d="M 215.293062 177.456758 
+L 281.111729 177.456758 
+L 281.111729 176.516679 
+L 215.293062 176.516679 
 z
-" clip-path="url(#paf02782328)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1c4d473445)" style="fill: #58789c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="line2d_6">
-    <path clip-path="url(#paf02782328)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
+    <path clip-path="url(#p1c4d473445)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
    </g>
    <g id="line2d_7">
-    <path clip-path="url(#paf02782328)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
+    <path clip-path="url(#p1c4d473445)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
    </g>
    <g id="line2d_8">
-    <path clip-path="url(#paf02782328)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
+    <path clip-path="url(#p1c4d473445)" style="fill: none; stroke: #424242; stroke-width: 2.25; stroke-linecap: round"/>
    </g>
    <g id="patch_6">
-    <path d="M 67.970312 177.458125 
-L 67.970312 22.318125 
+    <path d="M 42.519063 177.456758 
+L 42.519063 21.936328 
 " style="fill: none; stroke: #cccccc; stroke-width: 1.25; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 313.530312 177.458125 
-L 313.530312 22.318125 
+    <path d="M 289.339062 177.456758 
+L 289.339062 21.936328 
 " style="fill: none; stroke: #cccccc; stroke-width: 1.25; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 67.970312 177.458125 
-L 313.530312 177.458125 
+    <path d="M 42.519063 177.456758 
+L 289.339062 177.456758 
 " style="fill: none; stroke: #cccccc; stroke-width: 1.25; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_9">
-    <path d="M 67.970312 22.318125 
-L 313.530312 22.318125 
+    <path d="M 42.519063 21.936328 
+L 289.339062 21.936328 
 " style="fill: none; stroke: #cccccc; stroke-width: 1.25; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_9">
-    <!-- 7.630% -->
-    <g style="fill: #262626" transform="translate(86.019167 40.058152) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-25" d="M 4653 2053 
-Q 4381 2053 4226 1822 
-Q 4072 1591 4072 1178 
-Q 4072 772 4226 539 
-Q 4381 306 4653 306 
-Q 4919 306 5073 539 
-Q 5228 772 5228 1178 
-Q 5228 1588 5073 1820 
-Q 4919 2053 4653 2053 
-z
-M 4653 2450 
-Q 5147 2450 5437 2106 
-Q 5728 1763 5728 1178 
-Q 5728 594 5436 251 
-Q 5144 -91 4653 -91 
-Q 4153 -91 3862 251 
-Q 3572 594 3572 1178 
-Q 3572 1766 3864 2108 
-Q 4156 2450 4653 2450 
-z
-M 1428 4353 
-Q 1159 4353 1004 4120 
-Q 850 3888 850 3481 
-Q 850 3069 1003 2837 
-Q 1156 2606 1428 2606 
-Q 1700 2606 1854 2837 
-Q 2009 3069 2009 3481 
-Q 2009 3884 1853 4118 
-Q 1697 4353 1428 4353 
-z
-M 4250 4750 
-L 4750 4750 
-L 1831 -91 
-L 1331 -91 
-L 4250 4750 
-z
-M 1428 4750 
-Q 1922 4750 2215 4408 
-Q 2509 4066 2509 3481 
-Q 2509 2891 2217 2550 
-Q 1925 2209 1428 2209 
-Q 931 2209 642 2551 
-Q 353 2894 353 3481 
-Q 353 4063 643 4406 
-Q 934 4750 1428 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(286.279297 0)"/>
-    </g>
+    <text style="font-size: 12px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="83.655729" y="39.696211" transform="rotate(-0 83.655729 39.696211)">7.630%</text>
    </g>
    <g id="text_10">
-    <!-- 0.117% -->
-    <g style="fill: #262626" transform="translate(167.8725 172.89579) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(222.65625 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(286.279297 0)"/>
-    </g>
+    <text style="font-size: 12px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="165.929062" y="172.859589" transform="rotate(-0 165.929062 172.859589)">0.117%</text>
    </g>
    <g id="text_11">
-    <!-- 0.053% -->
-    <g style="fill: #262626" transform="translate(249.725833 174.024721) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(222.65625 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(286.279297 0)"/>
-    </g>
+    <text style="font-size: 12px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="248.202396" y="173.991289" transform="rotate(-0 248.202396 173.991289)">0.053%</text>
    </g>
    <g id="text_12">
-    <!-- Estimated collision rate (fraction of total transfection events) -->
-    <g style="fill: #262626" transform="translate(7.2 16.318125) scale(0.12 -0.12)">
-     <defs>
-      <path id="DejaVuSans-45" d="M 628 4666 
-L 3578 4666 
-L 3578 4134 
-L 1259 4134 
-L 1259 2753 
-L 3481 2753 
-L 3481 2222 
-L 1259 2222 
-L 1259 531 
-L 3634 531 
-L 3634 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-45"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(63.183594 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(115.283203 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(154.492188 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(182.275391 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(279.6875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(340.966797 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(380.175781 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(441.699219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(505.175781 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(536.962891 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(591.943359 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(653.125 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(680.908203 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(708.691406 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(736.474609 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(788.574219 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(816.357422 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(877.539062 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(940.917969 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(972.705078 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1013.818359 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1075.097656 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1114.306641 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1175.830078 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(1207.617188 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(1246.630859 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1281.835938 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1322.949219 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1384.228516 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1439.208984 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1478.417969 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1506.201172 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1567.382812 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1630.761719 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1662.548828 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(1723.730469 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1758.935547 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1790.722656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1829.931641 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1891.113281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1930.322266 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(1991.601562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2019.384766 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2051.171875 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2090.380859 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2131.494141 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2192.773438 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2256.152344 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2308.251953 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2343.457031 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2404.980469 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2459.960938 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2499.169922 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2526.953125 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2588.134766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2651.513672 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2683.300781 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(2744.824219 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2804.003906 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2865.527344 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2928.90625 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2968.115234 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(3020.214844 0)"/>
-    </g>
+    <text style="font-size: 12px; font-family: 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', sans-serif; text-anchor: middle; fill: #262626" x="165.929062" y="15.936328" transform="rotate(-0 165.929062 15.936328)">Estimated collision rate (fraction of total transfection events)</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="paf02782328">
-   <rect x="67.970312" y="22.318125" width="245.56" height="155.14"/>
+  <clipPath id="p1c4d473445">
+   <rect x="42.519063" y="21.936328" width="246.82" height="155.52043"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
`estimated_percent_conflict.ipynb` produces manuscript supplementary Fig S11 panel B. It never set `svg.fonttype: "none"` and never imported `scMPRAforge` (which sets it as a side effect), so matplotlib baked all text to glyph outlines and the SVG had **zero `<text>` elements**.

Two consequences, both silent:

1. The manuscript applies a `dataset_names` transform to this target, rewriting internal code names to citations. With no `<text>` nodes it matched nothing and reported nothing.
2. So the figure shipped with its x-axis tick labels reading **"Seelig", "Cohen", "Shendure"** as glyph outlines.

This was the last unidentified instance of a bug class that has now been found three times. The producer took a while to locate because it is a notebook, so every script-level grep missed it. It is also the only producer in the repo with genuinely no route to the rcParam.

## Fix

Two changes in the plotting cell:

- `plt.rcParams["svg.fonttype"] = "none"` before the figure is created, so text is editable — which the docx export path also needs.
- Dict keys renamed to citation form (`Cohen` -> `Zhao et al.`, `Shendure` -> `Lalanne et al.`, `Seelig` -> `Yin et al.`), so the correct labels are baked in rather than depending on a sync-time rewrite to be correct.

Numeric values are untouched.

## Verification

| | before | after |
|---|---|---|
| `<text>` elements | 0 | 12 |
| code names in file | 3 (as `<!-- Seelig -->` structural comments, i.e. drawn as paths) | 0 |
| citation names as text | 0 | 3 |

Bar values confirmed identical against the source dict: 0.11689... -> 0.117%, 0.05304... -> 0.053%, 7.63012... -> 7.630%. Same order, heights, colour, limits and title, checked by rendering old and new side by side.

The canvas narrows from 381.5pt to 331.9pt because `bbox_inches="tight"` crops to content and the new tick labels are narrower. The figure is still `figsize=(4, 3)`.

## Not changed

`coupon_collector.ipynb`, the sibling notebook. Its committed SVG is also path-only, but its producer already imports `scMPRAforge` and so gets the rcParam — the artifact is simply stale, predating that import. Re-running it means standing up a dask LocalCluster and re-running transfection simulations, and it renders no code names, so it is not worth it. Its axis labels are `gt_collisions` / `estimated_collisions`, a cosmetic problem of a different kind.
