### PR TITLE
Table S1: expansion names as Fig 1B prints them

### DIFF
--- a/analyses/model_selection/cross_family_agreement.py
+++ b/analyses/model_selection/cross_family_agreement.py
@@ -54,6 +54,28 @@ DATASET_LABEL = {"shendure": "Lalanne et al.", "cohen": "Zhao et al.",
 # manuscript introduces, so it is reported to the console and the TSV but
 # kept out of the figure panel and the supplementary table.
 MANUSCRIPT_DATASETS = set(DATASET_LABEL)
+
+# Expansion names exactly as Fig 1B prints them, so the table and the figure
+# name the same thing the same way (plot_nb_vs_zinb_bars.py::SERIES).
+#
+# The key is (dataset, expansion) rather than the expansion alone: "obs" is
+# not one mode. Lalanne et al.\'s reporter resolves a zero to a single
+# construct on its own, so its "obs" is already the fine expansion, while
+# Zhao et al. needs "obsingle" for that and its bare "obs" is the coarse one.
+# Rewriting the token alone would silently print two different modes under
+# one name.
+EXPANSION_LABEL = {
+    ("shendure", "obs"):      "observed, fine",
+    ("shendure", "cm"):       "consider missing",
+    # Not a series in Fig 1B, which shows only the two Lalanne et al. fits it
+    # compares; the table is exhaustive, so it needs the name anyway.
+    ("shendure", "cm_moib"):  "consider missing + MOI",
+    ("cohen", "obsingle"):    "observed, fine",
+    ("cohen", "obs"):         "observed, coarse",
+    ("cohen", "cm"):          "consider missing",
+    ("seelig", "cm_moib"):    "consider missing + MOI",
+    ("seelig", "cm"):         "consider missing",
+}
 # Fits shown in the left-hand scatter: the three canonical fits, plus the
 # reporter-free Lalanne fit as the contrast. That one is not a broken fit --
 # it is what the same experiment looks like when no transfection reporter was
@@ -330,8 +352,7 @@ def manuscript_table(rows):
         expansion, _, family = rest.rpartition("_")
         assert family in ("nb", "zinb"), (
             f"cannot read a count family off {name!r} (got {family!r})")
-        expansion = expansion.replace("cm_moib", "CM+MOI").replace("cm", "CM")
-        return expansion, family.upper()
+        return EXPANSION_LABEL[(dataset, expansion)], family.upper()
 
     tex = OUT / "cross_family_agreement.tex"
     with open(tex, "w") as f:
@@ -345,7 +366,7 @@ def manuscript_table(rows):
             ds = DATASET_LABEL.get(r["dataset"], r["dataset"])
             expansion, family = split_name(r["name"], r["dataset"])
             mark = "$^{*}$" if r["canonical"] else ""
-            f.write(f"{ds}{mark} & \\emph{{{expansion}}} & {family} & "
+            f.write(f"{ds}{mark} & {expansion} & {family} & "
                     f"{len(r['rel']):,} & {pct(r['rel'].median())} & "
                     f"{pct(r['rel'].quantile(0.95))} & "
                     f"{pct(r['rel'].max())} \\\\\n")

--- a/analyses/model_selection/output/cross_family_agreement.tex
+++ b/analyses/model_selection/output/cross_family_agreement.tex
@@ -4,20 +4,20 @@
 \hline
 Dataset & Expansion & Family & Pairs & Median & 95th pct & Max \\
 \hline
-Yin et al.$^{*}$ & \emph{CM+MOI} & NB & 2,688 & 0.08\% & 0.28\% & 2,799\% \\
-Yin et al. & \emph{CM+MOI} & ZINB & 2,688 & 0.09\% & 0.39\% & 2,797\% \\
-Zhao et al.$^{*}$ & \emph{obsingle} & NB & 453 & 0.10\% & 0.31\% & 13\% \\
-Lalanne et al.$^{*}$ & \emph{obs} & NB & 1,462 & 0.16\% & 0.56\% & 8.59\% \\
-Lalanne et al. & \emph{CM+MOI} & NB & 2,080 & 0.17\% & 3,515\% & 14,029\% \\
-Zhao et al. & \emph{obs} & NB & 453 & 0.20\% & 31\% & 11,407\% \\
-Zhao et al. & \emph{obsingle} & ZINB & 453 & 0.24\% & 0.68\% & 95\% \\
-Yin et al. & \emph{CM} & NB & 2,688 & 0.25\% & 1.29\% & 291\% \\
-Yin et al. & \emph{CM} & ZINB & 2,688 & 0.41\% & 1.49\% & 91\% \\
-Zhao et al. & \emph{CM} & NB & 456 & 0.75\% & 32\% & 343\% \\
-Zhao et al. & \emph{obs} & ZINB & 453 & 1.23\% & 85\% & 25,043\% \\
-Zhao et al. & \emph{CM} & ZINB & 456 & 2.87\% & 42\% & 785\% \\
-Lalanne et al. & \emph{obs} & ZINB & 1,462 & 2.89\% & 16\% & 47\% \\
-Lalanne et al. & \emph{CM} & NB & 2,080 & 9.73\% & 189\% & 1,246\% \\
-Lalanne et al. & \emph{CM} & ZINB & 2,080 & 16\% & 91\% & 597\% \\
+Yin et al.$^{*}$ & consider missing + MOI & NB & 2,688 & 0.08\% & 0.28\% & 2,799\% \\
+Yin et al. & consider missing + MOI & ZINB & 2,688 & 0.09\% & 0.39\% & 2,797\% \\
+Zhao et al.$^{*}$ & observed, fine & NB & 453 & 0.10\% & 0.31\% & 13\% \\
+Lalanne et al.$^{*}$ & observed, fine & NB & 1,462 & 0.16\% & 0.56\% & 8.59\% \\
+Lalanne et al. & consider missing + MOI & NB & 2,080 & 0.17\% & 3,515\% & 14,029\% \\
+Zhao et al. & observed, coarse & NB & 453 & 0.20\% & 31\% & 11,407\% \\
+Zhao et al. & observed, fine & ZINB & 453 & 0.24\% & 0.68\% & 95\% \\
+Yin et al. & consider missing & NB & 2,688 & 0.25\% & 1.29\% & 291\% \\
+Yin et al. & consider missing & ZINB & 2,688 & 0.41\% & 1.49\% & 91\% \\
+Zhao et al. & consider missing & NB & 456 & 0.75\% & 32\% & 343\% \\
+Zhao et al. & observed, coarse & ZINB & 453 & 1.23\% & 85\% & 25,043\% \\
+Zhao et al. & consider missing & ZINB & 456 & 2.87\% & 42\% & 785\% \\
+Lalanne et al. & observed, fine & ZINB & 1,462 & 2.89\% & 16\% & 47\% \\
+Lalanne et al. & consider missing & NB & 2,080 & 9.73\% & 189\% & 1,246\% \\
+Lalanne et al. & consider missing & ZINB & 2,080 & 16\% & 91\% & 597\% \\
 \hline
 \end{tabular}


### PR DESCRIPTION
Table S1's Expansion column printed the internal ortho tokens -- `obs`,
`obsingle`, `CM`, `CM+MOI` -- while Fig 1B names the same modes in words. The
table now uses Fig 1B's wording, taken from `plot_nb_vs_zinb_bars.py::SERIES`:

| dataset | was | is now |
|---|---|---|
| Lalanne et al. | `obs` | observed, fine |
| Lalanne et al. | `CM` | consider missing |
| Lalanne et al. | `CM+MOI` | consider missing + MOI |
| Zhao et al. | `obsingle` | observed, fine |
| Zhao et al. | `obs` | observed, coarse |
| Zhao et al. | `CM` | consider missing |
| Yin et al. | `CM+MOI` | consider missing + MOI |
| Yin et al. | `CM` | consider missing |

The lookup is keyed on `(dataset, expansion)`, not on the expansion alone,
because `obs` is not one mode: Lalanne et al.'s reporter resolves a zero to a
single construct unaided, so its `obs` is already the fine expansion, while
Zhao et al. needs `obsingle` for that and its bare `obs` is the coarse one. The
old code did `.replace("cm_moib", "CM+MOI").replace("cm", "CM")` on the token
alone, which cannot express that -- rewriting by token would print two
different modes under one name.

`(shendure, cm_moib)` has no counterpart in Fig 1B, which shows only the two
Lalanne et al. fits it compares. The table is exhaustive, so it takes the same
vocabulary extended to that combination.

The names are prose now rather than code identifiers, so the `\emph{}` around
them is gone.

Verified against the shipped table: all 15 rows keep their dataset, family and
every number; only the Expansion column differs. Regenerated on Bouchet, where
the ortho fits live.
